### PR TITLE
always alphabetize partners list

### DIFF
--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -7,7 +7,11 @@ module Admin
     def index
       @size = (params[:size] || 100).to_i
       @partners = Partner.order(id: :asc).page(@page).per(@size)
-      @partner_details = partners_query(@partners.pluck(:gravity_partner_id))
+      partners_hash = @partners.map { |p| [p.gravity_partner_id, p.id] }.to_h
+      aggregated_partner_details = partners_query(partners_hash.keys).map do |gravity_partner_id, details|
+        [gravity_partner_id, { given_name: details[:given_name], partner_id: partners_hash[gravity_partner_id] }]
+      end
+      @partner_details = aggregated_partner_details.sort_by { |_gravity_id, details| details[:given_name].downcase }
     end
   end
 end

--- a/app/views/admin/partners/index.html.erb
+++ b/app/views/admin/partners/index.html.erb
@@ -6,18 +6,18 @@
   <div class='row triple-padding-top'>
     <div class='col-md-12'>
       <div class='list-group'>
-        <% @partners.each do |partner| %>
-          <div class='list-group-item list-item--partner' data-id=<%= partner[:id] %>>
+        <% @partner_details.each do |gravity_partner_id, details| %>
+          <div class='list-group-item list-item--partner' data-id=<%= details[:partner_id] %>>
             <div class='list-group-item-info'>
               <p class='list-item--partner--name'>
-                <%= @partner_details[partner.gravity_partner_id][:given_name] %>
+                <%= details[:given_name] %>
               </p>
               <p>
-                <%= link_to 'View next digest contents', admin_partner_submissions_path(partner_id: partner.id, notified_at: '') %>
+                <%= link_to 'View next digest contents', admin_partner_submissions_path(partner_id: details[:partner_id], notified_at: '') %>
               </p>
             </div>
             <div class='list-group-item-info list-group-item-links'>
-              <%= link_to 'Edit partner contacts', "#{Convection.config.vibrations_url}/contacts?partner_id=#{partner.gravity_partner_id}", class: 'btn btn-secondary btn-tiny' %>
+              <%= link_to 'Edit partner contacts', "#{Convection.config.vibrations_url}/contacts?partner_id=#{gravity_partner_id}", class: 'btn btn-secondary btn-tiny' %>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
This is a pretty #minor change, but seemed unclean. On the view where we show all of the partners that we keep track of in convection:

![image](https://user-images.githubusercontent.com/2081340/32252892-5770c6c4-be6e-11e7-8e47-4fedd572079b.png)

... we weren't explicitly sorting them by name (just got lucky because when I imported them the first time, I did so in basically alphabetical order).

This PR just explicitly orders them by the name that we retrieve from gravity.