### PR TITLE
@ashkan18 => refactor specs to use fabricators

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,6 @@ Metrics/MethodLength:
 
 Metrics/CyclomaticComplexity:
   Max: 8
+
+Rails/SkipsModelValidations:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -55,4 +55,6 @@ group :test do
   gem 'webmock' # mock or forbid external network requests
   gem 'capybara', '~> 2.8' # for view tests
   gem 'rails-controller-testing'
+  gem 'fabrication'
+  gem 'database_cleaner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,9 +100,11 @@ GEM
       safe_yaml (~> 1.0.0)
     css_parser (1.4.8)
       addressable
+    database_cleaner (1.5.3)
     diff-lcs (1.3)
     erubis (2.7.0)
     execjs (2.7.0)
+    fabrication (2.13.2)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday-digestauth (0.2.1)
@@ -333,6 +335,8 @@ DEPENDENCIES
   bourbon
   capybara (~> 2.8)
   coffee-rails
+  database_cleaner
+  fabrication
   gemini_upload-rails!
   haml-rails
   hyperclient

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -13,7 +13,7 @@ class Asset < ActiveRecord::Base
     version = params[:image_url].keys.first
     url = params[:image_url].values.first
     return self unless version && url
-    Asset.where(id: id).update_all(['image_urls = jsonb_set(image_urls, ?, ?)', "{#{version}}", "\"#{url}\""]) # rubocop:disable Rails/SkipsModelValidations
+    Asset.where(id: id).update_all(['image_urls = jsonb_set(image_urls, ?, ?)', "{#{version}}", "\"#{url}\""])
   end
 
   def original_image

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -55,7 +55,7 @@ class SubmissionService
       else
         UserMailer.first_upload_reminder(email_args).deliver_now
       end
-      submission.increment!(:reminders_sent_count) # rubocop:disable Rails/SkipsModelValidations
+      submission.increment!(:reminders_sent_count)
     end
 
     def deliver_submission_receipt(submission_id)

--- a/spec/controllers/assets_controller_spec.rb
+++ b/spec/controllers/assets_controller_spec.rb
@@ -9,12 +9,12 @@ describe Admin::AssetsController, type: :controller do
       stub_gravity_user
       stub_gravity_user_detail
       stub_gravity_artist
-      @submission = Submission.create!(artist_id: 'artistid', user_id: 'userid')
+      @submission = Fabricate(:submission, artist_id: 'artistid', user_id: 'userid')
     end
 
     context 'fetching an asset' do
       it 'renders the show page if the asset exists' do
