### PR TITLE
@joeyAghion => add back sidekiq worker to procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -c ${SIDEKIQ_CONCURRENCY:-5}


### PR DESCRIPTION
This looks to have been accidentally removed in: https://github.com/artsy/convection/pull/120

cc @orta
