### PR TITLE
@yuki24 => adds rack-cors so we can accept requests from external apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'pg', '~> 0.15'
 gem 'uglifier', '>= 1.3.0'
 gem 'artsy-auth'
 
+gem 'rack-cors' # to allow cross-origin requests
+
 gem 'puma', '~> 3.0' # Use Puma as the app server
 
 gem 'sidekiq' # for sending emails in the background

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     public_suffix (2.0.5)
     puma (3.7.0)
     rack (2.0.1)
+    rack-cors (0.4.1)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -241,6 +242,7 @@ DEPENDENCIES
   premailer-rails
   pry-byebug
   puma (~> 3.0)
+  rack-cors
   rails (~> 5.0.0, >= 5.0.0.1)
   rails_param!
   rspec-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,12 @@ module Convection
 
     # include JWT middleware
     config.middleware.use 'JwtMiddleware'
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', headers: :any, methods: [:get, :post, :put, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds `rack-cors` so we can accept AJAX requests from apps like force. Each endpoint is secured by other forms of authentication (JWT that is decodable or a shared secret), so this is just necessary to get around the warnings.