### PR TITLE
@ashkan18 => add some state filters on the index page

### DIFF
--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -13,6 +13,11 @@
   color: #999999;
 }
 
+.flex-label {
+  display: flex;
+  justify-content: space-between;
+}
+
 .btn-approve {
   color: #0EDA83;
 

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -4,7 +4,14 @@ module Admin
     before_action :set_pagination_params, only: [:index]
 
     def index
-      @submissions = Submission.order(id: :desc).page(@page).per(@size)
+      @submissions_count = Submission.completed.count
+      @unreviewed_count = Submission.where(state: 'submitted').count
+      @approved_count = Submission.where(state: 'approved').count
+      @rejected_count = Submission.where(state: 'rejected').count
+      @filters = { state: params[:state] }
+
+      @submissions = params[:state] ? Submission.where(state: params[:state]) : Submission.completed
+      @submissions = @submissions.order(id: :desc).page(@page).per(@size)
     end
 
     def new

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -42,6 +42,8 @@ class Submission < ApplicationRecord
 
   before_validation :set_state, on: :create
 
+  scope :completed, -> { where.not(state: 'draft') }
+
   def can_submit?
     REQUIRED_FIELDS_FOR_SUBMISSION.all? { |attr| self[attr].present? }
   end

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -2,18 +2,30 @@
   <h2>Submissions</h2>
 </div>
 
-<div class='row triple-padding-top'>
-  <div class='row col-sm-12'>
-    <div class='col-sm-12'>
-      <%= link_to 'New Submission', new_admin_submission_path, class: 'btn btn-primary btn-full-width' %>
-    </div>
-  </div>
-</div>
-
-
 <div class='container'>
   <div class='row triple-padding-top'>
-    <div class='col-md-12'>
+    <div class='col-md-2'>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'All', admin_submissions_path %></div>
+        <div class='right'><%= @submissions_count %></div>
+      </div>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'Unreviewed', admin_submissions_path(state: 'submitted') %></div>
+        <div class='right'><%= @unreviewed_count %></div>
+      </div>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'Approved', admin_submissions_path(state: 'approved') %></div>
+        <div class='right'><%= @approved_count %></div>
+      </div>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'Rejected', admin_submissions_path(state: 'rejected') %></div>
+        <div class='right'><%= @rejected_count %></div>
+      </div>
+      <div class='row double-padding-top'>
+        <%= link_to 'New', new_admin_submission_path, class: 'btn btn-tiny btn-full-width' %>
+      </div>
+    </div>
+    <div class='col-md-10'>
       <div class='list-group'>
         <% @submissions.each do |submission| %>
           <div class='list-group-item list-item--submission' data-id=<%= submission.id %>>
@@ -45,5 +57,5 @@
       </div>
     </div>
   </div>
-  <%= render partial: 'shared/watt/paginator', locals: { total_items_count: @submissions.total_count, items_count: @submissions.length, per_page: @size, current_page: @page, base_url: admin_submissions_url } %>
+  <%= render partial: 'shared/watt/paginator', locals: { total_items_count: @submissions.total_count, items_count: @submissions.length, per_page: @size, current_page: @page, base_url: admin_submissions_url(@filters) } %>
 </div>

--- a/spec/controllers/admin/submissions_controller_spec.rb
+++ b/spec/controllers/admin/submissions_controller_spec.rb
@@ -7,7 +7,7 @@ describe Admin::SubmissionsController, type: :controller do
     end
     context 'filtering the index view' do
       before do
-        5.times { Fabricate(:submission) }
+        5.times { Fabricate(:submission, state: 'submitted') }
       end
       it 'returns the first two submissions on the first page' do
         get :index, params: { page: 1, size: 2 }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -16,6 +16,23 @@ describe Submission do
     end
   end
 
+  context 'scopes' do
+    describe 'completed' do
+      it 'returns the number of non-draft submissions' do
+        Fabricate(:submission, state: 'approved')
+        Fabricate(:submission, state: 'rejected')
+        Fabricate(:submission, state: 'draft')
+        Fabricate(:submission, state: 'submitted')
+        expect(Submission.completed.count).to eq(3)
+      end
+
+      it 'returns 0 if there are only draft submissions' do
+        Fabricate(:submission)
+        expect(Submission.completed.count).to eq(0)
+      end
+    end
+  end
+
   context 'category' do
     it 'allows only certain categories' do
       expect(Submission.new(category: nil)).to be_valid

--- a/spec/views/admin/submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/submissions/index.html.erb_spec.rb
@@ -16,9 +16,16 @@ describe 'admin/submissions/index.html.erb', type: :feature do
       expect(page).not_to have_selector('list-group-item')
     end
 
+    it 'displays zeros for the counts' do
+      expect(page).to have_content('All 0')
+      expect(page).to have_content('Unreviewed 0')
+      expect(page).to have_content('Approved 0')
+      expect(page).to have_content('Rejected 0')
+    end
+
     context 'with submissions' do
       before do
-        3.times { Fabricate(:submission, user_id: 'userid', artist_id: 'artistid') }
+        3.times { Fabricate(:submission, user_id: 'userid', artist_id: 'artistid', state: 'submitted') }
         page.visit '/'
       end
 
@@ -39,6 +46,49 @@ describe 'admin/submissions/index.html.erb', type: :feature do
         expect(page).to have_content('Edit')
         expect(page).to have_content('Add Asset')
         expect(page).to have_content('Jon Jonson')
+      end
+
+      it 'shows the counts of submissions' do
+        expect(page).to have_content('All 3')
+        expect(page).to have_content('Unreviewed 3')
+        expect(page).to have_content('Approved 0')
+        expect(page).to have_content('Rejected 0')
+      end
+
+      it 'lets you click a filter option' do
+        click_link('Unreviewed')
+        expect(page).to have_content('Submissions')
+        expect(page).to have_selector('.list-group-item', count: 3)
+        expect(current_path).to eq '/admin/submissions'
+      end
+    end
+
+    context 'with a variety of submissions' do
+      before do
+        3.times { Fabricate(:submission, user_id: 'userid', artist_id: 'artistid', state: 'submitted') }
+        Fabricate(:submission, user_id: 'userid', artist_id: 'artistid', state: 'approved')
+        Fabricate(:submission, user_id: 'userid', artist_id: 'artistid', state: 'rejected')
+        Fabricate(:submission, user_id: 'userid', artist_id: 'artistid', state: 'draft')
+        page.visit '/'
+      end
+
+      it 'shows the correct numbers' do
+        expect(page).to have_content('All 5')
+        expect(page).to have_content('Unreviewed 3')
+        expect(page).to have_content('Approved 1')
+        expect(page).to have_content('Rejected 1')
+      end
+
+      it 'lets you click into a filter option' do
+        click_link('Approved')
+        expect(page).to have_content('Submissions')
+        expect(page).to have_selector('.list-group-item', count: 1)
+      end
+
+      it 'filters by changing the url' do
+        page.visit('/admin/submissions?state=rejected')
+        expect(page).to have_content('Submissions')
+        expect(page).to have_selector('.list-group-item', count: 1)
       end
     end
   end


### PR DESCRIPTION
Slowly making this admin UI more useful--

This PR adds counts/filters for "Unreviewed", "Approved", and "Rejected" on the index page. Clicking on these filters will update the view to only show relevant submissions.

![image](https://user-images.githubusercontent.com/2081340/29625102-cac297e4-87f8-11e7-9871-c5a41db25fe5.png)

It's still not very pretty... I'll work on that later 😅 .