### PR TITLE
@joeyAghion => send digest from consign@

### DIFF
--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -12,6 +12,7 @@ class PartnerMailer < ApplicationMailer
     current_date = Time.now.utc.strftime('%B %-d')
     mail(
       to: email,
+      from: Convection.config.admin_email_address,
       subject: "New Artsy Consignments #{current_date}: #{@submissions.count} works"
     ) do |format|
       format.html { render layout: 'mailer_no_footer' }

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -122,6 +122,7 @@ describe PartnerSubmissionService do
           email = emails.first
           expect(email.subject).to include('New Artsy Consignments September 27: 3 works')
           expect(email.bcc).to eq(['consignments-archive@artsymail.com'])
+          expect(email.from).to eq(['consign@artsy.net'])
           expect(email.html_part.body).to include('<i>First approved artwork</i><span>, 1992</span>')
           expect(email.html_part.body).to include('<i>Second approved artwork</i><span>, 1993</span>')
           expect(email.html_part.body).to include('<i>Third approved artwork</i><span>, 1997</span>')


### PR DESCRIPTION
Since we explicitly ask partners reply to this email, we want it to be sent from consign@artsy.net instead of the default support@artsy.net.