### PR TITLE
@ashkan18 => support partial submission from mobile web

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -18,16 +18,13 @@ class Submission < ActiveRecord::Base
     'Textile Arts',
     'Other'
   ].freeze
+
   REQUIRED_FIELDS_FOR_SUBMISSION = %w(
     artist_id
     category
-    dimensions_metric
-    height
     location_city
-    medium
     title
     user_id
-    width
     year
   ).freeze
 

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -10,7 +10,7 @@ class SubmissionService
       return unless submitting
       notify_admin(submission.id)
       notify_user(submission.id)
-      delay_until(1.day.from_now).notify_user(submission.id)
+      delay_until(1.day.from_now).notify_user(submission.id) unless submission.images.count.positive?
     end
 
     def notify_admin(submission_id)

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -24,6 +24,27 @@ describe SubmissionService do
     stub_gravity_artist
   end
 
+  context 'update_submission' do
+    it 'sends no emails of the submission is not being submitted' do
+      SubmissionService.update_submission(submission, state: 'draft')
+      emails = ActionMailer::Base.deliveries
+      expect(emails.length).to eq 0
+    end
+
+    it 'sends a reminder if the submission has no images' do
+      SubmissionService.update_submission(submission, state: 'submitted')
+      emails = ActionMailer::Base.deliveries
+      expect(emails.length).to eq 3
+    end
+
+    it 'sends no reminders if the submission has images' do
+      submission.assets.create!(asset_type: 'image', image_urls: { square: 'http://square.jpg' })
+      SubmissionService.update_submission(submission, state: 'submitted')
+      emails = ActionMailer::Base.deliveries
+      expect(emails.length).to eq 2
+    end
+  end
+
   context 'notify_user' do
     describe 'with assets' do
       before do


### PR DESCRIPTION
This PR relaxes the required fields for submission, as we have intentionally removed some fields from the mobile web flow (but still want these to be valid).

It also updates the notification logic so we don't `delay` an image-submission-reminder if the submission already has images. In practice this would be fine since the delayed notification would exit early, but it's better to just not schedule it at all.