### PR TITLE
@ashkan18 => dont re-gzip response from gravQL

### DIFF
--- a/lib/gravql.rb
+++ b/lib/gravql.rb
@@ -8,8 +8,7 @@ class Gravql
         URI("#{Convection.config.gravity_api_url}/graphql"),
         { query: query, variables: variables }.to_json,
         'X-XAPP-TOKEN' => Convection.config.gravity_xapp_token,
-        'Content-Type' => 'application/json',
-        'Accept-Encoding' => 'gzip'
+        'Content-Type' => 'application/json'
       )
 
       JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
It looks like `Net::HTTP` [automatically handles](http://ruby-doc.org/stdlib-2.1.1/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-Compression) compressed responses, which (I think) is why the presence of this header was returning responses like 

```
"\x1F\x8B\b\x00KF\xD6Y\x00\x03|WkO\eW\x10\xFD++\x7Fh>4!\xF7\xFD\xC87\x02\x04HxD....
```

... which would then fail on the `JSON.parse` line. 😄 

cc @yuki24 