### PR TITLE
Replace typhoeus with Net::HTTP

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem 'jquery-rails'
 gem 'haml-rails' # required for watt layouts
 
 gem 'artsy-eventservice' # for posting events to artsy event stream
-gem 'typhoeus'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,8 +103,6 @@ GEM
     database_cleaner (1.5.3)
     diff-lcs (1.3)
     erubis (2.7.0)
-    ethon (0.10.1)
-      ffi (>= 1.3.0)
     execjs (2.7.0)
     fabrication (2.13.2)
     faraday (0.9.2)
@@ -116,7 +114,6 @@ GEM
       faraday_middleware (>= 0.9, < 0.10)
     faraday_middleware (0.9.2)
       faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.18)
     futuroscope (0.1.11)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -313,8 +310,6 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
-    typhoeus (1.3.0)
-      ethon (>= 0.9.0)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (3.0.4)
@@ -367,7 +362,6 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5.0)
   sidekiq
-  typhoeus
   uglifier (>= 1.3.0)
   watt!
   webmock
@@ -377,4 +371,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/lib/gravql.rb
+++ b/lib/gravql.rb
@@ -1,15 +1,17 @@
+require 'net/http'
+require 'uri'
+
 class Gravql
   module Schema
     def self.execute(query:, variables: {})
-      response = Typhoeus.post(
-        "#{Convection.config.gravity_api_url}/graphql",
-        body: { query: query, variables: variables }.to_json,
-        headers: {
-          'X-XAPP-TOKEN' => Convection.config.gravity_xapp_token,
-          'Content-Type' => 'application/json'
-        },
-        accept_encoding: 'gzip'
+      response = Net::HTTP.post(
+        URI("#{Convection.config.gravity_api_url}/graphql"),
+        { query: query, variables: variables }.to_json,
+        'X-XAPP-TOKEN' => Convection.config.gravity_xapp_token,
+        'Content-Type' => 'application/json',
+        'Accept-Encoding' => 'gzip'
       )
+
       JSON.parse(response.body, symbolize_names: true)
     end
   end


### PR DESCRIPTION
I don't think we need third-party HTTP libraries in this specific case. In fact, you don't need them in 99% of cases. We should just use `Net::HTTP.post` whenever possible.