### PR TITLE
@joeyAghion => adds utm params to "upload more photos button"

### DIFF
--- a/app/assets/stylesheets/emails.css.scss
+++ b/app/assets/stylesheets/emails.css.scss
@@ -119,18 +119,17 @@ table.bordered-email {
   }
 
   .upload-photo-button {
-    width: 100%;
-    max-width: 600px;
     background-color: black;
     font-family: sans-serif;
     text-transform: uppercase;
     height: 50px;
     font-size: 14px;
-
-    a {
-      text-decoration: none;
-      color: white;
-    }
+    text-decoration: none;
+    color: white;
+    padding-top: 15px;
+    padding-bottom: 15px;
+    padding-left: 31%;
+    padding-right: 31%;
   }
 
   table.email-footer {

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,0 +1,11 @@
+module UrlHelper
+  def upload_photo_url(submission_id, utm_params = {})
+    utm_url("#{Convection.config.artsy_url}/consign/submission/#{submission_id}/upload", utm_params)
+  end
+
+  private
+
+  def utm_url(url, utm_params)
+    "#{url}?#{utm_params.to_query}"
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -7,4 +7,12 @@ class ApplicationMailer < ActionMailer::Base
   def smtpapi(opts = {})
     headers['X-SMTPAPI'] = opts.to_json
   end
+
+  def utm_params(source:, campaign:)
+    {
+      utm_campaign: campaign,
+      utm_medium: 'email',
+      utm_source: source
+    }
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,4 +1,6 @@
 class UserMailer < ApplicationMailer
+  helper :url
+
   def submission_receipt(submission:, user:, user_detail:, artist:)
     @submission = submission
     @user = user
@@ -15,6 +17,7 @@ class UserMailer < ApplicationMailer
     @submission = submission
     @user = user
     @user_detail = user_detail
+    @utm_params = utm_params(source: 'drip-consignment-reminder-e01', campaign: 'consignment-complete')
 
     smtpapi category: ['first_upload_reminder'], unique_args: {
       submission_id: submission.id
@@ -26,6 +29,7 @@ class UserMailer < ApplicationMailer
     @submission = submission
     @user = user
     @user_detail = user_detail
+    @utm_params = utm_params(source: 'drip-consignment-reminder-e02', campaign: 'consignment-complete')
 
     smtpapi category: ['second_upload_reminder'], unique_args: {
       submission_id: submission.id
@@ -37,6 +41,7 @@ class UserMailer < ApplicationMailer
     @submission = submission
     @user = user
     @user_detail = user_detail
+    @utm_params = utm_params(source: 'drip-consignment-reminder-e03', campaign: 'consignment-complete')
 
     smtpapi category: ['third_upload_reminder'], unique_args: {
       submission_id: submission.id

--- a/app/views/user_mailer/first_upload_reminder.html.erb
+++ b/app/views/user_mailer/first_upload_reminder.html.erb
@@ -42,8 +42,8 @@
           </td>
         </tr>
         <tr>
-          <td class='upload-photo-button'>
-            <%= link_to('Upload Photos', "#{Convection.config.artsy_url}/consign2/submission/#{@submission.id}/upload") %>
+          <td>
+            <%= link_to('Upload Photos', upload_photo_url(@submission.id, @utm_params), class: 'upload-photo-button') %>
           </td>
         </tr>
         <%= render partial: 'shared/email_footer' %>

--- a/app/views/user_mailer/second_upload_reminder.html.erb
+++ b/app/views/user_mailer/second_upload_reminder.html.erb
@@ -27,8 +27,8 @@
           </td>
         </tr>
         <tr>
-          <td class='upload-photo-button'>
-            <%= link_to('Upload Photos', "#{Convection.config.artsy_url}/consign2/submission/#{@submission.id}/upload") %>
+          <td>
+            <%= link_to('Upload Photos', upload_photo_url(@submission.id, @utm_params), class: 'upload-photo-button') %>
           </td>
         </tr>
         <%= render partial: 'shared/email_footer' %>

--- a/app/views/user_mailer/third_upload_reminder.html.erb
+++ b/app/views/user_mailer/third_upload_reminder.html.erb
@@ -27,8 +27,8 @@
         </tr>
         </tr>
         <tr>
-          <td class='upload-photo-button'>
-            <%= link_to('Upload Photos', "#{Convection.config.artsy_url}/consign2/submission/#{@submission.id}/upload") %>
+          <td>
+            <%= link_to('Upload Photos', upload_photo_url(@submission.id, @utm_params), class: 'upload-photo-button') %>
           </td>
         </tr>
         <%= render partial: 'shared/email_footer' %>

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe UrlHelper, type: :helper do
+  before do
+    allow(Convection.config).to receive(:artsy_url).and_return('https://test.artsy.net')
+  end
+
+  describe '#upload_photo_url' do
+    it 'returns a url without utm params if none are provided' do
+      expect(helper.upload_photo_url(19)).to eq('https://test.artsy.net/consign/submission/19/upload?')
+    end
+    it 'returns a url with utm params if some are provided' do
+      utm_params = { utm_source: 'reminder', utm_campaign: 'consignments' }
+      expect(helper.upload_photo_url(19, utm_params)).to eq('https://test.artsy.net/consign/submission/19/upload?utm_campaign=consignments&utm_source=reminder')
+    end
+  end
+end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -74,6 +74,8 @@ describe SubmissionService do
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
         expect(emails.first.html_part.body).to include('Complete your consignment submission')
+        expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
+        expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e01')
         expect(emails.first.to).to eq(['michael@bluth.com'])
         expect(submission.reload.receipt_sent_at).to be nil
         expect(submission.reload.reminders_sent_count).to eq 1
@@ -85,9 +87,26 @@ describe SubmissionService do
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
         expect(emails.first.html_part.body).to include("We're missing photos of your work")
+        expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
+        expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e02')
         expect(emails.first.to).to eq(['michael@bluth.com'])
         expect(submission.reload.receipt_sent_at).to be nil
         expect(submission.reload.reminders_sent_count).to eq 2
+      end
+
+      it 'sends the third reminder if two reminders have ben sent' do
+        submission.update_attributes!(reminders_sent_count: 2)
+        SubmissionService.notify_user(submission)
+        emails = ActionMailer::Base.deliveries
+        expect(emails.length).to eq 1
+        expect(emails.first.html_part.body).to include(
+          'We’re unable to submit your work to our partner network without a photo'
+        )
+        expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
+        expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e03')
+        expect(emails.first.to).to eq(['michael@bluth.com'])
+        expect(submission.reload.receipt_sent_at).to be nil
+        expect(submission.reload.reminders_sent_count).to eq 3
       end
 
       it 'does not send a reminder if a receipt has already been sent' do


### PR DESCRIPTION
Based on a request from Sara Perle, this updates the utm params for the "upload more photos" button on the reminder emails (via https://github.com/artsy/consignments/issues/31).

I also increased the clickable area on the button by making it a link with a bunch of padding (I recall fancier implementations are not supported by all email clients).