### PR TITLE
@ashkan18 => change which gemini versions are accepted

### DIFF
--- a/app/controllers/api/callbacks_controller.rb
+++ b/app/controllers/api/callbacks_controller.rb
@@ -22,7 +22,7 @@ module Api
       params.permit(
         :access_token,
         :token,
-        image_url: [:large_rectangle, :medium_rectangle, :square, :thumbnail],
+        image_url: [:square, :large, :medium, :thumbnail],
         metadata: [:id, :_type]
       )
     end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -61,7 +61,7 @@ class Submission < ActiveRecord::Base
   end
 
   def processed_images
-    assets.images.select { |image| image.image_urls['medium_rectangle'].present? }
+    assets.images.select { |image| image.image_urls['medium'].present? }
   end
 
   def ready?

--- a/app/views/shared/_submission.html.erb
+++ b/app/views/shared/_submission.html.erb
@@ -21,7 +21,7 @@
 <% end %>
 
 <% @submission.processed_images.each do |image| %>
-  <%= image_tag image.image_urls['medium_rectangle'] %>
+  <%= image_tag image.image_urls['medium'] %>
 <% end %>
 
 <p>

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -83,7 +83,7 @@ describe Submission do
       asset1 = submission.assets.create!(
         asset_type: 'image',
         gemini_token: 'gemini1',
-        image_urls: { medium_rectangle: 'https://image.jpg' }
+        image_urls: { medium: 'https://image.jpg' }
       )
       submission.assets.create!(
         asset_type: 'image',
@@ -100,30 +100,30 @@ describe Submission do
       expect(submission.finished_processing_images_for_email?).to eq true
     end
 
-    it 'returns true if all of the assets have a medium_rectangle url' do
+    it 'returns true if all of the assets have a medium url' do
       submission.assets.create!(
         asset_type: 'image',
         gemini_token: 'gemini1',
-        image_urls: { medium_rectangle: 'https://image.jpg' }
+        image_urls: { medium: 'https://image.jpg' }
       )
       submission.assets.create!(
         asset_type: 'image',
         gemini_token: 'gemini2',
-        image_urls: { medium_rectangle: 'https://image2.jpg' }
+        image_urls: { medium: 'https://image2.jpg' }
       )
       expect(submission.finished_processing_images_for_email?).to eq true
     end
 
-    it 'returns false if only some of the images have a medium_rectangle url' do
+    it 'returns false if only some of the images have a medium url' do
       submission.assets.create!(
         asset_type: 'image',
         gemini_token: 'gemini1',
-        image_urls: { medium_rectangle: 'https://image.jpg' }
+        image_urls: { medium: 'https://image.jpg' }
       )
       submission.assets.create!(
         asset_type: 'image',
         gemini_token: 'gemini2',
-        image_urls: { medium_rectangle: 'https://image2.jpg' }
+        image_urls: { medium: 'https://image2.jpg' }
       )
       submission.assets.create!(
         asset_type: 'image',
@@ -133,7 +133,7 @@ describe Submission do
       expect(submission.finished_processing_images_for_email?).to eq false
     end
 
-    it 'returns false if none of the images have a medium_rectangle url' do
+    it 'returns false if none of the images have a medium url' do
       submission.assets.create!(
         asset_type: 'image',
         gemini_token: 'gemini1',

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -46,20 +46,20 @@ describe 'Submission Flow', type: :request do
       post '/api/callbacks/gemini', params: {
         access_token: 'auth-token',
         token: 'gemini-token',
-        image_url: { medium_rectangle: 'https://new-image.jpg' },
+        image_url: { medium: 'https://new-image.jpg' },
         metadata: { id: submission.id }
       }
 
       post '/api/callbacks/gemini', params: {
         access_token: 'auth-token',
         token: 'gemini-token2',
-        image_url: { medium_rectangle: 'https://another-image.jpg' },
+        image_url: { medium: 'https://another-image.jpg' },
         metadata: { id: submission.id }
       }
       expect(submission.assets.detect { |a| a.gemini_token == 'gemini-token' }.reload.image_urls)
-        .to eq('medium_rectangle' => 'https://new-image.jpg')
+        .to eq('medium' => 'https://new-image.jpg')
       expect(submission.assets.detect { |a| a.gemini_token == 'gemini-token2' }.reload.image_urls)
-        .to eq('medium_rectangle' => 'https://another-image.jpg')
+        .to eq('medium' => 'https://another-image.jpg')
 
       stub_gravity_root
       stub_gravity_user


### PR DESCRIPTION
This has already been updated in gemini, but instead of `medium_rectangle`, we want to show the `medium` image in the email. This also whitelists a different set of images that we will start accepting callbacks for.