### PR TITLE
@ashkan18 => update styles for mobile

### DIFF
--- a/app/assets/stylesheets/emails.css.scss
+++ b/app/assets/stylesheets/emails.css.scss
@@ -8,10 +8,6 @@ table.bordered-email {
   border-collapse: separate;
   table-layout: fixed;
 
-  @media (max-width: 450px) {
-    padding: 10px !important;
-  }
-
   td {
     font-family: TimesNewRoman, 'Times New Roman', Times, serif;
   }
@@ -141,7 +137,7 @@ table.bordered-email {
 
   .email-footer-text {
     padding-top: 23px;
-    font-size: 16px;
+    font-size: 15px;
 
     a {
       color: black;
@@ -207,6 +203,30 @@ table.bordered-email {
 
     a {
       color: black;
+    }
+  }
+}
+
+@media (max-width: 450px) {
+  table.bordered-email {
+    padding: 10px !important;
+    border: none !important;
+
+    .email-title {
+      font-size: 26px !important;
+    }
+
+    .email-sub-title {
+      font-size: 20px !important;
+    }
+
+    .checklist-item {
+      font-size: 20px !important;
+    }
+
+    .upload-photo-button {
+      padding-left: 25% !important;
+      padding-right: 25% !important;
     }
   }
 }

--- a/app/views/user_mailer/third_upload_reminder.html.erb
+++ b/app/views/user_mailer/third_upload_reminder.html.erb
@@ -9,7 +9,7 @@
           <table class='medium-width-table' align='center'>
             <tr>
               <td class='email-title'>
-                We’re unable to submit your work to our partner network without a photo
+                We’re unable to complete your submission
               </td>
             </tr>
           </table>
@@ -22,7 +22,7 @@
         <tr>
         <tr>
           <td class='email-sub-title'>
-            Upload photos of your work to complete your consignments submission.
+            Without photos of your work we cannot submit the work to our partner network.
           </td>
         </tr>
         </tr>

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -99,9 +99,7 @@ describe SubmissionService do
         SubmissionService.notify_user(submission)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.first.html_part.body).to include(
-          'We’re unable to submit your work to our partner network without a photo'
-        )
+        expect(emails.first.html_part.body).to include('We’re unable to complete your submission')
         expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
         expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e03')
         expect(emails.first.to).to eq(['michael@bluth.com'])


### PR DESCRIPTION
This PR adds some styles for our mobile view. It doesn't seem great that we have to use `!important` for the responsive styles, but I couldn't find a consensus on a better alternative for including media queries (since premailer is inlining the styles, this is the only way to give them precedence).

Let me know if you've had to deal with this at all in impulse or pulse. Otherwise for our simple adjustments it's probably okay.