### PR TITLE
@ashkinas => ability to save and send an offer to a user

### DIFF
--- a/app/controllers/admin/offers_controller.rb
+++ b/app/controllers/admin/offers_controller.rb
@@ -44,7 +44,7 @@ module Admin
     end
 
     def update
-      OfferService.update_offer(@offer, offer_params)
+      OfferService.update_offer(@offer, @current_user, offer_params)
       redirect_to admin_offer_path(@offer)
     rescue OfferService::OfferError => e
       flash.now[:error] = e.message

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -79,4 +79,19 @@ class UserMailer < ApplicationMailer
     mail(to: user_detail.email,
          subject: 'An important update about your consignment submission')
   end
+
+  def offer(offer:, user:, user_detail:, artist:)
+    @offer = offer
+    @submission = offer.submission
+    @artist = artist
+    @user = user
+    @user_detail = user_detail
+    @utm_params = utm_params(source: 'consignment-offer', campaign: 'consignment-offer')
+
+    smtpapi category: ['offer'], unique_args: {
+      offer_id: offer.id
+    }
+    mail(to: user_detail.email,
+         subject: 'An important update about your consignment submission')
+  end
 end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -2,9 +2,10 @@ class OfferService
   class OfferError < StandardError; end
 
   class << self
-    def update_offer(offer, params)
-      offer.update_attributes!(params)
-      offer
+    def update_offer(offer, current_user = nil, params = {})
+      offer.assign_attributes(params)
+      update_offer_state(offer, current_user) if offer.state_changed?
+      offer.save!
     rescue ActiveRecord::RecordInvalid => e
       raise OfferError, e.message
     end
@@ -18,6 +19,36 @@ class OfferService
       offer
     rescue ActiveRecord::RecordNotFound => e
       raise OfferError, e.message
+    end
+
+    def update_offer_state(offer, current_user)
+      case offer.state
+      when 'sent' then send_offer!(offer, current_user)
+      end
+    end
+
+    def send_offer!(offer, current_user)
+      delay.deliver_offer(offer.id, current_user)
+    end
+
+    def deliver_offer(offer_id, current_user)
+      offer = Offer.find(offer_id)
+      return if offer.sent_at
+
+      user = Gravity.client.user(id: offer.submission.user_id)._get
+      user_detail = user.user_detail._get
+      raise 'User lacks email.' if user_detail.email.blank?
+
+      artist = Gravity.client.artist(id: offer.submission.artist_id)._get
+
+      UserMailer.offer(
+        offer: offer,
+        user: user,
+        user_detail: user_detail,
+        artist: artist
+      ).deliver_now
+
+      offer.update_attributes!(sent_at: Time.now.utc, sent_by: current_user)
     end
   end
 end

--- a/app/views/admin/offers/show.html.erb
+++ b/app/views/admin/offers/show.html.erb
@@ -52,6 +52,9 @@
               <div class='row edit-container triple-padding-top'>
                 <% if @offer.state == 'draft' %>
                   <div>
+                    <%= link_to 'Save & Send', admin_offer_path(@offer, offer: { state: 'sent' }), method: :put, class: 'btn btn-secondary btn-small btn-full-width', data: { confirm: 'This action will send the offer to the collector. This action cannot be undone.' } %>
+                  </div>
+                  <div class='single-padding-top'>
                     <%= link_to 'Edit', edit_admin_offer_path(@offer), class: 'btn btn-secondary btn-small btn-full-width' %>
                   </div>
                   <div class='single-padding-top'>

--- a/app/views/user_mailer/offer.html.erb
+++ b/app/views/user_mailer/offer.html.erb
@@ -1,0 +1,30 @@
+<%= stylesheet_link_tag 'emails', media: 'all' %>
+
+<table class='padded-email'>
+  <tr>
+    <td>
+      <table class='email-content' align='left'>
+        <tr>
+          <td>
+            <%= render 'shared/email_header' %>
+          </td>
+        </tr>
+        <tr>
+          <td class='email-title'>
+            <%= @offer.partner_submission.partner.name %> has sent you an offer
+          </td>
+        </tr>
+        <tr>
+          <td class='email-sub-title'>
+            #<%= @offer.reference_id %>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= render 'shared/submission_block', submission: @submission %>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/db/migrate/20171214192939_add_offer_sent_at.rb
+++ b/db/migrate/20171214192939_add_offer_sent_at.rb
@@ -1,0 +1,6 @@
+class AddOfferSentAt < ActiveRecord::Migration[5.0]
+  def change
+    add_column :offers, :sent_at, :datetime
+    add_column :offers, :sent_by, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212160509) do
+ActiveRecord::Schema.define(version: 20171214192939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 20171212160509) do
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
     t.integer  "submission_id"
