### PR TITLE
@joeyAghion => little cosmetic improvements for the partner digest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ LineLength:
   Exclude:
     - config/environments/*
     - config/initializers/*
-  Max: 128
+  Max: 139
   IgnoreCopDirectives: true
 
 Style/AlignParameters:
@@ -36,7 +36,7 @@ Metrics/AbcSize:
   Max: 62
 
 Metrics/MethodLength:
-  Max: 30
+  Max: 33
 
 Metrics/CyclomaticComplexity:
   Max: 8

--- a/app/assets/stylesheets/emails.css.scss
+++ b/app/assets/stylesheets/emails.css.scss
@@ -273,6 +273,10 @@ table.bordered-email {
       width: 100%;
       max-width: 500px;
 
+      table.contents--left {
+        border-right: 1px solid #666666;
+      }
+
       .two-column {
         text-align: left;
 
@@ -294,7 +298,6 @@ table.bordered-email {
       }
 
       .collector-links {
-        border-right: 1px solid #666666;
         padding-right: 20px;
         margin-right: 20px;
         padding-left: 20px;
@@ -465,10 +468,8 @@ table.bordered-email {
 }
 
 @media all and (min-width: 480px) {
-  .footer-contact-row {
-    .collector-links {
-      border-right: 1px solid #666666 !important;
-    }
+  table.contents--left {
+    border-right: 1px solid #666666 !important;
   }
 }
 
@@ -507,10 +508,8 @@ table.bordered-email {
     }
 
   table.footer-contact {
-    .footer-contact-row {
-      .collector-links {
-        border-right: 0px !important;
-      }
+    table.contents--left {
+      border-right: 0px !important;
     }
   }
 }

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -17,6 +17,15 @@ module SubmissionsHelper
     submission.edition_number.present? ? "#{submission.edition_number}/#{submission.edition_size}" : nil
   end
 
+  def formatted_medium_metadata(submission)
+    edition_text = formatted_editions(submission).present? ? "Edition #{formatted_editions(submission)}" : nil
+    [
+      submission.medium.try(:truncate, 100),
+      formatted_dimensions(submission),
+      edition_text
+    ].compact.join(', ')
+  end
+
   def reviewer_byline(submission)
     if submission.approved?
       "Approved by #{submission.reviewed_by_user.try(:name)}"

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -14,6 +14,8 @@ class PartnerMailer < ApplicationMailer
     mail(
       to: Convection.config.debug_email_address,
       subject: "New Artsy Consignments #{current_date}: #{@submissions.count} works"
-    )
+    ) do |format|
+      format.html { render layout: 'mailer_no_footer' }
+    end
   end
 end

--- a/app/views/shared/_email_footer.html.erb
+++ b/app/views/shared/_email_footer.html.erb
@@ -30,7 +30,7 @@
               <table width="100%" class='column-outer-table'>
                 <tr>
                   <td class="inner">
-                    <table class="contents">
+                    <table class="contents contents--left">
                       <tr>
                         <td class='collector-links'>
                           <p class='small-margin-bottom'>

--- a/app/views/shared/_submission_digest_block.html.erb
+++ b/app/views/shared/_submission_digest_block.html.erb
@@ -42,7 +42,7 @@
                 </tr>
                 <tr>
                   <td>
-                    <%= submission.medium %>, <%= formatted_dimensions(submission) %>
+                    <%= formatted_medium_metadata(submission) %>
                   </td>
                 </tr>
                 <tr>
@@ -53,7 +53,7 @@
                 <% if submission.provenance.present? %>
                   <tr>
                     <td>
-                      <i><%= submission.provenance.truncate(50) %></i>
+                      <i><%= submission.provenance.truncate(45) %></i>
                     </td>
                   </tr>
                 <% end %>

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -97,6 +97,65 @@ describe SubmissionsHelper, type: :helper do
     end
   end
 
+  context 'formatted_medium_metadata' do
+    let(:submission) do
+      Fabricate(
+        :submission,
+        medium: 'Oil on linen',
+        edition_number: '10a',
+        edition_size: 100,
+        height: 10,
+        width: 10,
+        depth: 15,
+        dimensions_metric: 'cm'
+      )
+    end
+    it 'displays the correct text when all info is present' do
+      expect(helper.formatted_medium_metadata(submission)).to eq 'Oil on linen, 10x10x15cm, Edition 10a/100'
+    end
+    it 'truncates the medium correctly' do
+      submission.update_attributes!(
+        medium: 'Since the late 1990s, KAWS has produced art toys to be circulated as global commodities. '\
+                'By engaging directly with branding, production, and distribution, his toys compel their '\
+                'collectors to consider what the commodity status of art objects is today. Seen here, the '\
+                "\"Accomplice” characters from KAWS are appropriately branded with the artist's trademark \"X\" "\
+                "to replace each of the figure's original eyes. The black example is from an edition of 500 "\
+                'and the pink example is from an edition of 1000'
+      )
+      expect(helper.formatted_medium_metadata(submission)).to eq(
+        'Since the late 1990s, KAWS has produced art toys to be circulated as global commodities. By engag..., 10x10x15cm, Edition 10a/100'
+      )
+    end
+    it 'displays the correct text when there is no medium' do
+      submission.update_attributes!(medium: nil)
+      expect(helper.formatted_medium_metadata(submission)).to eq '10x10x15cm, Edition 10a/100'
+    end
+    it 'displays the correct text when there is no edition number/size' do
+      submission.update_attributes!(edition_number: nil, edition_size: nil)
+      expect(helper.formatted_medium_metadata(submission)).to eq 'Oil on linen, 10x10x15cm'
+    end
+    it 'displays the correct text when there are no dimensions' do
+      submission.update_attributes!(height: nil, width: nil, depth: nil)
+      expect(helper.formatted_medium_metadata(submission)).to eq 'Oil on linen, Edition 10a/100'
+    end
+    it 'displays the correct text when there is only a medium' do
+      submission.update_attributes!(height: nil, width: nil, depth: nil, edition_number: nil, edition_size: nil)
+      expect(helper.formatted_medium_metadata(submission)).to eq 'Oil on linen'
+    end
+    it 'displays the correct text when there is only an edition number/size' do
+      submission.update_attributes!(height: nil, width: nil, depth: nil, medium: nil)
+      expect(helper.formatted_medium_metadata(submission)).to eq 'Edition 10a/100'
+    end
+    it 'displays the correct text when there are only dimensions' do
+      submission.update_attributes!(medium: nil, edition_number: nil, edition_size: nil)
+      expect(helper.formatted_medium_metadata(submission)).to eq '10x10x15cm'
+    end
+    it 'displays the correct text when there is no info' do
+      submission.update_attributes!(medium: nil, edition_number: nil, edition_size: nil, height: nil, width: nil, depth: nil)
+      expect(helper.formatted_medium_metadata(submission)).to eq ''
+    end
+  end
+
   context 'reviewer_byline' do
     it 'shows the correct label for an approved submission' do
       stub_gravity_root

--- a/spec/mailers/previews/partner_mailer_preview.rb
+++ b/spec/mailers/previews/partner_mailer_preview.rb
@@ -22,12 +22,19 @@ class PartnerMailerPreview < ActionMailer::Preview
       width: 14,
       dimensions_metric: 'in',
       category: 'Painting',
-      medium: 'Oil on linen',
+      medium: 'Since the late 1990s, KAWS has produced art toys to be circulated as global commodities. '\
+              'By engaging directly with branding, production, and distribution, his toys compel their '\
+              'collectors to consider what the commodity status of art objects is today. Seen here, the '\
+              "\"Accomplice” characters from KAWS are appropriately branded with the artist's trademark \"X\" "\
+              "to replace each of the figure's original eyes. The black example is from an edition of 500 "\
+              'and the pink example is from an edition of 1000',
       artist_name: 'Damien Hirst',
       location_city: 'New York',
       location_state: 'NY',
       location_country: 'USA',
       provenance: 'Inherited from my mother who got it from her father after he divorced from his second wife.',
+      edition_number: '12a',
+      edition_size: 100,
       large_images: [
         OpenStruct.new(image_urls: { 'large' => 'http://foo1.jpg' }),
         OpenStruct.new(image_urls: { 'large' => 'http://foo2.jpg' }),


### PR DESCRIPTION
This PR:
- Removes the footer from the digest email (turns out we don't want it)
- Fixes the digest email to truncate the medium text and display edition information:
![image](https://user-images.githubusercontent.com/2081340/31726770-cd646918-b3f5-11e7-8450-5ff3eaa42262.png)