### PR TITLE
@joeyAghion => adds the ability for an admin to accept or reject an offer

### DIFF
--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -122,3 +122,9 @@ input[type="submit"].disabled-button {
 .section-title {
   font-size: 24px;
 }
+
+.offers_show {
+  .overview-section {
+    margin-right: 0px !important;
+  }
+}

--- a/app/controllers/admin/offers_controller.rb
+++ b/app/controllers/admin/offers_controller.rb
@@ -72,6 +72,8 @@ module Admin
         :other_fees_percent,
         :photography_cents,
         :price_cents,
+        :rejection_reason,
+        :rejection_note,
         :sale_date,
         :sale_name,
         :sale_period_end,

--- a/app/helpers/offers_helper.rb
+++ b/app/helpers/offers_helper.rb
@@ -1,0 +1,14 @@
+module OffersHelper
+  def reviewed_byline(offer)
+    if offer.accepted?
+      "Accepted by #{offer.recorded_by_user.try(:name)}."
+    elsif offer.rejected?
+      [
+        "Rejected by #{offer.recorded_by_user.try(:name)}. #{offer.rejection_reason}",
+        offer.rejection_note
+      ].compact.reject(&:blank?).join(': ').strip
+    elsif offer.lapsed?
+      'Offer lapsed.'
+    end
+  end
+end

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -18,4 +18,30 @@ class PartnerMailer < ApplicationMailer
       format.html { render layout: 'mailer_no_footer' }
     end
   end
+
+  def offer_acceptance_notification(offer:, artist:)
+    @offer = offer
+    @submission = offer.submission
+    @artist = artist
+    @utm_params = utm_params(source: 'consignment-offer-accepted', campaign: 'consignment-offer')
+
+    smtpapi category: ['offer'], unique_args: {
+      offer_id: offer.id
+    }
+    mail(to: Convection.config.debug_email_address,
+         subject: 'An important update about your consignment offer')
+  end
+
+  def offer_rejection_notification(offer:, artist:)
+    @offer = offer
+    @submission = offer.submission
+    @artist = artist
+    @utm_params = utm_params(source: 'consignment-offer-rejected', campaign: 'consignment-offer')
+
+    smtpapi category: ['offer'], unique_args: {
+      offer_id: offer.id
+    }
+    mail(to: Convection.config.debug_email_address,
+         subject: 'An important update about your consignment offer')
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -80,18 +80,16 @@ class UserMailer < ApplicationMailer
          subject: 'An important update about your consignment submission')
   end
 
-  def offer(offer:, user:, user_detail:, artist:)
+  def offer(offer:, artist:)
     @offer = offer
     @submission = offer.submission
     @artist = artist
-    @user = user
-    @user_detail = user_detail
     @utm_params = utm_params(source: 'consignment-offer', campaign: 'consignment-offer')
 
     smtpapi category: ['offer'], unique_args: {
       offer_id: offer.id
     }
