### PR TITLE
@ashkan18 => scope asset find and rescue from gemini error

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,8 +12,10 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require bootstrap
 //= require watt/underscore
 //= require watt/jquery-ui-1.10.3.custom.js
+//= require watt/flash
 //= require jquery.fileupload.js
 //= require gemini/gemini_upload
 //= require new_asset

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -5,6 +5,9 @@ module Admin
 
     def show
       @original_image = @asset.original_image
+    rescue Asset::GeminiHttpException
+      @original_image = nil
+      flash.now[:error] = 'Error fetching Gemini image'
     end
 
     def new
@@ -27,7 +30,7 @@ module Admin
     end
 
     def set_asset
-      @asset = Asset.find(params[:id])
+      @asset = @submission.assets.find(params[:id])
     end
   end
 end


### PR DESCRIPTION
This PR:
- Rescues from `Asset::GeminiHttpException` errors when fetching the `original_image` url for an asset and shows a flash error in that case.
  - This required adding `watt/flash` and `bootstrap` dependencies to `application.js`

![image](https://user-images.githubusercontent.com/2081340/27548909-644454de-5a68-11e7-94d2-cb406a177401.png)
- Scopes the `set_asset` method to only look for assets that are part of a submission (since the routes are scoped anyways to be `/submissions/:submission_id/assets/:id`