-        asset = @submission.assets.create(asset_type: 'image')
+        asset = Fabricate(:image, submission: @submission, gemini_token: nil)
         get :show, params: {
           submission_id: @submission.id,
           id: asset.id
@@ -32,7 +32,7 @@ describe Admin::AssetsController, type: :controller do
       end
 
       it 'renders a flash error if the original image cannot be found' do
-        asset = @submission.assets.create(asset_type: 'image')
+        asset = Fabricate(:image, submission: @submission)
         expect_any_instance_of(Asset).to receive(:original_image).and_raise(Asset::GeminiHttpException)
         get :show, params: {
           submission_id: @submission.id,

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -7,7 +7,7 @@ describe Admin::SubmissionsController, type: :controller do
     end
     context 'filtering the index view' do
       before do
-        5.times { Submission.create! }
+        5.times { Fabricate(:submission) }
       end
       it 'returns the first two submissions on the first page' do
         get :index, params: { page: 1, size: 2 }

--- a/spec/events/submission_event_spec.rb
+++ b/spec/events/submission_event_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe SubmissionEvent do
   let(:submission) do
-    Submission.create!(
+    Fabricate(:submission,
       artist_id: 'artistid',
       user_id: 'userid',
       title: 'My Artwork',
@@ -16,8 +16,7 @@ describe SubmissionEvent do
       location_city: 'New York',
       location_state: 'NY',
       location_country: 'US',
-      category: 'Painting'
-    )
+      category: 'Painting')
   end
   let(:event) { SubmissionEvent.new(model: submission, action: 'submitted') }
   describe '#object' do

--- a/spec/fabricators/asset_fabricator.rb
+++ b/spec/fabricators/asset_fabricator.rb
@@ -1,0 +1,19 @@
+Fabricator(:asset) do
+end
+
+Fabricator(:image, from: :asset) do
+  asset_type 'image'
+  gemini_token { Fabricate.sequence(:gemini_token) { |i| "gemini-#{i}" } }
+  image_urls do
+    {
+      square: 'https://image-square.jpg',
+      thumbnail: 'https://image-thumb.jpg',
+      large: 'https://image-large.jpg'
+    }
+  end
+end
+
+Fabricator(:unprocessed_image, from: :asset) do
+  asset_type 'image'
+  gemini_token { Fabricate.sequence(:gemini_token) { |i| "gemini-#{i}" } }
+end

--- a/spec/fabricators/submission_fabricator.rb
+++ b/spec/fabricators/submission_fabricator.rb
@@ -1,0 +1,16 @@
+Fabricator(:submission) do
+  user_id { Fabricate.sequence(:user_id) }
+  artist_id { Fabricate.sequence(:artist_id) }
+  title { Fabricate.sequence(:title) { |i| "The Last Supper #{i}" } }
+  year 2010
+  medium 'oil on paper'
+  category { Submission::CATEGORIES.first }
+  height 10
+  width 12
+  dimensions_metric 'in'
+  signature false
+  authenticity_certificate false
+  location_city 'New York'
+  location_state 'New York'
+  location_country 'USA'
+end

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -3,75 +3,71 @@ require 'rails_helper'
 describe SubmissionsHelper, type: :helper do
   context 'formatted_location' do
     it 'correctly formats location fields' do
-      submission = Submission.create!(
+      submission = Fabricate(:submission,
         location_city: 'Brooklyn',
         location_state: 'New York',
-        location_country: 'USA'
-      )
+        location_country: 'USA')
       expect(helper.formatted_location(submission)).to eq 'Brooklyn, New York, USA'
     end
 
     it 'returns empty string when location values are nil' do
-      submission = Submission.create!
+      submission = Fabricate(:submission,
+        location_city: '',
+        location_state: '',
+        location_country: '')
       expect(helper.formatted_location(submission)).to be_blank
     end
   end
 
   context 'formatted_dimensions' do
     it 'correctly formats dimension fields' do
-      submission = Submission.create(
+      submission = Fabricate(:submission,
         width: '10',
         height: '12',
         depth: '1.75',
-        dimensions_metric: 'IN'
-      )
+        dimensions_metric: 'in')
       expect(helper.formatted_dimensions(submission)).to eq '12 x 10 x 1.75 in'
     end
 
     it 'returns empty string when dimension values are nil' do
-      submission = Submission.create!
+      submission = Fabricate(:submission, width: nil, height: nil, depth: nil)
       expect(helper.formatted_dimensions(submission)).to be_blank
     end
   end
 
   context 'formatted_category' do
     it 'correctly formats category and medium fields if both are present' do
-      submission = Submission.create(
+      submission = Fabricate(:submission,
         category: 'Painting',
-        medium: 'Oil on linen'
-      )
+        medium: 'Oil on linen')
       expect(helper.formatted_category(submission)).to eq 'Painting, Oil on linen'
     end
 
     it 'correctly formats category and medium fields if category is nil' do
-      submission = Submission.create(
+      submission = Fabricate(:submission,
         category: nil,
-        medium: 'Oil on linen'
-      )
+        medium: 'Oil on linen')
       expect(helper.formatted_category(submission)).to eq 'Oil on linen'
     end
 
     it 'correctly formats category and medium fields if medium is nil' do
-      submission = Submission.create(
+      submission = Fabricate(:submission,
         category: 'Painting',
-        medium: nil
-      )
+        medium: nil)
       expect(helper.formatted_category(submission)).to eq 'Painting'
     end
 
     it 'correctly formats category and medium fields if category is empty' do
-      submission = Submission.create(
-        category: '',
-        medium: 'Oil on linen'
-      )
+      submission = Fabricate(:submission,
+        category: nil,
+        medium: 'Oil on linen')
       expect(helper.formatted_category(submission)).to eq 'Oil on linen'
     end
 
     it 'correctly formats category and medium fields if medium is empty' do
-      submission = Submission.create(
+      submission = Fabricate(:submission,
         category: 'Painting',
-        medium: ''
-      )
+        medium: '')
       expect(helper.formatted_category(submission)).to eq 'Painting'
     end
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -10,7 +10,7 @@ describe Asset do
   end
 
   describe '#update_image_urls!' do
-    let(:asset) { Asset.create!(asset_type: 'image') }
+    let(:asset) { Fabricate(:unprocessed_image) }
 
     it 'adds a new image version url' do
       params = { image_url: { square: 'https://square-image.jpg' } }
@@ -42,7 +42,7 @@ describe Asset do
   end
 
   describe '#original_image' do
-    let(:asset) { Asset.create!(asset_type: 'image') }
+    let(:asset) { Fabricate(:image, gemini_token: nil) }
 
     before do
       allow(Convection.config).to receive(:gemini_app).and_return('https://media-test.artsy.net')

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 describe Submission do
+  let(:submission) { Fabricate(:submission) }
+
   context 'state' do
     it 'correctly sets the initial state to draft' do
-      submission = Submission.create!(artist_id: 'andy-warhol')
       expect(submission.state).to eq 'draft'
     end
 
@@ -32,85 +33,40 @@ describe Submission do
   end
 
   context 'processed_images' do
-    let(:submission) { Submission.create(category: 'Painting') }
-
     it 'returns an empty array if there are no images' do
       expect(submission.processed_images).to eq []
     end
 
     it 'returns an empty array if there are no processed images' do
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini1'
-      )
+      Fabricate(:unprocessed_image, submission: submission)
       expect(submission.processed_images).to eq []
     end
 
     it 'returns only the processed images' do
-      asset1 = submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini1',
-        image_urls: { square: 'https://image.jpg' }
-      )
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini2'
-      )
+      asset1 = Fabricate(:image, submission: submission)
+      Fabricate(:unprocessed_image, submission: submission)
       expect(submission.processed_images).to eq [asset1]
     end
   end
 
   context 'finished_processing_images_for_email?' do
