### PR TITLE
@ashkinas => add UI for adding partners

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :test do
   gem 'yarjuf' # formatting for test reports on CircleCI
   gem 'webmock' # mock or forbid external network requests
   gem 'capybara', '~> 2.8' # for view tests
+  gem 'capybara-webkit'
   gem 'rails-controller-testing'
   gem 'fabrication'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.1.0)
+      capybara (~> 2.0, >= 2.0.2)
+      json
     coderay (1.1.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -154,6 +157,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.1.0)
     jwt (1.5.6)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
@@ -348,6 +352,7 @@ DEPENDENCIES
   bootstrap-sass
   bourbon
   capybara (~> 2.8)
+  capybara-webkit
   coffee-rails
   database_cleaner
   decent_exposure

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,9 @@
 //= require watt/flash
 //= require watt/autocomplete
 //= require jquery.fileupload.js
+//= require watt/modals
+//= require watt/remodal
 //= require gemini/gemini_upload
 //= require new_asset
 //= require new_submission
+//= require new_partner

--- a/app/assets/javascripts/new_partner.js.coffee
+++ b/app/assets/javascripts/new_partner.js.coffee
@@ -1,0 +1,28 @@
+$ ->
+  # Partner autocomplete
+  updatePartnerSelectionsForm = (selection) ->
+    $( "#partner-selections-form #gravity_partner_id" ).val( selection.id )
+    $( "#partner-selections-form #name" ).val( selection.given_name )
+    $( "#partner-selections-form #partner-search" ).val( selection.given_name )
+    $( "#partner-selections-form #partner-name-display" ).html('Selected partner: ' + selection.given_name)
+    enableDisableButton()
+
+  enableDisableButton = () ->
+    if $('#partner-selections-form #gravity_partner_id').val().length > 0
+      $('#partner-selections-form #partner-search-submit').removeClass('disabled-button')
+    else
+      $('#partner-selections-form #partner-search-submit').addClass('disabled-button')
+
+  if $('#partner-selections-form').length != 0
+    enableDisableButton()
+    $('#partner-selections-form #partner-search').autocomplete(
+      source: (request, response) ->
+        $.getJSON('/match_partner', term: request.term, response)
+      select: (event, ui) ->
+        updatePartnerSelectionsForm(ui.item)
+        false
+    ).data("ui-autocomplete")._renderItem = (ul, item) ->
+      $( "<li class='ui-menu-item'>" )
+        .attr( "data-value", item.value )
+        .append( "<a class='ui-corner-all'>#{item.given_name}</a>" )
+        .appendTo( ul )

--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -114,3 +114,16 @@ $green: #0EDA83;
     margin-left: 20px;
   }
 }
+
+.partners_index {
+  .ui-autocomplete.ui-menu {
+    z-index: 10000
+  }
+}
+
+input[type="submit"].disabled-button {
+  cursor: not-allowed;
+  border-color: #F8F8F8 !important;
+  background-color: $gray !important;
+  pointer-events: none;
+}

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -1,5 +1,7 @@
 module Admin
   class PartnersController < ApplicationController
+    include GraphqlHelper
+
     expose(:partners) do
       matching_partners = Partner.all
       matching_partners = matching_partners.search_by_name(params[:term]) if params[:term]
@@ -11,8 +13,29 @@ module Admin
     end
 
     include GraphqlHelper
-    before_action :set_pagination_params, only: [:index]
+    before_action :set_pagination_params, only: [:index, :create]
 
     def index; end
+
+    def create
+      partner = Partner.new(gravity_partner_id: params[:gravity_partner_id], name: params[:name]) if params[:gravity_partner_id]
+      if partner && partner.save
+        flash[:notice] = 'Partner successfully created.'
+        redirect_to admin_partners_path
+      else
+        flash.now[:error] = "Error creating gravity partner. #{partner&.errors&.full_messages&.to_sentence}"
+        render 'index'
+      end
+    end
+
+    def match_partner
+      if params[:term]
+        @term = params[:term]
+        @partners = match_partners_query(@term)
+      end
+      respond_to do |format|
+        format.json { render json: @partners || [] }
+      end
+    end
   end
 end

