### PR TITLE
@joeyAghion => default bcc consignments-archive google group on emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
   default from: 'Artsy <support@artsy.net>'
+  default bcc: Convection.config.bcc_email_address
   layout 'mailer'
 
   protected

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -13,7 +13,7 @@ class UserMailer < ApplicationMailer
     }
     mail(to: user_detail.email,
          subject: "Consignment Submission Confirmation ##{@submission.id}",
-         bcc: Convection.config.admin_email_address)
+         bcc: [Convection.config.admin_email_address, Convection.config.bcc_email_address])
   end
 
   def first_upload_reminder(submission:, user:, user_detail:)
@@ -63,8 +63,7 @@ class UserMailer < ApplicationMailer
       submission_id: submission.id
     }
     mail(to: Convection.config.debug_email_address,
-         subject: 'Your consignment has been approved',
-         bcc: Convection.config.admin_email_address)
+         subject: 'Your consignment has been approved')
   end
 
   def submission_rejected(submission:, user:, user_detail:, artist:)
@@ -78,7 +77,6 @@ class UserMailer < ApplicationMailer
       submission_id: submission.id
     }
     mail(to: Convection.config.debug_email_address,
-         subject: 'An important update about your consignment submission',
-         bcc: Convection.config.admin_email_address)
+         subject: 'An important update about your consignment submission')
   end
 end

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -7,6 +7,7 @@ Convection.config = OpenStruct.new(
   admin_email_address: ENV['ADMIN_EMAIL_ADDRESS'] || 'consign@artsy.net',
   artsy_url: ENV['ARTSY_URL'] || 'https://staging.artsy.net',
   auction_offer_form_url: ENV['AUCTION_OFFER_FORM_URL'] || 'https://foo.com',
+  bcc_email_address: ENV['BCC_EMAIL_ADDRESS'] || 'consignments-archive@artsymail.com',
   cloudfront_url: ENV['CLOUDFRONT_URL'],
   consignment_communication_name: ENV['CONSIGNMENT_COMMUNICATION_NAME'] || 'Consignment Submissions',
   contact_email_address: ENV['CONTACT_EMAIL'] || 'specialist@artsy.net',

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -125,6 +125,7 @@ describe PartnerSubmissionService do
           expect(emails.length).to eq 1
           email = emails.first
           expect(email.subject).to include('New Artsy Consignments September 27: 3 works')
+          expect(email.bcc).to eq(['consignments-archive@artsymail.com'])
           expect(email.html_part.body).to include('<i>First approved artwork</i><span>, 1992</span>')
           expect(email.html_part.body).to include('<i>Second approved artwork</i><span>, 1993</span>')
           expect(email.html_part.body).to include('<i>Third approved artwork</i><span>, 1997</span>')

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -60,6 +60,7 @@ describe SubmissionService do
       SubmissionService.update_submission(submission, { state: 'approved' }, 'userid')
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
+      expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
       expect(emails.first.html_part.body).to include(
         'Your work is currently being reviewed for consignment by our network of trusted partners'
       )
@@ -86,6 +87,7 @@ describe SubmissionService do
       SubmissionService.update_submission(submission, { state: 'rejected' }, 'userid')
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
+      expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
       expect(emails.first.html_part.body).to include(
         'they do not have a market for this work at the moment'
       )
@@ -125,6 +127,7 @@ describe SubmissionService do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
+        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
         expect(emails.first.html_part.body).to include('Complete your consignment submission')
         expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
         expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e01')
@@ -138,6 +141,7 @@ describe SubmissionService do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
+        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
         expect(emails.first.html_part.body).to include("We're missing photos of your work")
         expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
         expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e02')
@@ -151,6 +155,7 @@ describe SubmissionService do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
+        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
         expect(emails.first.html_part.body).to include("We're unable to complete your submission")
         expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
         expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e03')
@@ -222,6 +227,7 @@ describe SubmissionService do
       SubmissionService.deliver_submission_receipt(submission.id)
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
+      expect(emails.first.bcc).to include('consignments-archive@artsymail.com', 'lucille@bluth.com')
       expect(emails.first.html_part.body).to include('Thank you for submitting your work to our consignments network')
     end
   end


### PR DESCRIPTION
Similar to what we do in auctions, I can already foresee it being helpful to have a record of the partner digest and other consignments-related automated emails. This adds `consignments-archive@artsymail.com` as the default bcc address for all emails sent from convection.