-    let(:submission) { Submission.create(category: 'Painting') }
-
     it 'returns true if there are no assets' do
       expect(submission.finished_processing_images_for_email?).to eq true
     end
 
     it 'returns true if all of the assets have a square url' do
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini1',
-        image_urls: { square: 'https://image.jpg' }
-      )
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini2',
-        image_urls: { square: 'https://image2.jpg' }
-      )
+      2.times { Fabricate(:image, submission: submission) }
       expect(submission.finished_processing_images_for_email?).to eq true
     end
 
     it 'returns false if only some of the images have a square url' do
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini1',
-        image_urls: { square: 'https://image.jpg' }
-      )
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini2',
-        image_urls: { square: 'https://image2.jpg' }
-      )
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini3',
-        image_urls: { medium: 'https://image3.jpg' }
-      )
+      Fabricate(:image, submission: submission)
+      Fabricate(:unprocessed_image, submission: submission)
       expect(submission.finished_processing_images_for_email?).to eq false
     end
 
-    it 'returns false if none of the images have a medium url' do
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini1',
-        image_urls: { medium: 'https://image.jpg' }
-      )
-      submission.assets.create!(
-        asset_type: 'image',
-        gemini_token: 'gemini2',
-        image_urls: { medium: 'https://image2.jpg' }
-      )
+    it 'returns false if none of the images have a square url' do
+      2.times { Fabricate(:unprocessed_image, submission: submission) }
       expect(submission.finished_processing_images_for_email?).to eq false
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,7 +41,13 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :truncation
+  end
+  config.around do |example|
+    DatabaseCleaner.cleaning { example.run }
+  end
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/requests/api/assets/create_spec.rb
+++ b/spec/requests/api/assets/create_spec.rb
@@ -4,7 +4,7 @@ require 'support/gravity_helper'
 describe 'Create Asset' do
   let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