+    t.datetime "sent_at"
+    t.string   "sent_by"
     t.index ["partner_submission_id"], name: "index_offers_on_partner_submission_id", using: :btree
     t.index ["reference_id"], name: "index_offers_on_reference_id", using: :btree
     t.index ["submission_id"], name: "index_offers_on_submission_id", using: :btree

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/gravity_helper'
 
 describe OfferService do
   let(:submission) { Fabricate(:submission, state: 'approved') }
@@ -64,7 +65,7 @@ describe OfferService do
         high_estimate_cents: 20_000,
         commission_percent: 10,
         offer_type: 'auction consignment')
-      OfferService.update_offer(offer, high_estimate_cents: 30_000, notes: 'New offer notes!')
+      OfferService.update_offer(offer, 'userid', high_estimate_cents: 30_000, notes: 'New offer notes!')
       expect(offer.reload.high_estimate_cents).to eq 30_000
       expect(offer.reload.notes).to eq 'New offer notes!'
     end
@@ -76,8 +77,55 @@ describe OfferService do
         commission_percent: 10,
         offer_type: 'auction consignment')
       expect do
-        OfferService.update_offer(offer, offer_type: 'non-valid-type')
+        OfferService.update_offer(offer, 'userid', offer_type: 'non-valid-type')
       end.to raise_error(OfferService::OfferError)
+    end
+  end
+
+  context 'sending an offer' do
+    let(:partner) { Fabricate(:partner, name: 'Happy Gallery') }
+    let(:submission) { Fabricate(:submission) }
+    let(:partner_submission) { Fabricate(:partner_submission, partner: partner, submission: submission) }
+    let(:offer) { Fabricate(:offer, offer_type: 'purchase', price_cents: 10_000, state: 'draft', partner_submission: partner_submission) }
+
+    before do
+      stub_gravity_root
+      stub_gravity_user(id: offer.submission.user_id)
+      stub_gravity_user_detail(email: 'michael@bluth.com', id: offer.submission.user_id)
+      stub_gravity_artist(id: submission.artist_id)
+    end
+
+    it 'sends an email to a user with offer information' do
+      OfferService.update_offer(offer, 'userid', state: 'sent')
+      emails = ActionMailer::Base.deliveries
+      expect(emails.length).to eq 1
+      expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
+      expect(emails.first.to).to eq(['michael@bluth.com'])
+      expect(emails.first.html_part.body).to include(
+        'Happy Gallery has sent you an offer'
+      )
+      expect(offer.reload.state).to eq 'sent'
+      expect(offer.sent_by).to eq 'userid'
+      expect(offer.sent_at).to_not be_nil
+    end
+
+    it 'does not send an email if the email has already been sent' do
+      offer.update_attributes!(sent_at: Time.now.utc)
+      OfferService.update_offer(offer, 'userid', state: 'sent')
+      emails = ActionMailer::Base.deliveries
+      expect(emails.length).to eq 0
+    end
+
+    it 'does nothing if the state has not been changed' do
+      OfferService.update_offer(offer, 'userid', price_cents: 20_000)
+      emails = ActionMailer::Base.deliveries
+      expect(emails.length).to eq 0
+    end
+
+    it 'raises an exception if the offer cannot be found' do
+      expect do
+        OfferService.deliver_offer('foo', nil)
+      end.to raise_error("Couldn't find Offer with 'id'=foo")
     end
   end
 end

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -53,5 +53,28 @@ describe 'admin/offers/show.html.erb', type: :feature do
       page.visit "/admin/offers/#{offer.id}"
       expect(page).to_not have_selector('#offer-delete-button')
     end
+
+    describe 'save & send' do
+      it 'shows the save & send button when offer is in draft state' do
+        offer.update_attributes!(state: 'draft')
+        page.visit "/admin/offers/#{offer.id}"
+        expect(page).to have_content('Save & Send')
+      end
+
+      it 'does not show the save & send button after the offer has been sent' do
+        offer.update_attributes!(state: 'sent')
+        page.visit "/admin/offers/#{offer.id}"
+        expect(page).to_not have_content('Save & Send')
+      end
+
+      it 'allows you to save the offer' do
+        stub_gravity_artist(id: submission.artist_id)
+        offer.update_attributes!(state: 'draft')
+        page.visit "/admin/offers/#{offer.id}"
+        click_link('Save & Send')
+        expect(page).to have_content("Offer ##{offer.reference_id} (sent)")
+        expect(page).to_not have_content('Save & Send')
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds a button to the offer view that allows an admin to send the offer to users. Doing so moves the offer out of the _draft_ state and into the _sent_ state. It also sends an email to users with the offer information.

Once the offer has been sent, it can no longer be edited or deleted.

![convection-save-offer](https://user-images.githubusercontent.com/2081340/34050337-7aaa5960-e188-11e7-8ea2-9d2165bc0592.gif)