-    mail(to: user_detail.email,
+    mail(to: Convection.config.debug_email_address,
          subject: 'An important update about your consignment submission')
   end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -8,6 +8,9 @@ class Offer < ApplicationRecord
   STATES = %w(
     draft
     sent
+    accepted
+    rejected
+    lapsed
   ).freeze
 
   CURRENCIES = %w(
@@ -16,12 +19,22 @@ class Offer < ApplicationRecord
     GBP
   ).freeze
 
+  REJECTION_REASONS = [
+    'Low estimate',
+    'High commission',
+    'High shipping/marketing costs',
+    'Took competing offer',
+    'Lost interest',
+    'Other'
+  ].freeze
+
   belongs_to :partner_submission
   belongs_to :submission
 
   validates :state, inclusion: { in: STATES }
   validates :offer_type, inclusion: { in: OFFER_TYPES }, allow_nil: true
   validates :currency, inclusion: { in: CURRENCIES }, allow_nil: true
+  validates :rejection_reason, inclusion: { in: REJECTION_REASONS }, allow_nil: true
 
   before_validation :set_state, on: :create
   before_create :create_reference_id
@@ -29,6 +42,20 @@ class Offer < ApplicationRecord
 
   def set_state
     self.state ||= 'draft'
+  end
+
+  # defines methods sent?, accepted?, etc. for each possible offer state
+  STATES.each do |method|
+    define_method "#{method}?".to_sym do
+      state == method
+    end
+  end
+
+  def recorded_by_user
+    admin_user_id = accepted_by || rejected_by
+    Gravity.client.user(id: admin_user_id)._get if admin_user_id
+  rescue Faraday::ResourceNotFound
+    nil
   end
 
   def create_reference_id

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -24,6 +24,8 @@ class OfferService
     def update_offer_state(offer, current_user)
       case offer.state
       when 'sent' then send_offer!(offer, current_user)
+      when 'accepted' then accept!(offer, current_user)
+      when 'rejected' then reject!(offer, current_user)
       end
     end
 
@@ -31,20 +33,46 @@ class OfferService
       delay.deliver_offer(offer.id, current_user)
     end
 
+    def accept!(offer, current_user)
+      offer.update_attributes!(accepted_by: current_user, accepted_at: Time.now.utc)
+      delay.deliver_acceptance_notification(offer.id)
+    end
+
+    def reject!(offer, current_user)
+      offer.update_attributes!(rejected_by: current_user, rejected_at: Time.now.utc)
+      delay.deliver_rejection_notification(offer.id)
+    end
+
+    private
+
+    def deliver_acceptance_notification(offer_id)
+      offer = Offer.find(offer_id)
+      artist = Gravity.client.artist(id: offer.submission.artist_id)._get
+
+      PartnerMailer.offer_acceptance_notification(
+        offer: offer,
+        artist: artist
+      ).deliver_now
+    end
+
+    def deliver_rejection_notification(offer_id)
+      offer = Offer.find(offer_id)
+      artist = Gravity.client.artist(id: offer.submission.artist_id)._get
+
+      PartnerMailer.offer_rejection_notification(
+        offer: offer,
+        artist: artist
+      ).deliver_now
+    end
+
     def deliver_offer(offer_id, current_user)
       offer = Offer.find(offer_id)
       return if offer.sent_at
-
-      user = Gravity.client.user(id: offer.submission.user_id)._get
-      user_detail = user.user_detail._get
-      raise 'User lacks email.' if user_detail.email.blank?
 
       artist = Gravity.client.artist(id: offer.submission.artist_id)._get
 
       UserMailer.offer(
         offer: offer,
-        user: user,
-        user_detail: user_detail,
         artist: artist
       ).deliver_now
 

--- a/app/views/admin/offers/_reject_offer.html.erb
+++ b/app/views/admin/offers/_reject_offer.html.erb
@@ -1,0 +1,39 @@
+<div class='modal remodal' data-remodal-id='reject-offer-modal'>
+  <div class='modal-header'>
+    <h3>
+      Please select rejection reason
+    </h3>
+  </div>
+  <div class='modal-close'>
+    <%= link_to '', '#', id: 'reject-offer-close'%>
+  </div>
+  <div class='modal-content'>
+    <div class='single-padding-top'>
+      <div class='col-sm-12'>
+        <%= form_for(@offer, url: admin_offer_path, method: :put) do |f| %>
+          <%= f.hidden_field :state, value: 'rejected' %>
+          <div class='row'>
+            <div class='col-md-12'>
+              <% Offer::REJECTION_REASONS.each do |rejection_reason| %>
+                <div class='offer-type-radio'>
+                  <%= f.radio_button :rejection_reason, rejection_reason, checked: (rejection_reason == @offer.rejection_reason || rejection_reason == Offer::REJECTION_REASONS.first), class: 'form-control' %>
+                  <%= f.label :rejection_reason, rejection_reason, value: rejection_reason, class: 'control-label' %>
+                </div>
+              <% end %>
+              <div class='row single-padding-top'>
+                <div class='col-sm-12'>
+                  <%= f.text_area :rejection_note, placeholder: 'Fill out reason', class: 'form-control' %>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class='row triple-padding-top'>
+            <div class='col-md-12'>
+              <%= f.submit 'Save and Send', class: 'btn btn-primary btn-full-width' %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/offers/new_step_0.html.erb
+++ b/app/views/admin/offers/new_step_0.html.erb
@@ -24,7 +24,7 @@
                     <% Offer::OFFER_TYPES.each do |offer_type| %>
                       <div class='offer-type-radio'>
                         <%= radio_button_tag :offer_type, offer_type, (offer_type == @offer.offer_type || offer_type == Offer::OFFER_TYPES.first), { class: 'form-control' } %>
-                        <%= label_tag :offer_type, offer_type, value: offer_type, class: 'control-label', for: offer_type %>
+                        <%= label_tag :offer_type, offer_type, for: "offer_type_#{offer_type.parameterize.underscore}", class: 'control-label' %>
                       </div>
                     <% end %>
                   </div>

--- a/app/views/admin/offers/show.html.erb
+++ b/app/views/admin/offers/show.html.erb
@@ -9,7 +9,7 @@
       <div class='row'>
         <div class='col-sm-12'>
           <div class='row'>
-            <div class='col-sm-10'>
+            <div class='col-sm-9'>
               <div class='row'>
                 <div class='triple-padding-top'>
                   <div class='watt-overview'>
@@ -48,7 +48,7 @@
                 </div>
               </div>
             </div>
-            <div class='col-sm-2'>
+            <div class='col-sm-3'>
               <div class='row edit-container triple-padding-top'>
                 <% if @offer.state == 'draft' %>
                   <div>
@@ -61,6 +61,18 @@
                     <%= link_to('Delete', admin_offer_path(@offer), method: :delete, class: 'btn btn-delete btn-small btn-full-width',
                           id: 'offer-delete-button',
                           data: { confirm: 'This action will delete the offer. This action cannot be undone.' }) %>
+                  </div>
+                <% elsif @offer.state == 'sent' %>
+                  <div>
+                    <%= link_to 'Reject Offer', '#', { 'data-remodal-target' => 'reject-offer-modal', class: 'btn btn-small btn-delete btn-full-width' } %>
+                  </div>
+                  <div class='single-padding-top'>
+                    <%= link_to('Accept Offer', admin_offer_path(@offer, offer: { state: 'accepted' }), method: :put, class: 'btn btn-secondary btn-small btn-full-width',
+                          data: { confirm: 'This action will accept the offer and email the partner whose offer has been accepted. This action cannot be undone.' }) %>
+                  </div>
+                  <div class='single-padding-top'>
+                    <%= link_to('Offer Lapsed', admin_offer_path(@offer, offer: { state: 'lapsed' }), method: :put, class: 'btn btn-secondary btn-small btn-full-width',
+                          data: { confirm: 'This action will mark the consignment as lapsed. This action cannot be undone.' }) %>
                   </div>
                 <% end %>
               </div>
@@ -91,6 +103,18 @@
       <div class='double-padding-top'>
         <%= render 'admin/submissions/collector_info', submission: @offer.submission %>
       </div>
+
+      <div class='double-padding-top'>
+        <div class='bold-label'>
+          Internal Approval
+        </div>
+        <div class='single-padding-top'>
+          <div>
+            <%= reviewed_byline(@offer) %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
+<%= render 'reject_offer' %>

--- a/app/views/partner_mailer/offer_acceptance_notification.html.erb
+++ b/app/views/partner_mailer/offer_acceptance_notification.html.erb
@@ -1,0 +1,30 @@
+<%= stylesheet_link_tag 'emails', media: 'all' %>
+
+<table class='padded-email'>
+  <tr>
+    <td>
+      <table class='email-content' align='left'>
+        <tr>
+          <td>
+            <%= render 'shared/email_header' %>
+          </td>
+        </tr>
+        <tr>
+          <td class='email-title'>
+            Your offer has been accepted
+          </td>
+        </tr>
+        <tr>
+          <td class='email-sub-title'>
+            Next steps:<br/>We will connect you directly with the collector to complete this transaction.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= render 'shared/submission_block', submission: @submission %>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/app/views/partner_mailer/offer_rejection_notification.html.erb
+++ b/app/views/partner_mailer/offer_rejection_notification.html.erb
@@ -1,0 +1,26 @@
+<%= stylesheet_link_tag 'emails', media: 'all' %>
+
+<table class='padded-email'>
+  <tr>
+    <td>
+      <table class='email-content' align='left'>
+        <tr>
+          <td>
+            <%= render 'shared/email_header' %>
+          </td>
+        </tr>
+        <tr>
+          <td class='email-sub-title'>
+            <p>The collector has rejected your offer. Sorry.</p>
+            <p>Sincerely,<br />The Consignments Team</p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= render 'shared/submission_block', submission: @submission %>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/db/migrate/20171218214858_add_reject_accept_fields.rb
+++ b/db/migrate/20171218214858_add_reject_accept_fields.rb
@@ -1,0 +1,11 @@
+class AddRejectAcceptFields < ActiveRecord::Migration[5.0]
+  def change
+    add_column :offers, :rejection_reason, :string
+    add_column :offers, :rejection_note, :text
+    add_column :offers, :rejected_by, :string
+    add_column :offers, :rejected_at, :datetime
+
+    add_column :offers, :accepted_by, :string
+    add_column :offers, :accepted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171214192939) do
+ActiveRecord::Schema.define(version: 20171218214858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,12 @@ ActiveRecord::Schema.define(version: 20171214192939) do
     t.integer  "submission_id"
     t.datetime "sent_at"
     t.string   "sent_by"
+    t.string   "rejection_reason"
+    t.text     "rejection_note"
+    t.string   "rejected_by"
+    t.datetime "rejected_at"
+    t.string   "accepted_by"
+    t.datetime "accepted_at"
     t.index ["partner_submission_id"], name: "index_offers_on_partner_submission_id", using: :btree
     t.index ["reference_id"], name: "index_offers_on_reference_id", using: :btree
     t.index ["submission_id"], name: "index_offers_on_submission_id", using: :btree

--- a/spec/fabricators/partner_fabricator.rb
+++ b/spec/fabricators/partner_fabricator.rb
@@ -1,4 +1,4 @@
 Fabricator(:partner) do
   gravity_partner_id { Fabricate.sequence(:gravity_partner_id) { |i| "partner-id-#{i}" } }
-  name { Fabricate.sequence(:name) { |i| "Galler #{i}" } }
+  name { Fabricate.sequence(:name) { |i| "Gallery #{i}" } }
 end

--- a/spec/helpers/offers_helper_spec.rb
+++ b/spec/helpers/offers_helper_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe OffersHelper, type: :helper do
+  context 'reviewed_byline' do
+    before do
+      stub_gravity_root
+      stub_gravity_user
+    end
+
+    it 'shows the correct label for an accepted offer' do
+      offer = Fabricate(:offer, state: 'accepted', accepted_by: 'userid')
+      expect(helper.reviewed_byline(offer)).to eq 'Accepted by Jon Jonson.'
+    end
+
+    it 'shows the correct label for a rejected offer' do
+      offer = Fabricate(:offer, state: 'rejected', rejected_by: 'userid')
+      expect(helper.reviewed_byline(offer)).to eq 'Rejected by Jon Jonson.'
+    end
+
+    it 'shows the correct label for a rejected offer with a rejection_reason' do
+      offer = Fabricate(:offer, state: 'rejected', rejected_by: 'userid', rejection_reason: 'Low estimate')
+      expect(helper.reviewed_byline(offer)).to eq 'Rejected by Jon Jonson. Low estimate'
+    end
+
+    it 'shows the correct label for a rejected offer with a rejection_reason and rejection_note' do
+      offer = Fabricate(:offer,
+        state: 'rejected',
+        rejected_by: 'userid',
+        rejection_reason: 'Other',
+        rejection_note: 'User not a fan of this partner.')
+      expect(helper.reviewed_byline(offer)).to eq 'Rejected by Jon Jonson. Other: User not a fan of this partner.'
+    end
+
+    it 'shows the correct label for an accepted offer with no user' do
+      offer = Fabricate(:offer, state: 'accepted')
+      expect(helper.reviewed_byline(offer)).to eq 'Accepted by .'
+    end
+
+    it 'shows the correct label for a rejected offer with no user' do
+      offer = Fabricate(:offer, state: 'rejected')
+      expect(helper.reviewed_byline(offer)).to eq 'Rejected by .'
+    end
+  end
+end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -45,4 +45,12 @@ describe Offer do
       expect(offer.submission).to eq offer.partner_submission.submission
     end
   end
+
+  context 'rejection_reason' do
+    it 'allows only certain rejection reasons' do
+      expect(Offer.new(rejection_reason: 'blah')).not_to be_valid
+      expect(Offer.new(rejection_reason: 'Other')).to be_valid
+      expect(Offer.new(rejection_reason: 'Low estimate')).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Before we have a UI for users to input their own response to an offer, admins will need to enter these outcomes in convection.

This PR allows admins to mark an offer as **accepted**, **rejected** (with reason), or **lapsed**. An open question is whether or not admins should be able to _go back_ on what they'd selected (i.e. can an offer be accepted and then later rejected?). Since choosing an option causes a notification to go out to the partner, I thought we should keep it as "binding" for now (the UI does not allow you to change) and will revisit when @katarinabatina is back.

Included in this PR:
- Buttons on the `offer` page that let you choose the new status
- New fields on `Offer` to keep track of rejections/acceptances
- Two dummy emails-- one for an accepted offer and one for a rejected offer. (as far as I know, when an offer lapses we just like to keep track but don't send any notifications. Could always change).

![reject-submission](https://user-images.githubusercontent.com/2081340/34171886-05497834-e4be-11e7-97eb-1894a055cbb9.gif)