-  let(:submission) { Submission.create!(artist_id: 'andy-warhol', user_id: 'userid') }
+  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid') }
 
   describe 'POST /assets' do
     it 'rejects unauthorized requests' do

--- a/spec/requests/api/assets/show_spec.rb
+++ b/spec/requests/api/assets/show_spec.rb
@@ -12,22 +12,22 @@ describe 'Show Asset' do
     end
 
     it 'returns an error if it cannot find the asset' do
-      Asset.create!(asset_type: 'image', gemini_token: 'gemini')
+      Fabricate(:image)
       get '/api/assets/foo', headers: headers
       expect(response.status).to eq 404
       expect(JSON.parse(response.body)['error']).to eq 'Not Found'
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Submission.create!(artist_id: 'andy-warhol', user_id: 'buster-bluth')
-      asset = Asset.create!(asset_type: 'image', gemini_token: 'gemini', submission_id: submission.id)
+      submission = Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'buster-bluth')
+      asset = Fabricate(:image, submission: submission)
       get "/api/assets/#{asset.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Submission.create!(artist_id: 'andy-warhol', user_id: 'userid')
-      asset = Asset.create!(asset_type: 'image', gemini_token: 'gemini', submission_id: submission.id)
+      submission = Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid')
+      asset = Fabricate(:image, submission: submission)
       get "/api/assets/#{asset.id}", headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)

--- a/spec/requests/api/callbacks/gemini_spec.rb
+++ b/spec/requests/api/callbacks/gemini_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Gemini Callback' do
-  let(:submission) { Submission.create!(artist_id: 'andy-warhol', user_id: 'userid') }
+  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid') }
 
   before do
     allow(Convection.config).to receive(:access_token).and_return('auth-token')
@@ -41,7 +41,7 @@ describe 'Gemini Callback' do
     end
 
     it 'updates the asset to have the right image url' do
