### PR TITLE
Omit :partial and :locals keys when rendering templates

### DIFF
--- a/app/views/admin/assets/new.html.erb
+++ b/app/views/admin/assets/new.html.erb
@@ -50,6 +50,6 @@
     </div>
   <% end %>
   <div id='gemini-upload'>
-    <%= render partial: 'gemini_form', locals: { accept: 'image/jpeg,image/png' } %>
+    <%= render 'gemini_form', accept: 'image/jpeg,image/png' %>
   </div>
 </div>

--- a/app/views/admin/partner_submissions/index.html.erb
+++ b/app/views/admin/partner_submissions/index.html.erb
@@ -12,5 +12,5 @@
       </div>
     </div>
   </div>
-  <%= render partial: 'shared/watt/paginator', locals: { total_items_count: @partner_submissions.total_count, items_count: @partner_submissions.length, per_page: @size, current_page: @page, base_url: admin_partner_submissions_url(@filters) } %>
+  <%= render 'shared/watt/paginator', total_items_count: @partner_submissions.total_count, items_count: @partner_submissions.length, per_page: @size, current_page: @page, base_url: admin_partner_submissions_url(@filters) %>
 </div>

--- a/app/views/admin/partners/index.html.erb
+++ b/app/views/admin/partners/index.html.erb
@@ -24,5 +24,5 @@
       </div>
     </div>
   </div>
-  <%= render partial: 'shared/watt/paginator', locals: { total_items_count: @partners.total_count, items_count: @partners.length, per_page: @size, current_page: @page, base_url: admin_partners_url } %>
+  <%= render 'shared/watt/paginator', total_items_count: @partners.total_count, items_count: @partners.length, per_page: @size, current_page: @page, base_url: admin_partners_url %>
 </div>

--- a/app/views/admin/submissions/edit.html.erb
+++ b/app/views/admin/submissions/edit.html.erb
@@ -2,4 +2,4 @@
   <h2>Edit Submission #<%= @submission.id %></h2>
 </div>
 
-<%= render partial: 'form' %>
+<%= render 'form' %>

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -33,5 +33,5 @@
       </div>
     </div>
   </div>
-  <%= render partial: 'shared/watt/paginator', locals: { total_items_count: @submissions.total_count, items_count: @submissions.length, per_page: @size, current_page: @page, base_url: admin_submissions_url(@filters) } %>
+  <%= render 'shared/watt/paginator', total_items_count: @submissions.total_count, items_count: @submissions.length, per_page: @size, current_page: @page, base_url: admin_submissions_url(@filters) %>
 </div>

--- a/app/views/admin/submissions/new.html.erb
+++ b/app/views/admin/submissions/new.html.erb
@@ -2,4 +2,4 @@
   <h2>New Submission</h2>
 </div>
 
-<%= render partial: 'form' %>
+<%= render 'form' %>

--- a/app/views/admin_mailer/submission.html.erb
+++ b/app/views/admin_mailer/submission.html.erb
@@ -2,4 +2,4 @@
 
 <%= link_to('View Submission In Admin', "#{Convection.config.convection_url}/admin/submissions/#{@submission.id}") %>
 
-<%=render partial: 'shared/submission'%>
+<%= render 'shared/submission' %>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,5 +1,5 @@
 <a href=<%= root_url %> class='brand'>
-  <%= render partial: '/shared/watt/svgs/mark' %>
+  <%= render '/shared/watt/svgs/mark' %>
 </a>
 
 <div class='nav-application-name'>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -16,7 +16,7 @@
       </tr>
       <tr>
         <td>
-          <%= render partial: 'shared/email_footer' %>
+          <%= render 'shared/email_footer' %>
         </td>
       </tr>
     </table>

--- a/app/views/partner_mailer/submission_digest.html.erb
+++ b/app/views/partner_mailer/submission_digest.html.erb
@@ -6,7 +6,7 @@
       <table class='email-content submission-batch-email' align='center'>
         <tr>
           <td>
-            <%= render partial: 'shared/email_header' %>
+            <%= render 'shared/email_header' %>
           </td>
         </tr>
         <tr>

--- a/app/views/user_mailer/first_upload_reminder.html.erb
+++ b/app/views/user_mailer/first_upload_reminder.html.erb
@@ -9,7 +9,7 @@
             <table class='email-content first-reminder-email' align='left'>
               <tr>
                 <td>
-                  <%= render partial: 'shared/email_header' %>
+                  <%= render 'shared/email_header' %>
                 </td>
               </tr>
               <tr>

--- a/app/views/user_mailer/second_upload_reminder.html.erb
+++ b/app/views/user_mailer/second_upload_reminder.html.erb
@@ -9,7 +9,7 @@
             <table class='email-content' align='center'>
               <tr>
                 <td>
-                  <%= render partial: 'shared/email_header' %>
+                  <%= render 'shared/email_header' %>
                 </td>
               </tr>
               <tr>

--- a/app/views/user_mailer/submission_approved.html.erb
+++ b/app/views/user_mailer/submission_approved.html.erb
@@ -6,7 +6,7 @@
       <table class='email-content' align='left'>
         <tr>
           <td>
-            <%= render partial: 'shared/email_header' %>
+            <%= render 'shared/email_header' %>
           </td>
         </tr>
         <tr>
@@ -21,7 +21,7 @@
         </tr>
         <tr>
           <td>
-            <%= render partial: 'shared/submission_block', locals: { submission: @submission } %>
+            <%= render 'shared/submission_block', submission: @submission %>
           </td>
         </tr>
       </table>

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -9,7 +9,7 @@
             <table class='email-content' align='center'>
               <tr>
                 <td>
-                  <%= render partial: 'shared/email_header' %>
+                  <%= render 'shared/email_header' %>
                 </td>
               </tr>
               <tr>
@@ -19,7 +19,7 @@
               </tr>
               <tr>
                 <td>
-                  <%= render partial: 'shared/submission_block', locals: { submission: @submission } %>
+                  <%= render 'shared/submission_block', submission: @submission %>
                 </td>
               </tr>
             </table>

--- a/app/views/user_mailer/submission_rejected.html.erb
+++ b/app/views/user_mailer/submission_rejected.html.erb
@@ -6,7 +6,7 @@
       <table class='email-content' align='left'>
         <tr>
           <td>
-            <%= render partial: 'shared/email_header' %>
+            <%= render 'shared/email_header' %>
           </td>
         </tr>
         <tr>
@@ -18,7 +18,7 @@
         </tr>
         <tr>
           <td>
-            <%= render partial: 'shared/submission_block', locals: { submission: @submission } %>
+            <%= render 'shared/submission_block', submission: @submission %>
           </td>
         </tr>
       </table>

--- a/app/views/user_mailer/third_upload_reminder.html.erb
+++ b/app/views/user_mailer/third_upload_reminder.html.erb
@@ -9,7 +9,7 @@
             <table class='email-content' align='center'>
               <tr>
                 <td>
-                  <%= render partial: 'shared/email_header' %>
+                  <%= render 'shared/email_header' %>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
In some cases `:partial` and `:key` declarations could be omitted.