### PR TITLE
@mzikherman => formatting improvements/little bug fixes for the partner digest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,24 @@
+ACCESS_TOKEN=replace-me
+ARTSY_URL=https://staging.artsy.net
+AUCTION_OFFER_FORM_URL=https://foo.com
 AUTHENTICATION_TOKEN=replace-me
+GEMINI_ACCOUNT_KEY=convection-staging
+GEMINI_APP=https://media.artsy.net
+GEMINI_S3_KEY=replace-me
+GRAVITY_APP_ID=replace-me
+GRAVITY_APP_SECRET=replace-me
+GRAVITY_URL=https://stagingapi.artsy.net
 GRAVITY_XAPP_TOKEN=replace-me
+JWT_SECRET=replace-me
 SIDEKIQ_USERNAME=admin
 SIDEKIQ_PASSWORD=replace-me
 SMTP_ADDRESS=mailtrap.io
 SMTP_PASSWORD=replace-me
 SMTP_PORT=465
 SMTP_USER=replace-me
+
+# necessary for rabbit setup
 RABBITMQ_URL=replace-me
 RABBITMQ_CA_CERT=replace-me
 RABBITMQ_CLIENT_CERT=replace-me
 RABBITMQ_CLIENT_KEY=replace-me
-CONSIGNMENT_COMMUNICATION_ID=replace-me

