### PR TITLE
@joeyAghion => adds rake task for running daily digest

### DIFF
--- a/lib/tasks/partners.rake
+++ b/lib/tasks/partners.rake
@@ -1,7 +1,7 @@
 namespace :partners do
   desc 'Sends daily email to partners with newly approved submissons.'
   task daily_digest: :environment do
-    puts "[#{Time.now}] Generating daily partner digest for #{Partner.count} partners ..."
+    puts "[#{Time.now.utc}] Generating daily partner digest for #{Partner.count} partners ..."
     PartnerSubmissionService.daily_digest
   end
 end


### PR DESCRIPTION
The `daily_digest` and similar methods already have tests-- I'm just adding a rake task wrapper + some extra logging output. I was planning to run this through jenkins, but I'm open if we have other preferences?