### PR TITLE
@ashkinas => updating partner digest email to include links to large images

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,5 +16,10 @@ if Rails.env.development? || Rails.env.test?
     t.rspec_opts = %W(-f JUnit -o #{test_output})
   end
 
+  task 'print_schema' => :environment do
+    require 'graphql/schema/printer'
+    puts GraphQL::Schema::Printer.new(RootSchema).print_schema
+  end
+
   task default: [:rubocop, :spec]
 end

--- a/app/assets/stylesheets/emails.css.scss
+++ b/app/assets/stylesheets/emails.css.scss
@@ -1,3 +1,5 @@
+$sans-serif: HelveticaNeue, Helvetica, 'Helvetica', sans-serif;
+
 table.bordered-email {
   width: 100%;
   padding: 30px;
@@ -27,6 +29,10 @@ table.bordered-email {
     font-size: 40px;
     padding-top: 20px;
     padding-bottom: 20px;
+  }
+
+  .sans-serif {
+    font-family: $sans-serif;
   }
 
   .email-main-photo img {
@@ -220,19 +226,20 @@ table.bordered-email {
 
   table.submission-batch-email {
     text-align: left;
+    max-width: 660px;
 
     .email-title {
       padding-bottom: 0px;
     }
 
     .email-sub-title {
-      padding-top: 0px;
+      padding-top: 15px;
       padding-bottom: 20px;
       font-size: 20px;
     }
 
     .email-sub-title-gray {
-      font-size: 18px;
+      font-size: 16px;
       color: gray;
       font-family: sans-serif;
       padding-bottom: 20px;
@@ -243,6 +250,10 @@ table.bordered-email {
         width: 150px;
         max-width: 150px;
       }
+    }
+
+    .submission-image-row-mobile {
+      display: none;
     }
 
     .submission-batch-metadata {
@@ -256,6 +267,26 @@ table.bordered-email {
 
     table.submission-batch-todo {
       text-align: left;
+
+      .email-sub-title {
+        padding-bottom: 0px;
+      }
+
+      td {
+        font-family: $sans-serif;
+      }
+    }
+
+    table.image-links-table {
+      text-align: left;
+
+      a {
+        color: #000001;
+      }
+
+      td:first-child {
+        padding-left: 0px;
+      }
     }
   }
 }
@@ -280,6 +311,34 @@ table.bordered-email {
     .upload-photo-button {
       padding-left: 25% !important;
       padding-right: 25% !important;
+    }
+
+    table.submission-batch-email {
+      td {
+        padding-left: 0px !important;
+      }
+
+      .email-sub-title {
+        font-size: 16px !important;
+      }
+
+      .email-sub-title-gray {
+        font-size: 14px !important;
+      }
+
+      .submission-image {
+        display: none !important;
+      }
+
+      .submission-image-row-mobile {
+        display: block !important;
+
+        .submission-image-mobile {
+          img {
+            max-width: 230px;
+          }
+        }
+      }
     }
   }
 }

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -36,4 +36,8 @@ module SubmissionsHelper
       submission.processed_images.first.image_urls['square']
     end
   end
+
+  def formatted_current_time
+    Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%l:%M %Z %B %-d, %Y')
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -64,6 +64,10 @@ class Submission < ApplicationRecord
     images.select { |image| image.image_urls['square'].present? }
   end
 
+  def large_images
+    images.select { |image| image.image_urls['large'].present? }
+  end
+
   def thumbnail
     thumbnail_image = images.select { |image| image.image_urls['thumbnail'].present? }.first
     return thumbnail_image.image_urls['thumbnail'] if thumbnail_image

--- a/app/views/partner_mailer/submission_digest.html.erb
+++ b/app/views/partner_mailer/submission_digest.html.erb
@@ -6,78 +6,108 @@
       <table class='email-content submission-batch-email' align='center'>
         <%= render partial: 'shared/email_header' %>
         <tr>
-          <td class='email-title'>
+          <td class='email-title sans-serif'>
             New works available from Artsy collectors
           </td>
         </tr>
         <tr>
-          <td class='email-sub-title'>
+          <td class='email-sub-title sans-serif'>
             In order to guarantee availability of the work please reply with your offers within 48hrs.
           </td>
         </tr>
         <tr>
           <td class='email-sub-title-gray'>
-            Submissions as of <%= Time.now.utc.strftime('%B %-d, %Y') %>
+            Submissions as of <%= formatted_current_time %>
           </td>
         </tr>
         <tr>
-          <table>
-            <% @submissions.each do |submission| %>
-              <tr>
-                <% if submission.processed_images.length > 0 %>
-                  <td class='submission-image'>
-                    <%= image_tag(preferred_image(submission), id: 'first-image') %>
-                  </td>
-                <% else %>
-                  <td class='submission-image'>
-                    <%= image_tag(image_url('missing_image.png'), id: 'first-image') %>
-                  </td>
-                <% end %>
-                <td>
-                  <table class='submission-batch-metadata'>
-                    <tr>
-                      <td class='gray'>
-                        <%= submission.id %>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td class='bold'>
-                        <%= submission.artist_name %>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <i><%= submission.title %></i><span><%= ", #{submission.year}" %></span>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <%= submission.category %>, <%= formatted_dimensions(submission) %>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td class='small-padding-top'>
-                        <%= formatted_location(submission) %>
-                      </td>
-                    </tr>
-                    <% if submission.provenance.present? %>
+          <td>
+            <table>
+              <% @submissions.each do |submission| %>
+                <tr class='submission-image-row-mobile'>
+                  <% if submission.processed_images.length > 0 %>
+                    <td class='submission-image-mobile'>
+                      <%= image_tag(preferred_image(submission)) %>
+                    </td>
+                  <% else %>
+                    <td class='submission-image-mobile'>
+                      <%= image_tag(image_url('missing_image.png')) %>
+                    </td>
+                  <% end %>
+                </tr>
+                <tr>
+                  <% if submission.processed_images.length > 0 %>
+                    <td class='submission-image'>
+                      <%= image_tag(preferred_image(submission)) %>
+                    </td>
+                  <% else %>
+                    <td class='submission-image'>
+                      <%= image_tag(image_url('missing_image.png')) %>
+                    </td>
+                  <% end %>
+                  <td>
+                    <table class='submission-batch-metadata'>
                       <tr>
-                        <td>
-                          <i><%= submission.provenance.truncate(50) %></i>
+                        <td class='gray'>
+                          <%= submission.id %>
                         </td>
                       </tr>
-                    <% end %>
-                  </table>
-                </td>
-              </tr>
-            <% end %>
-          </table>
+                      <tr>
+                        <td class='bold'>
+                          <%= submission.artist_name %>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <i><%= submission.title %></i><span><%= ", #{submission.year}" %></span>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td>
+                          <%= submission.category %>, <%= formatted_dimensions(submission) %>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td class='small-padding-top'>
+                          <%= formatted_location(submission) %>
+                        </td>
+                      </tr>
+                      <% if submission.provenance.present? %>
+                        <tr>
+                          <td>
+                            <i><%= submission.provenance.truncate(50) %></i>
+                          </td>
+                        </tr>
+                      <% end %>
+                      <tr>
+                        <td>
+                          <table class='image-links-table'>
+                            <% submission.large_images.each_slice(4) do |batch| %>
+                              <tr>
+                                <% batch.each_with_index do |image, index| %>
+                                  <% if image.image_urls['large'].present? %>
+                                    <td>
+                                      <%= link_to "Image #{submission.large_images.find_index(image) + 1}", image.image_urls['large'] %>
+                                    </td>
+                                  <% end %>
+                                <% end %>
+                              </tr>
+                            <% end %>
+                          </table>
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+              <% end %>
+            </table>
+          </td>
         </tr>
         <tr>
           <td>
-            <table class='submission-batch-todo'>
+            <table class='submission-batch-todo sans-serif'>
               <tr>
-                <td class='email-sub-title'>
+                <td class='email-sub-title sans-serif'>
                   If interested in the listed works please include the following information in your offer:
                 </td>
               </tr>
@@ -111,7 +141,7 @@
                 </td>
               </tr>
               <tr>
-                <td class='email-sub-title'>
+                <td class='email-sub-title gray'>
                   The specialist team
                 </td>
               </tr>

--- a/spec/mailers/previews/partner_mailer_preview.rb
+++ b/spec/mailers/previews/partner_mailer_preview.rb
@@ -21,7 +21,16 @@ class PartnerMailerPreview < ActionMailer::Preview
       location_city: 'New York',
       location_state: 'NY',
       location_country: 'USA',
-      provenance: 'Inherited from my mother who got it from her father after he divorced from his second wife.'
+      provenance: 'Inherited from my mother who got it from her father after he divorced from his second wife.',
+      large_images: [
+        OpenStruct.new(image_urls: { 'large' => 'http://foo1.jpg' }),
+        OpenStruct.new(image_urls: { 'large' => 'http://foo2.jpg' }),
+        OpenStruct.new(image_urls: { 'large' => 'http://foo3.jpg' }),
+        OpenStruct.new(image_urls: { 'large' => 'http://foo4.jpg' }),
+        OpenStruct.new(image_urls: { 'large' => 'http://foo5.jpg' }),
+        OpenStruct.new(image_urls: { 'large' => 'http://foo6.jpg' }),
+        OpenStruct.new(image_urls: { 'large' => 'http://foo7.jpg' })
+      ]
     )
   end
 

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -148,6 +148,22 @@ describe PartnerSubmissionService do
           expect(emails.first.html_part.body).to include(second_image.image_urls['square'])
         end
 
+        it 'includes links to additional images' do
+          first_image = Fabricate(:image, submission: @approved1)
+          Fabricate(:image, submission: @approved1, image_urls: { 'large' => 'http://foo1.jpg' })
+          Fabricate(:image, submission: @approved1, image_urls: { 'large' => 'http://foo2.jpg' })
+          Fabricate(:image, submission: @approved1, image_urls: { 'large' => 'http://foo3.jpg' })
+          PartnerSubmissionService.daily_digest
+
+          emails = ActionMailer::Base.deliveries
+          expect(emails.length).to eq 1
+          email_body = emails.first.html_part.body
+          expect(email_body).to include(first_image.image_urls['square'])
+          expect(email_body).to include('<a href="https://image-large.jpg" style="color: #000001;">Image 1</a>')
+          expect(email_body).to include('<a href="https://image-large.jpg" style="color: #000001;">Image 1</a>')
+          expect(email_body).to include('<a href="https://image-large.jpg" style="color: #000001;">Image 1</a>')
+        end
+
         it 'sends an email digest to multiple partners' do
           partner2 = Fabricate(:partner, gravity_partner_id: 'phillips')
           PartnerSubmissionService.generate_for_new_partner(partner2)


### PR DESCRIPTION
Your favorite kind of PR!

This updates the partner digest email template to include links to the `large` versions of uploaded images.
![image](https://user-images.githubusercontent.com/2081340/30403480-d44abda6-98af-11e7-9c64-ecb20eee4905.png)

It also adds a response email view:
![image](https://user-images.githubusercontent.com/2081340/30403497-e7b8d300-98af-11e7-81b3-76c3458740b8.png)

The image on the responsive view should be centered but I can't figure out how to do that right now 😫 . Will revisit in a future PR, maybe you know some handy trick! I think it's getting messed up because we are hiding and showing it in different versions. Also I'm _sure_ that will break in some email clients, but I'll use litmus to test it out once it's in staging. (these emails aren't being sent in production yet)