--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Convection is the application that powers our consignments workflow, enabling us
 
 [![CircleCI](https://circleci.com/gh/artsy/convection.svg?style=svg&circle-token=cf452a49d5399e749ebbb85a0843d6111b79c9aa)](https://circleci.com/gh/artsy/convection)
 
-* __State:__ development
-* __Staging:__ [convection-staging.herokuapp.com](https://convection-staging.artsy.net) | [convection-staging on Heroku](https://dashboard.heroku.com/apps/convection-staging/resources)
-* __Production:__ [convection-production.herokuapp.com](https://convection.artsy.net) | [convection-production on Heroku](https://dashboard.heroku.com/apps/convection-production/resources)
+* __State:__ early production
+* __Staging:__ [https://convection-staging.artsy.net](https://convection-staging.artsy.net) | [convection-staging on Heroku](https://dashboard.heroku.com/apps/convection-staging/resources)
+* __Production:__ [https://convection.artsy.net](https://convection.artsy.net) | [convection-production on Heroku](https://dashboard.heroku.com/apps/convection-production/resources)
 * __Github:__ [https://github.com/artsy/convection](https://github.com/artsy/convection)
 * __CI:__ [CircleCI](https://circleci.com/gh/artsy/convection)
+* __Point people:__ [sweir27](https://github.com/sweir27)
 * __Branching/Deploys:__ PRs merged to `master` are automatically built and deployed to staging. PRs from `master` to `release` are automatically deployed to production. [Deploy to production](https://github.com/artsy/convection/compare/release...master?expand=1).
 
 ### Set up
 
     bundle # install dependencies
     bundle exec rake # run rubocop and tests
-    cp .env.example .env # create local file for configuration, edit it
+    cp .env.example .env # create local file for configuration, edit it (can use values from `heroku config --app convection-staging`)
     foreman start # run local rails server
 
 ### Development notes

--- a/app/assets/stylesheets/emails.css.scss
+++ b/app/assets/stylesheets/emails.css.scss
@@ -213,7 +213,9 @@ table.bordered-email {
     border-collapse: separate;
     table-layout: fixed;
     text-align: left;
-    padding: 20px;
+    padding-top: 20px;
+    padding-right: 20px;
+    padding-bottom: 20px;
     background-color: black;
     color: white;
 
@@ -234,7 +236,7 @@ table.bordered-email {
 
       .footer-icon {
         width: 40px;
-
+        padding-left: 20px;
         img {
           height: 20px;
           max-height: 20px;
@@ -244,6 +246,10 @@ table.bordered-email {
       .footer-icon-facebook {
         width: 30px;
       }
+    }
+
+    .need-help {
+      padding-left: 20px;
     }
 
     a {
@@ -276,7 +282,14 @@ table.bordered-email {
         }
 
         .second-column {
-          max-width: 250px;
+          max-width: 255px;
+        }
+      }
+
+      .specialist-contacts {
+        padding-left: 20px;
+        p {
+          color: white;
         }
       }
 
@@ -284,6 +297,13 @@ table.bordered-email {
         border-right: 1px solid white;
         padding-right: 20px;
         margin-right: 20px;
+        padding-left: 20px;
+      }
+    }
+
+    .address-row {
+      td {
+        padding-left: 20px;
       }
     }
   }
@@ -468,7 +488,7 @@ table.bordered-email {
 
       .first-column {
         width: 100% !important;
-        max-width: none !important;
+        max-width: 230px !important;
         img {
           width: 100% !important;
           max-width: none !important;

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -26,15 +26,8 @@ module Admin
     end
 
     def show
-      @notified_partner_submissions = @submission.partner_submissions.where.not(notified_at: nil)
-      partners = @notified_partner_submissions.map(&:partner)
-      return unless partners && !partners.empty?
-      partners_details_response = Gravql::Schema.execute(
-        query: GravqlQueries::PARTNER_DETAILS_QUERY,
-        variables: { ids: partners.pluck(:gravity_partner_id) }
-      )
-      flash.now[:error] = 'Error fetching some partner details.' if partners_details_response[:errors].present?
-      @partner_details = partners_details_response[:data][:partners].map { |pd| [pd[:id], pd] }.to_h
+      notified_partner_submissions = @submission.partner_submissions.where.not(notified_at: nil)
+      @partner_submissions_count = notified_partner_submissions.group_by_day.count
     end
 
     def edit; end

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -8,8 +8,8 @@ module UrlHelper
     utm_url("#{Convection.config.artsy_url}/#{path}", utm_params)
   end
 
-  def offer_url(partner_type)
-    partner_type == 'Gallery' ? Convection.config.gallery_offer_form_url : Convection.config.auction_offer_form_url
+  def offer_form_url
+    Convection.config.auction_offer_form_url
   end
 
   private

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -1,4 +1,6 @@
 class PartnerSubmission < ApplicationRecord
   belongs_to :partner
   belongs_to :submission
+
+  scope :group_by_day, -> { group("date_trunc('day', created_at) ") }
 end

--- a/app/views/admin/partners/index.html.erb
+++ b/app/views/admin/partners/index.html.erb
@@ -13,7 +13,7 @@
                 <%= @partner_details[partner.gravity_partner_id][:given_name] %>
               </p>
               <p>
-                <%= link_to 'View next digest contents', admin_partner_submissions_path(partner_id: partner.id, notified_at: nil) %>
+                <%= link_to 'View next digest contents', admin_partner_submissions_path(partner_id: partner.id, notified_at: '') %>
               </p>
             </div>
             <div class='list-group-item-info list-group-item-links'>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -177,10 +177,9 @@
       <% end %>
       <div class='row double-padding-top'>
         <div class='bold-label'>Partner Interest</div>
-        <% @notified_partner_submissions.each do |ps| %>
-          <p>
-            <%= @partner_details[ps.partner.gravity_partner_id].try(:[], :given_name) %> notified on <%= formatted_date(ps.notified_at) %>
-          </p>
+
+        <% @partner_submissions_count.each do |date, count| %>
+          <%= "#{count} partners notified on #{date.strftime('%Y-%m-%d')}" %>
         <% end %>
       </div>
     </div>

--- a/app/views/partner_mailer/submission_digest.html.erb
+++ b/app/views/partner_mailer/submission_digest.html.erb
@@ -40,18 +40,24 @@
             <table class='submission-batch-todo sans-serif'>
               <tr>
                 <td>
-                  <table class='full-width-button'>
-                    <tr>
-                        <td class='submit-proposal-button'>
-                          <%= link_to('Submit Proposal', offer_url(@partner_type)) %>
-                        </td>
-                    </tr>
-                  </table>
+                  <% if @partner_type == 'Auction' %>
+                    <table class='full-width-button'>
+                      <tr>
+                          <td class='submit-proposal-button'>
+                            <%= link_to('Submit Proposal', offer_form_url) %>
+                          </td>
+                      </tr>
+                    </table>
+                  <% end %>
                 </td>
               </tr>
               <tr>
                 <td class='email-sub-title'>
-                  Please respond directly to this email if you have any questions,
+                  <% if @partner_type == 'Gallery' %>
+                    Please respond directly to this email with your proposal, or if you have any questions.
+                  <% else %>
+                    Please respond directly to this email if you have any questions,
+                  <% end %>
                 </td>
               </tr>
               <tr>

--- a/app/views/shared/_email_footer.html.erb
+++ b/app/views/shared/_email_footer.html.erb
@@ -9,7 +9,7 @@
           <td class='footer-icon footer-icon-facebook'>
             <%= link_to image_tag(image_url('facebook.png'), id: 'facebook'), 'https://facebook.com/artsy' %>
           </td class='footer-icon'>
-          <td>
+          <td class='footer-icon'>
             <%= link_to image_tag(image_url('instagram.png'), id: 'instagram'), 'https://instagram.com/artsy' %>
           </td>
         </tr>
@@ -77,7 +77,7 @@
       </table>
     </td>
   </tr>
-  <tr class='small-info-row'>
+  <tr class='small-info-row address-row'>
     <td>
       Artsy · 401 Broadway · 26th Floor · New York, NY · 10013
     </td>

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -13,7 +13,6 @@ Convection.config = OpenStruct.new(
   contact_phone_number: ENV['CONTACT_PHONE_NUMBER'] || '+1 (646) 712-8154',
   convection_url: ENV['CONVECTION_URL'] || 'https://convection-staging.artsy.net',
   debug_email_address: ENV['DEBUG_EMAIL_ADDRESS'] || 'sarah@artsymail.com',
-  gallery_offer_form_url: ENV['GALLERY_OFFER_FORM_URL'] || 'https://foo.com',
   gemini_account_key: ENV['GEMINI_ACCOUNT_KEY'] || 'convection-staging',
   gemini_app: ENV['GEMINI_APP'] || 'https://media.artsy.net',
   gemini_s3_key: ENV['GEMINI_S3_KEY'] || 'replace-me',

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -15,18 +15,13 @@ describe UrlHelper, type: :helper do
     end
   end
 
-  describe '#offer_url' do
+  describe '#offer_form_url' do
     before do
       allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction')
-      allow(Convection.config).to receive(:gallery_offer_form_url).and_return('https://google.com/gallery')
-    end
-
-    it 'returns the correct url for a gallery' do
-      expect(helper.offer_url('Gallery')).to eq('https://google.com/gallery')
     end
 
     it 'returns the correct url for an auction' do
-      expect(helper.offer_url('Auction')).to eq('https://google.com/auction')
+      expect(helper.offer_form_url).to eq('https://google.com/auction')
     end
   end
 end

--- a/spec/mailers/previews/partner_mailer_preview.rb
+++ b/spec/mailers/previews/partner_mailer_preview.rb
@@ -1,6 +1,12 @@
 class PartnerMailerPreview < ActionMailer::Preview
-  def submission_digest
-    PartnerMailer.submission_digest(submission_digest_mail_params)
+  def submission_digest_auction
+    params = submission_digest_mail_params.merge(partner: OpenStruct.new(name: 'Phillips', type: 'Auction'))
+    PartnerMailer.submission_digest(params)
+  end
+
+  def submission_digest_gallery
+    params = submission_digest_mail_params.merge(partner: OpenStruct.new(name: 'Gagosian', type: 'Gallery'))
+    PartnerMailer.submission_digest(params)
   end
 
   private
@@ -40,8 +46,7 @@ class PartnerMailerPreview < ActionMailer::Preview
         submission_params,
         submission_params,
         submission_params
-      ],
-      partner: OpenStruct.new(name: 'Phillips', type: 'Auction')
+      ]
     }
   end
 end

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -11,7 +11,6 @@ describe 'admin/submissions/show.html.erb', type: :feature do
     before do
       allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
       allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction')
-      allow(Convection.config).to receive(:gallery_offer_form_url).and_return('https://google.com/gallery')
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail
@@ -93,8 +92,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
       page.visit "/admin/submissions/#{@submission.id}"
 
       expect(page).to have_content('Partner Interest')
-      expect(page).to have_content('Partner 1 notified on')
-      expect(page).to have_content('Phillips notified on')
+      expect(page).to have_content('2 partners notified on')
     end
 
     context 'unreviewed submission' do


### PR DESCRIPTION
Bunch of little fixes baked in here:
- Updated the `.env.example` file since it was sorely out of date
- Updated the README slightly to be more informative
- Changed our logic around what to show auction houses v. galleries: we won't be giving galleries a form to fill out, so the logic has changed to show a button in the case of an auction house and some text in the case of a gallery:
  - Gallery: ![image](https://user-images.githubusercontent.com/2081340/31506500-941c135e-af45-11e7-8da0-a50ceaac5470.png)
  - Auction house: ![image](https://user-images.githubusercontent.com/2081340/31506513-9d21c728-af45-11e7-8385-0d1651a93097.png)
- Instead of listing every partner who was notified about a consignment, we show just the number and the day:
![image](https://user-images.githubusercontent.com/2081340/31506572-c36ab282-af45-11e7-9c0f-1528dc6e0019.png)
- Fixed the "View next digest contents" to pass `notified_at: ''` instead of `notified_at: nil` since we want the param to exist and setting it to nil causes it to be stripped.
