### PR TITLE
@joeyAghion => don't require a location_city

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -27,7 +27,6 @@ class Submission < ApplicationRecord
   REQUIRED_FIELDS_FOR_SUBMISSION = %w(
     artist_id
     category
-    location_city
     title
     user_id
     year
@@ -69,8 +68,9 @@ class Submission < ApplicationRecord
   end
 
   def thumbnail
-    thumbnail_image = images.select { |image| image.image_urls['thumbnail'].present? }.first
-    return thumbnail_image.image_urls['thumbnail'] if thumbnail_image
+    return primary_image.image_urls['thumbnail'] if primary_image && primary_image.image_urls['thumbnail'].present?
+    thumbnail_image = images.detect { |image| image.image_urls['thumbnail'].present? }
+    thumbnail_image.image_urls['thumbnail'] if thumbnail_image
   end
 
   # defines methods submitted?, approved?, etc. for each possible submission state


### PR DESCRIPTION
This PR removes `location_city` as a required field for submission. There are no UIs which allow you to even create a draft submission without `location` fields entered based on Google's API, but I imagine there are places around the world which have some (but not all) of `location_city`, `location_state`, and `location_country`. Since we can't assume anything, I don't think the server validation is useful here.