### PR TITLE
@mzikherman => use saved partner name instead of querying

### DIFF
--- a/app/controllers/admin/partner_submissions_controller.rb
+++ b/app/controllers/admin/partner_submissions_controller.rb
@@ -9,7 +9,6 @@ module Admin
       notified_at = params[:notified_at] && params[:notified_at].blank? ? nil : params[:notified_at]
 
       @partner = Partner.find(params[:partner_id])
-      @partner_details = partners_query(@partner.gravity_partner_id)
 
       partner_submissions = @partner.partner_submissions
       partner_submissions = partner_submissions.where(notified_at: notified_at) if params[:notified_at]

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -1,13 +1,10 @@
 module Admin
   class PartnersController < ApplicationController
     include GraphqlHelper
-
     before_action :set_pagination_params, only: [:index]
 
     def index
-      @size = (params[:size] || 100).to_i
-      @partners = Partner.order(id: :asc).page(@page).per(@size)
-      @partner_details = partners_query(@partners.pluck(:gravity_partner_id))
+      @partners = Partner.order(name: :asc).page(@page).per(@size)
     end
   end
 end

--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -1,15 +1,6 @@
 module GraphqlHelper
   extend ActiveSupport::Concern
 
-  PARTNER_DETAILS_QUERY = %|
-    query partnersDetails($ids: [ID]!){
-      partners(ids: $ids){
-        id
-        given_name
-      }
-    }
-  |.freeze
-
   ARTISTS_DETAILS_QUERY = %|
   query artistsDetails($ids: [ID]!){
     artists(ids: $ids){
@@ -18,16 +9,6 @@ module GraphqlHelper
     }
   }
   |.freeze
