### PR TITLE
@mzikherman => use correct gemini metadata params in callback

### DIFF
--- a/app/controllers/api/callbacks_controller.rb
+++ b/app/controllers/api/callbacks_controller.rb
@@ -8,7 +8,7 @@ module Api
       param! :metadata, Hash, required: true
       param! :token, String, required: true
 
-      submission = Submission.find(gemini_params[:metadata][:submission_id])
+      submission = Submission.find(gemini_params[:metadata][:id])
       asset = submission.assets.detect { |a| a.gemini_token == gemini_params[:token] }
 
       raise ActiveRecord::RecordNotFound unless asset && asset.gemini_token == gemini_params[:token]
@@ -23,7 +23,7 @@ module Api
         :access_token,
         :token,
         image_url: [:square],
-        metadata: [:submission_id]
+        metadata: [:id, :_type]
       )
     end
 

--- a/spec/requests/callbacks/gemini_spec.rb
+++ b/spec/requests/callbacks/gemini_spec.rb
@@ -14,7 +14,7 @@ describe 'Gemini Callback', type: :request do
         access_token: 'wrong-token',
         token: 'gemini',
         image_url: { square: 'https://new-image.jpg' },
-        metadata: { submission_id: submission.id }
+        metadata: { id: submission.id, _type: 'Consignment' }
       }
       expect(response.status).to eq 401
     end
@@ -23,7 +23,7 @@ describe 'Gemini Callback', type: :request do
       post '/api/callbacks/gemini', params: {
         access_token: 'auth-token',
         token: 'gemini',
-        'metadata' => { submission_id: submission.id }
+        'metadata' => { id: submission.id, _type: 'Consignment' }
       }
       expect(response.status).to eq 400
     end
@@ -33,7 +33,7 @@ describe 'Gemini Callback', type: :request do
         access_token: 'auth-token',
         token: 'gemini',
         image_url: { square: 'https://new-image.jpg' },
-        metadata: { submission_id: submission.id }
+        metadata: { id: submission.id, _type: 'Consignment' }
       }
 
       expect(response.status).to eq 404
@@ -46,7 +46,7 @@ describe 'Gemini Callback', type: :request do
         access_token: 'auth-token',
         token: 'gemini',
         image_url: { square: 'https://new-image.jpg' },
-        metadata: { submission_id: submission.id }
+        metadata: { id: submission.id, _type: 'Consignment' }
       }
 
       expect(response.status).to eq 200

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -46,14 +46,14 @@ describe 'Submission Flow', type: :request do
         access_token: 'auth-token',
         token: 'gemini-token',
         image_url: { square: 'https://new-image.jpg' },
-        metadata: { submission_id: submission.id }
+        metadata: { id: submission.id }
       }
 
       post '/api/callbacks/gemini', params: {
         access_token: 'auth-token',
         token: 'gemini-token2',
         image_url: { square: 'https://another-image.jpg' },
-        metadata: { submission_id: submission.id }
+        metadata: { id: submission.id }
       }
       expect(submission.assets.detect { |a| a.gemini_token == 'gemini-token' }.reload.image_urls)
         .to eq('square' => 'https://new-image.jpg')


### PR DESCRIPTION
Turns out [gemini expects](https://github.com/artsy/gemini/blob/master/app/models/entry.rb#L72) specific params (`id` and `_type`) in their metadata object, so we have to adjust this endpoint to accept those. 😅 