--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -10,6 +10,15 @@ module GraphqlHelper
   }
   |.freeze
 
+  MATCH_PARTNERS_QUERY = %|
+  query matchPartners($term: String) {
+    match_partners(term: $term){
+      id
+      given_name
+    }
+  }
+  |.freeze
+
   def artists_query(artist_ids)
     artist_details_response = Gravql::Schema.execute(
       query: ARTISTS_DETAILS_QUERY,
@@ -18,5 +27,15 @@ module GraphqlHelper
     flash.now[:error] = 'Error fetching artist details.' if artist_details_response[:errors].present?
     return unless artist_details_response.try(:[], :data).try(:[], :artists).present?
     artist_details_response[:data][:artists].map { |h| [h[:id], h[:name]] }.to_h
+  end
+
+  def match_partners_query(term)
+    match_partners_response = Gravql::Schema.execute(
+      query: MATCH_PARTNERS_QUERY,
+      variables: { term: term }
+    )
+    flash.now[:error] = 'Error fetching partner details.' if match_partners_response[:errors].present?
+    return unless match_partners_response.try(:[], :data).try(:[], :match_partners).present?
+    match_partners_response[:data][:match_partners]
   end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -9,4 +9,6 @@ class Partner < ApplicationRecord
     }
 
   has_many :partner_submissions
+
+  validates :gravity_partner_id, presence: true, uniqueness: true
 end

--- a/app/views/admin/partners/_create_partner.html.erb
+++ b/app/views/admin/partners/_create_partner.html.erb
@@ -1,0 +1,34 @@
+<div class='modal remodal' data-remodal-id='create-partner-modal'>
+  <div class='modal-header'>
+    <h2>
+      Add new Partner
+    </h2>
+  </div>
+  <div class='modal-close'>
+    <%= link_to '', '#', id: 'create-partner-close'%>
+  </div>
+  <div class='modal-content'>
+    <p>
+      Adding a partner to convection subscribes them to our consignments product. In order for contacts at the partner to receive
+      notifications (such as digests), they must also have partner contacts subscribed to receive the "consignment submission" communication.
+    </p>
+    <div class='single-padding-top'>
+      <p class='bold-label'>
+        Search for gravity partner
+      </p>
+      <div class='col-sm-12' id='partner-selections-form'>
+        <%= form_tag admin_partners_url, method: 'post' do %>
+          <div class='form-group'>
+            <%= text_field_tag 'gravity_partner', '', class: 'form-control', id: 'partner-search' %>
+            <%= hidden_field_tag 'gravity_partner_id' %>
+            <%= hidden_field_tag 'name' %>
+            <div class='single-padding-top'>
+              <%= submit_tag 'Create Partner', class: 'btn btn-primary btn-full-width', id: 'partner-search-submit' %>
+            </div>
+          </div>
+          <div id='partner-name-display'></div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/partners/index.html.erb
+++ b/app/views/admin/partners/index.html.erb
@@ -1,12 +1,23 @@
 <div class='page-title'>
-  <h2>
-    <%= link_to 'Partners', admin_partners_url %>
-  </h2>
+  <div class='row'>
+    <div class='col-md-12'>
+      <div class='col-md-10'>
+        <h2>
+          <%= link_to 'Partners', admin_partners_url %>
+        </h2>
+      </div>
+      <div class='col-md-2'>
+        <div class='row'>
+          <%= link_to 'Add Partner', '#', { 'data-remodal-target' => 'create-partner-modal', class: 'btn btn-secondary btn-tiny pull-right' } %>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class='container'>
-  <div class='row triple-padding-top'>
-    <div class='col-md-12'>
+  <div class='row double-padding-top'>
+    <div class='row col-md-12'>
       <%= form_tag admin_partners_url, method: 'get' do %>
         <div class='form-group'>
           <div class='col-sm-10'>