-
-  def partners_query(partner_ids)
-    partners_details_response = Gravql::Schema.execute(
-      query: PARTNER_DETAILS_QUERY,
-      variables: { ids: partner_ids }
-    )
-    flash.now[:error] = 'Error fetching some partner details.' if partners_details_response[:errors].present?
-    return unless partners_details_response.try(:[], :data).try(:[], :partners).present?
-    partners_details_response[:data][:partners].map { |pd| [pd[:id], pd] }.to_h
-  end
 
   def artists_query(artist_ids)
     artist_details_response = Gravql::Schema.execute(

--- a/app/services/partner_submission_service.rb
+++ b/app/services/partner_submission_service.rb
@@ -38,7 +38,7 @@ class PartnerSubmissionService
 
       submission_ids = submissions.pluck(:id)
       partner_contacts.map(&:email).each do |email|
-        delay.deliver_partner_contact_email(submission_ids, gravity_partner.name, gravity_partner.type, email)
+        delay.deliver_partner_contact_email(submission_ids, partner.name, gravity_partner.type, email)
       end
 
       notified_at = Time.now.utc

--- a/app/views/admin/partner_submissions/index.html.erb
+++ b/app/views/admin/partner_submissions/index.html.erb
@@ -1,5 +1,5 @@
 <div class='page-title'>
-<h2>Submissions for <%= @partner_details.values.first[:given_name] %> included in next digest</h2>
+<h2>Submissions for <%= @partner.name %> included in next digest</h2>
 </div>
 
 <div class='container'>

--- a/app/views/admin/partners/index.html.erb
+++ b/app/views/admin/partners/index.html.erb
@@ -10,7 +10,7 @@
           <div class='list-group-item list-item--partner' data-id=<%= partner[:id] %>>
             <div class='list-group-item-info'>
               <p class='list-item--partner--name'>
-                <%= @partner_details[partner.gravity_partner_id][:given_name] %>
+                <%= partner.name %>
               </p>
               <p>
                 <%= link_to 'View next digest contents', admin_partner_submissions_path(partner_id: partner.id, notified_at: '') %>

--- a/spec/controllers/admin/partners_controller_spec.rb
+++ b/spec/controllers/admin/partners_controller_spec.rb
@@ -2,33 +2,17 @@ require 'rails_helper'
 
 describe Admin::PartnersController, type: :controller do
   describe 'with some partners' do
-    let(:partners) { Array.new(5) { Fabricate(:partner) } }
-    let(:gravql_partners_response) do
-      {
-        data: {
-          partners: partners.map { |p, idx| { id: p.gravity_partner_id, given_name: "p_#{idx}" } }
-        }
-      }
-    end
-    let(:xapp_token) { 'xapp_token' }
-    let(:gravql_stub) do
-      stub_request(:post, 'http://gravity.biz/api/graphql')
-        .to_return(body: gravql_partners_response.to_json)
-        .with(
-          headers: {
-            'X-XAPP-TOKEN' => xapp_token,
-            'Content-Type' => 'application/json'
-          }
-        )
-    end
+    let!(:partner1) { Fabricate(:partner, name: 'zz top') }
+    let!(:partner2) { Fabricate(:partner, name: 'abracadabra') }
+    let!(:partner3) { Fabricate(:partner, name: 'animal prints') }
+    let!(:partner4) { Fabricate(:partner, name: 'bubbles') }
+    let!(:partner5) { Fabricate(:partner, name: 'gagosian') }
+
     before do
-      allow(Convection.config).to receive_messages(gravity_xapp_token: xapp_token, gravity_api_url: 'http://gravity.biz/api')
       allow_any_instance_of(Admin::PartnersController).to receive(:require_artsy_authentication)
     end
+
     describe '#index' do
-      before do
-        gravql_stub
-      end
       context 'with successful partner details request' do
         it 'returns the first two partners on the first page' do
           get :index, params: { page: 1, size: 2 }
@@ -38,32 +22,10 @@ describe Admin::PartnersController, type: :controller do
           get :index, params: { page: 3, size: 2 }
           expect(assigns(:partners).count).to eq 1
         end
-      end
-
-      context 'with errors in partner details response' do
-        let(:gravql_partners_response) do
-          {
-            data: {
-              partners: partners.map { |p, idx| { id: p.gravity_partner_id, given_name: "p_#{idx}" } }
-            },
-            errors: [
-              {
-                message: "Can't access subscription_state",
-                locations: [
-                  {
-                    line: 6,
-                    column: 5
-                  }
-                ],
-                path: ['partners', 0, 'subscription_state']
-              }
-            ]
-          }
-        end
-
-        it 'renders flash error' do
-          get :index, params: { page: 1, size: 2 }
-          expect(flash[:error]).to eq 'Error fetching some partner details.'
+        it 'orders the partners correctly' do
+          get :index, params: { page: 1 }
+          expect(assigns(:partners).count).to eq 5
+          expect(assigns(:partners).map(&:name)).to eq(['abracadabra', 'animal prints', 'bubbles', 'gagosian', 'zz top'])
         end
       end
     end

--- a/spec/fabricators/partner_fabricator.rb
+++ b/spec/fabricators/partner_fabricator.rb
@@ -1,3 +1,4 @@
 Fabricator(:partner) do
   gravity_partner_id { Fabricate.sequence(:gravity_partner_id) { |i| "partner-id-#{i}" } }
+  name { Fabricate.sequence(:name) { |i| "Galler #{i}" } }
 end

--- a/spec/views/admin/partner_submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/partner_submissions/index.html.erb_spec.rb
@@ -5,19 +5,7 @@ describe 'admin/partner_submissions/digest.html.erb', type: :feature do
     before do
       allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
       allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
-      @partner = Fabricate(:partner, gravity_partner_id: 'partnerid')
-      gravql_partners_response = {
-        data: {
-          partners: [
-            { id: 'partnerid', given_name: 'Wright' }
-          ]
-        }
-      }
-      stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
-        .with do |request|
-          parsed = JSON.parse(request.body)
-          parsed['variables']['ids'] == 'partnerid' && parsed['query'].include?('partnersDetails')
-        end.to_return(body: gravql_partners_response.to_json)
+      @partner = Fabricate(:partner, gravity_partner_id: 'partnerid', name: 'Wright')
 
       gravql_artists_response = {
         data: {


### PR DESCRIPTION
Little optimizations. 😄 

Since https://github.com/artsy/convection/pull/112 we have the ability to save partner names in convection. This PR updates the UI to use `partner.name` instead of having to query for it everywhere. I've already migrated the data in staging and production to save the partner names, but I'll be adding a jenkins job to run the sync daily.

It's possible we will need the partner graphQL query in the future, but for now we can remove the code since it is unused 🔪 .