### PR TITLE
@mzikherman => ability to delete a (draft) offer from the UI

### DIFF
--- a/app/controllers/admin/offers_controller.rb
+++ b/app/controllers/admin/offers_controller.rb
@@ -2,7 +2,7 @@ module Admin
   class OffersController < ApplicationController
     include GraphqlHelper
 
-    before_action :set_offer, only: [:show, :edit, :update]
+    before_action :set_offer, only: [:show, :edit, :update, :destroy]
     before_action :set_pagination_params, only: [:index]
 
     def new_step_0
@@ -36,6 +36,12 @@ module Admin
     end
 
     def edit; end
+
+    def destroy
+      @offer.destroy
+      flash[:success] = 'Offer deleted.'
+      redirect_to admin_submission_path(@offer.submission)
+    end
 
     def update
       OfferService.update_offer(@offer, offer_params)

--- a/app/views/admin/offers/show.html.erb
+++ b/app/views/admin/offers/show.html.erb
@@ -51,7 +51,14 @@
             <div class='col-sm-2'>
               <div class='row edit-container triple-padding-top'>
                 <% if @offer.state == 'draft' %>
-                  <%= link_to 'Edit', edit_admin_offer_path(@offer), class: 'btn btn-secondary btn-small btn-full-width' %>
+                  <div>
+                    <%= link_to 'Edit', edit_admin_offer_path(@offer), class: 'btn btn-secondary btn-small btn-full-width' %>
+                  </div>
+                  <div class='single-padding-top'>
+                    <%= link_to('Delete', admin_offer_path(@offer), method: :delete, class: 'btn btn-delete btn-small btn-full-width',
+                          id: 'offer-delete-button',
+                          data: { confirm: 'This action will delete the offer. This action cannot be undone.' }) %>
+                  </div>
                 <% end %>
               </div>
             </div>

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe 'admin/offers/show.html.erb', type: :feature do
+  context 'always' do
+    let(:submission) { Fabricate(:submission) }
+    let(:partner) { Fabricate(:partner) }
+    let(:partner_submission) { Fabricate(:partner_submission, submission: submission, partner: partner) }
+    let(:offer) { Fabricate(:offer, partner_submission: partner_submission, offer_type: 'purchase', state: 'draft') }
+
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+
+      stub_gravity_root
+      stub_gravity_user(id: submission.user_id)
+      stub_gravity_user_detail(id: submission.user_id)
+
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      gravql_artists_response = {
+        data: {
+          artists: [
+            { id: 'artist1', name: 'Andy Warhol' },
+            { id: 'artist2', name: 'Kara Walker' }
+          ]
+        }
+      }
+      stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
+        .to_return(body: gravql_artists_response.to_json)
+        .with(
+          headers: {
+            'X-XAPP-TOKEN' => 'xapp_token',
+            'Content-Type' => 'application/json'
+          }
+        )
+      page.visit "/admin/offers/#{offer.id}"
+    end
+
+    it 'displays the page title and content' do
+      expect(page).to have_content("Offer ##{offer.reference_id}")
+      expect(page).to have_content('Offer type purchase')
+    end
+
+    it 'lets you delete the offer' do
+      stub_gravity_artist(id: submission.artist_id)
+      expect(page).to have_selector('#offer-delete-button')
+      click_link('offer-delete-button')
+      expect(page.current_path).to eq("/admin/submissions/#{submission.id}")
+      expect(page).to have_content('Offer deleted')
+    end
+
+    it 'does not display the delete button if not in draft state' do
+      offer.update_attributes!(state: 'sent')
+      page.visit "/admin/offers/#{offer.id}"
+      expect(page).to_not have_selector('#offer-delete-button')
+    end
+  end
+end


### PR DESCRIPTION
Little PR to allow admins to delete offers that are in `draft` mode (i.e. haven't been sent to a user yet).

![convection-delete-offer](https://user-images.githubusercontent.com/2081340/34009823-5e7afdc2-e0d8-11e7-9bdd-8d46ef336665.gif)