-      submission.assets.create!(asset_type: 'image', gemini_token: 'gemini')
+      Fabricate(:unprocessed_image, submission: submission, gemini_token: 'gemini')
       post '/api/callbacks/gemini', params: {
         access_token: 'auth-token',
         token: 'gemini',

--- a/spec/requests/api/submissions/show_spec.rb
+++ b/spec/requests/api/submissions/show_spec.rb
@@ -12,20 +12,20 @@ describe 'Show Submission' do
     end
 
     it 'returns an error if it cannot find the submission' do
-      Submission.create!(artist_id: 'andy-warhol', user_id: 'buster-bluth')
+      Fabricate(:submission, user_id: 'buster-bluth')
       get '/api/submissions/foo', headers: headers
       expect(response.status).to eq 404
       expect(JSON.parse(response.body)['error']).to eq 'Not Found'
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Submission.create!(artist_id: 'andy-warhol', user_id: 'buster-bluth')
+      submission = Fabricate(:submission, user_id: 'buster-bluth')
       get "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Submission.create!(artist_id: 'andy-warhol', user_id: 'userid')
+      submission = Fabricate(:submission, user_id: 'userid')
       get "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)

--- a/spec/requests/api/submissions/update_spec.rb
+++ b/spec/requests/api/submissions/update_spec.rb
@@ -12,20 +12,20 @@ describe 'Update Submission' do
     end
 
     it 'returns an error if it cannot find the submission' do
-      Submission.create!(artist_id: 'andy-warhol', user_id: 'buster-bluth')
+      Fabricate(:submission, user_id: 'buster-bluth')
       put '/api/submissions/foo', headers: headers
       expect(response.status).to eq 404
       expect(JSON.parse(response.body)['error']).to eq 'Not Found'
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Submission.create!(artist_id: 'andy-warhol', user_id: 'buster-bluth')
+      submission = Fabricate(:submission, user_id: 'buster-bluth')
       put "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Submission.create!(artist_id: 'andy-warhol', user_id: 'userid')
+      submission = Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid')
       put "/api/submissions/#{submission.id}", params: {
         artist_id: 'kara-walker'
       }, headers: headers
@@ -38,18 +38,7 @@ describe 'Update Submission' do
     describe 'submitting' do
       describe 'with a valid submission' do
         before do
-          @submission = Submission.create!(
-            artist_id: 'artistid',
-            user_id: 'userid',
-            title: 'My Artwork',
-            medium: 'painting',
-            year: '1992',
-            height: '12',
-            width: '14',
-            dimensions_metric: 'in',
-            location_city: 'New York',
-            category: 'Painting'
-          )
+          @submission = Fabricate(:submission, user_id: 'userid', artist_id: 'artistid')
         end
 
         it 'sends a receipt when your state is updated to submitted' do
@@ -60,7 +49,7 @@ describe 'Update Submission' do
           stub_gravity_user_detail(email: 'michael@bluth.com')
           stub_gravity_artist
 
-          @submission.assets.create!(asset_type: 'image', image_urls: { square: 'https://square.jpg' })
+          Fabricate(:image, submission: @submission)
 
           put "/api/submissions/#{@submission.id}", params: {
             state: 'submitted'
@@ -93,10 +82,10 @@ describe 'Update Submission' do
       end
 
       it 'returns an error if you try to submit without all of the relevant fields' do
-        submission = Submission.create!(
+        submission = Fabricate(:submission,
           artist_id: 'andy-warhol',
-          user_id: 'userid'
-        )
+          user_id: 'userid',
+          title: nil)
         put "/api/submissions/#{submission.id}", params: {
           artist_id: 'kara-walker',
           state: 'submitted'

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe NotificationService do
   let(:submission) do
-    Submission.create!(
+    Fabricate(:submission,
       artist_id: 'artistid',
       user_id: 'userid',
       title: 'My Artwork',
@@ -12,8 +12,7 @@ describe NotificationService do
       width: '14',
       dimensions_metric: 'in',
       location_city: 'New York',
-      category: 'Painting'
-    )
+      category: 'Painting')
   end
 
   describe '#post_submission_event' do

--- a/spec/views/admin/submissions/edit.html.erb_spec.rb
+++ b/spec/views/admin/submissions/edit.html.erb_spec.rb
@@ -5,15 +5,14 @@ describe 'admin/submissions/edit.html.erb', type: :feature do
   context 'always' do
     before do
       allow_any_instance_of(Admin::SubmissionsController).to receive(:require_artsy_authentication)
-      @submission = Submission.create!(
+      @submission = Fabricate(:submission,
         title: 'my artwork',
         artist_id: 'artistid',
         edition: true,
         edition_size: 100,
         edition_number: '23a',
         category: 'Painting',
-        user_id: 'userid'
-      )
+        user_id: 'userid')
       page.visit "/admin/submissions/#{@submission.id}/edit"
     end
 

--- a/spec/views/admin/submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/submissions/index.html.erb_spec.rb
@@ -15,9 +15,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
 
     context 'with submissions' do
       before do
-        3.times do |index|
-          Submission.create!(title: "Artwork #{index}", user_id: 'userid', artist_id: 'artistid')
-        end
+        3.times { Fabricate(:submission, user_id: 'userid', artist_id: 'artistid') }
         page.visit '/'
       end
 

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -10,15 +10,14 @@ describe 'admin/submissions/show.html.erb', type: :feature do
       stub_gravity_user_detail
       stub_gravity_artist
 
-      @submission = Submission.create!(
+      @submission = Fabricate(:submission,
         title: 'my sartwork',
         artist_id: 'artistid',
         edition: true,
         edition_size: 100,
         edition_number: '23a',
         category: 'Painting',
-        user_id: 'userid'
-      )
+        user_id: 'userid')
       page.visit "/admin/submissions/#{@submission.id}"
     end
 
@@ -33,7 +32,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
     context 'with assets' do
       before do
         4.times do
-          @submission.assets.create!(asset_type: 'image')
+          Fabricate(:image, submission: @submission, gemini_token: nil)
         end
         page.visit "/admin/submissions/#{@submission.id}"
       end


### PR DESCRIPTION
This PR adds the `fabrication` gem, with fabricators for `Submission`s and `Asset`s. It also updates their usage in the corresponding specs.