### PR TITLE
@joeyAghion => send approval/rejection emails to actual users

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -62,7 +62,7 @@ class UserMailer < ApplicationMailer
     smtpapi category: ['submission_approved'], unique_args: {
       submission_id: submission.id
     }
-    mail(to: Convection.config.debug_email_address,
+    mail(to: user_detail.email,
          subject: 'Your consignment has been approved')
   end
 
@@ -76,7 +76,7 @@ class UserMailer < ApplicationMailer
     smtpapi category: ['submission_rejected'], unique_args: {
       submission_id: submission.id
     }
-    mail(to: Convection.config.debug_email_address,
+    mail(to: user_detail.email,
          subject: 'An important update about your consignment submission')
   end
 end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -61,6 +61,7 @@ describe SubmissionService do
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
       expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
+      expect(emails.first.to).to eq(['michael@bluth.com'])
       expect(emails.first.html_part.body).to include(
         'Your work is currently being reviewed for consignment by our network of trusted partners'
       )
@@ -88,6 +89,7 @@ describe SubmissionService do
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
       expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
+      expect(emails.first.to).to eq(['michael@bluth.com'])
       expect(emails.first.html_part.body).to include(
         'they do not have a market for this work at the moment'
       )


### PR DESCRIPTION
This PR unlocks the approval/rejection to send to actual users instead of the debug email address. I'll make sure to update the team when this is deployed!