@@ -40,3 +51,4 @@
   </div>
   <%= render 'shared/watt/paginator', total_items_count: partners.total_count, items_count: partners.length, per_page: @size, current_page: @page, base_url: admin_partners_url %>
 </div>
+<%= render 'create_partner' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,13 +6,14 @@ Rails.application.routes.draw do
         post :multiple, on: :collection
       end
     end
-    resources :partners, only: :index do
+    resources :partners, only: [:index, :create] do
       resources :submissions, only: :index, controller: 'partner_submissions'
     end
     root to: 'submissions#index'
   end
   get '/match_artist', to: 'admin/submissions#match_artist'
   get '/match_user', to: 'admin/submissions#match_user'
+  get '/match_partner', to: 'admin/partners#match_partner'
   get 'system/up'
 
   root to: redirect('/admin')

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,6 +67,7 @@ RSpec.configure do |config|
   config.before(:each) do
     Sidekiq::Worker.clear_all
     ActionMailer::Base.deliveries.clear
+    WebMock.disable_net_connect!(allow_localhost: true)
   end
 end
 

--- a/spec/views/admin/partners/create.html.erb_spec.rb
+++ b/spec/views/admin/partners/create.html.erb_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe 'partners create', type: :feature do
+  context 'always', js: true do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+      Fabricate(:partner, name: 'Gagosian Gallery')
+      Fabricate(:partner, name: 'Alan Cristea Gallery')
+      Fabricate(:partner, name: 'Rosier Gallery')
+      Fabricate(:partner, name: 'Auction House')
+
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      gravql_match_partners_response = {
+        data: {
+          match_partners: [
+            { id: 'partner1', given_name: 'Storefront' }
+          ]
+        }
+      }
+      stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
+        .to_return(body: gravql_match_partners_response.to_json)
+        .with(
+          headers: {
+            'X-XAPP-TOKEN' => 'xapp_token',
+            'Content-Type' => 'application/json'
+          }
+        )
+
+      page.visit '/admin/partners'
+    end
+
+    it 'allows you to create a partner' do
+      expect(Partner.count).to eq 4
+      click_link('Add Partner')
+      expect(page).to have_selector('#partner-selections-form #partner-search-submit.disabled-button') # button is disabled at first
+      fill_in('gravity_partner', with: 'store')
+      expect(page).to have_selector('.ui-menu-item a')
+      page.execute_script("$('.ui-menu-item:contains(\"Storefront\")').find('a').trigger('mouseenter').click()")
+      expect(page).to_not have_selector('#partner-selections-form #partner-search-submit.disabled-button')
+      click_button('Create Partner')
+      expect(page).to have_content('Partner successfully created.')
+      expect(Partner.count).to eq 5
+      expect(Partner.last.name).to eq 'Storefront'
+    end
+
+    it 'does not create a partner if the create partner button is not clicked' do
+      expect(Partner.count).to eq 4
+      click_link('Add Partner')
+      expect(page).to have_selector('#partner-selections-form #partner-search-submit.disabled-button') # button is disabled at first
+      fill_in('gravity_partner', with: 'store')
+      expect(page).to have_selector('.ui-menu-item a')
+      page.execute_script("$('.ui-menu-item:contains(\"Storefront\")').find('a').trigger('mouseenter').click()")
+      expect(page).to_not have_selector('#partner-selections-form #partner-search-submit.disabled-button')
+      find('#create-partner-close').trigger('click')
+      expect(page).to_not have_content('Partner successfully created.')
+      expect(Partner.count).to eq 4
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a UI for adding partners to convection. It uses the gravQL version of the match endpoint (https://github.com/artsy/gravity/pull/11445) for the autocomplete.

In order to create this UI, I used the remodal libraries available in watt. I'm not sure if there is a new/better way to do modals on the PE team, but this was pretty simple. (I don't want to introduce react for things like this, since they are still pretty easy to do with modals/minor javascript).

![convection-add-partner](https://user-images.githubusercontent.com/2081340/33774522-897cb764-dc09-11e7-91f5-b46ee2cfc62f.gif)

It also includes additional validations on the `gravity_partner_id` field on `Partner`.