### PR TITLE
@joeyAghion => adds the ability to create an offer from scratch

### DIFF
--- a/app/assets/javascripts/new_offer.js.coffee
+++ b/app/assets/javascripts/new_offer.js.coffee
@@ -1,26 +1,58 @@
 $ ->
 
   # Choose a partner to associate with an offer
-  formatPartner = (partner) ->
-    partner.name
+  if $('#new-offer-partner').length != 0
+    formatPartner = (partner) ->
+      partner.name
 
-  $('#new-offer-partner').select2(
-    ajax: {
-      url: '/admin/partners',
-      dataType: 'json',
-      data: (params) ->
-        term: params.term
-      processResults: (data, params) ->
-        results: data
-    },
-    allowClear: true,
-    placeholder: 'Select a partner',
-    minimumInputLength: 1,
-    width: 'element',
-    templateResult: formatPartner,
-    templateSelection: formatPartner
-  ).on('select2:select', (event) ->
-    $( '#partner_id' ).val( event.params.data.id )
-  ).on('select2:unselect', () ->
-    $( '#partner_id' ).val('')
-  ).val($('#partner_id').val()).trigger('change')
+    $('#new-offer-partner').select2(
+      ajax: {
+        url: '/admin/partners',
+        dataType: 'json',
+        data: (params) ->
+          term: params.term
+        processResults: (data, params) ->
+          results: data
+      },
+      allowClear: true,
+      placeholder: 'Select a partner',
+      minimumInputLength: 1,
+      width: 'element',
+      templateResult: formatPartner,
+      templateSelection: formatPartner
+    ).on('select2:select', (event) ->
+      $( '#partner_id' ).val( event.params.data.id )
+    ).on('select2:unselect', () ->
+      $( '#partner_id' ).val('')
+    ).val($('#partner_id').val()).trigger('change')
+
+  # Choose the submission to create an offer for
+  if $('#new-offer-submission').length != 0
+    formatSubmission = (submission) ->
+      if submission?.id != undefined && submission?.id?.length != 0
+        text = "##{submission.id} <b>#{submission.title}</b> (#{submission.state})"
+        submission = "<div class='new-offer-submission-thumbnail'><span><img src=#{submission.thumbnail}></img></span><span>#{text}</span></div>"
+        $(submission)
+      else
+        ''
+
+    $('#new-offer-submission').select2(
+      ajax: {
+        url: '/admin/submissions',
+        dataType: 'json',
+        data: (params) ->
+          term: params.term
+        processResults: (data, params) ->
+          results: data
+      },
+      allowClear: true,
+      placeholder: 'Select a submission',
+      minimumInputLength: 1,
+      width: 'element',
+      templateResult: formatSubmission,
+      templateSelection: formatSubmission
+    ).on('select2:select', (event) ->
+      $( '#submission_id' ).val( event.params.data.id )
+    ).on('select2:unselect', () ->
+      $( '#submission_id' ).val('')
+    ).val($('#submission_id').val()).trigger('change')

--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -128,3 +128,29 @@ input[type="submit"].disabled-button {
     margin-right: 0px !important;
   }
 }
+
+.submission-select {
+  .select2-selection {
+    height: auto !important;
+    min-height: 28px;
+  }
+}
+
+.select2-selection__rendered {
+  .new-offer-submission-thumbnail {
+    float: left;
+  }
+}
+
+.new-offer-submission-thumbnail {
+  span {
+    padding-right: 20px;
+  }
+
+  img {
+    padding-top: 5px;
+    padding-bottom: 5px;
+    max-width: 40px;
+    max-height: 40px;
+  }
+}

--- a/app/controllers/admin/offers_controller.rb
+++ b/app/controllers/admin/offers_controller.rb
@@ -22,6 +22,14 @@ module Admin
       Offer.count
     end
 
+    expose(:partner) do
+      Partner.find(params[:partner_id]) if params[:partner_id].present?
+    end
+
+    expose(:submission) do
+      Submission.find(params[:submission_id]) if params[:submission_id].present?
+    end
+
     def new_step_0
       @offer = Offer.new
       @submission = Submission.find(params[:submission_id]) if params[:submission_id]
@@ -31,8 +39,6 @@ module Admin
       @offer = Offer.new(offer_type: params[:offer_type])
 
       if params[:submission_id].present? && params[:partner_id].present? && params[:offer_type].present?
-        @submission = Submission.find(params[:submission_id])
-        @partner = Partner.find(params[:partner_id])
         render 'new_step_1'
       else
         flash.now[:error] = 'Offer requires type, submission, and partner.'

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -14,6 +14,14 @@ module Admin
       @submissions = @submissions.search(params[:term]) if params[:term]
       @submissions = @submissions.order(id: :desc).page(@page).per(@size)
       @artist_details = artists_query(@submissions.map(&:artist_id))
+
+      respond_to do |format|
+        format.html
+        format.json do
+          submissions_with_thumbnails = @submissions.map { |submission| submission.as_json.merge(thumbnail: submission.thumbnail) }
+          render json: submissions_with_thumbnails || []
+        end
+      end
     end
 
     def new

--- a/app/views/admin/offers/index.html.erb
+++ b/app/views/admin/offers/index.html.erb
@@ -25,6 +25,9 @@
         <div class='left'><%= link_to 'Rejected', admin_offers_path(state: 'rejected') %></div>
         <div class='right'><%= counts['rejected'] || 0 %></div>
       </div>
+      <div class='row double-padding-top'>
+        <%= link_to 'New', new_step_0_admin_offers_path, class: 'btn btn-tiny btn-full-width' %>
+      </div>
     </div>
     <div class='col-md-10'>
       <div class='list-group'>

--- a/app/views/admin/offers/new_step_0.html.erb
+++ b/app/views/admin/offers/new_step_0.html.erb
@@ -36,13 +36,13 @@
                   <label class='col-sm-3 control-label'>
                     Submission
                   </label>
-                  <div class='col-sm-9'>
-                    <% if @submission.present? %>
-                      #<%= @submission.id %>
+                  <div class='col-sm-9 submission-select'>
+                    <% if submission.present? %>
+                      #<%= submission.id %>
                     <% else %>
-                      <%= select_tag :submission, raw("<option selected value=#{@submission&.id}></option>"), class: 'form-control', id: 'new-offer-submission' %>
+                      <%= select_tag :submission, '', class: 'form-control', id: 'new-offer-submission' %>
                     <% end %>
-                    <%= hidden_field_tag :submission_id, @submission&.id %>
+                    <%= hidden_field_tag :submission_id, submission&.id %>
                   </div>
                 </div>
               </div>
@@ -53,8 +53,12 @@
                     Partner
                   </label>
                   <div class='col-sm-9'>
-                    <%= select_tag :partner, '', class: 'form-control', id: 'new-offer-partner' %>
-                    <%= hidden_field_tag :partner_id %>
+                    <% if partner.present? %>
+                      <%= partner.name %>
+                    <% else %>
+                      <%= select_tag :partner, '', class: 'form-control', id: 'new-offer-partner' %>
+                    <% end %>
+                    <%= hidden_field_tag :partner_id, partner&.id %>
                   </div>
                 </div>
               </div>
@@ -71,4 +75,3 @@
     </div>
   <% end %>
 </div>
-

--- a/app/views/admin/offers/new_step_1.html.erb
+++ b/app/views/admin/offers/new_step_1.html.erb
@@ -1,14 +1,14 @@
 <div class='page-title'>
   <h2>New Offer</h2>
   <p class='single-padding-top'>
-    <%= @offer.offer_type.capitalize %> offer for Submission #<%= @submission.id %> by <%= @partner.name %>
+    <%= @offer.offer_type.capitalize %> offer for Submission #<%= submission.id %> by <%= partner.name %>
   </p>
 </div>
 
 <div class='container'>
   <%= form_for(@offer, url: admin_offers_path, method: :post) do |f| %>
-    <%= hidden_field_tag :submission_id, @submission.id %>
-    <%= hidden_field_tag :partner_id, @partner.id %>
+    <%= hidden_field_tag :submission_id, submission.id %>
+    <%= hidden_field_tag :partner_id, partner.id %>
     <%= hidden_field_tag 'offer[offer_type]', @offer.offer_type %>
     <div class='row'>
       <div class='col-md-12'>

--- a/spec/controllers/admin/submissions_controller_spec.rb
+++ b/spec/controllers/admin/submissions_controller_spec.rb
@@ -22,22 +22,59 @@ describe Admin::SubmissionsController, type: :controller do
           }
         )
     end
-    context 'filtering the index view' do
+
+    context 'with many submissions' do
       before do
-        5.times { Fabricate(:submission, state: 'submitted') }
+        @submission1 = Fabricate(:submission, state: 'submitted', title: 'hi hi')
+        @submission2 = Fabricate(:submission, state: 'submitted', title: 'my artwork')
+        @submission3 = Fabricate(:submission, state: 'submitted', title: 'another artwork')
+        Fabricate(:submission, state: 'submitted', title: 'zzz')
+        Fabricate(:submission, state: 'submitted', title: 'aaa')
       end
-      it 'returns the first two submissions on the first page' do
-        get :index, params: { page: 1, size: 2 }
-        expect(assigns(:submissions).count).to eq 2
+
+      describe 'filtering the index view' do
+        it 'returns the first two submissions on the first page' do
+          get :index, params: { page: 1, size: 2 }
+          expect(assigns(:submissions).count).to eq 2
+        end
+        it 'paginates correctly' do
+          get :index, params: { page: 3, size: 2 }
+          expect(assigns(:submissions).count).to eq 1
+        end
+        it 'sets the artist details correctly' do
+          get :index
+          expect(assigns(:artist_details)).to eq('artist1' => 'Andy Warhol',
+                                                 'artist2' => 'Kara Walker')
+        end
       end
-      it 'paginates correctly' do
-        get :index, params: { page: 3, size: 2 }
-        expect(assigns(:submissions).count).to eq 1
-      end
-      it 'sets the artist details correctly' do
-        get :index
-        expect(assigns(:artist_details)).to eq('artist1' => 'Andy Warhol',
-                                               'artist2' => 'Kara Walker')
+
+      describe 'matching on the index' do
+        it 'returns the submissions that match as json' do
+          get :index, format: 'json', params: { term: 'hi' }
+          submissions = JSON.parse(response.body)
+          expect(submissions.length).to eq 1
+          expect(submissions.first['id']).to eq @submission1.id
+          expect(submissions.first['thumbnail']).to eq nil
+        end
+
+        it 'returns multiple submissions that match' do
+          get :index, format: 'json', params: { term: 'art' }
+          submissions = JSON.parse(response.body)
+          expect(submissions.length).to eq 2
+          expect(submissions.map { |sub| sub['id'] }).to eq [@submission2.id, @submission3.id]
+        end
+
+        it 'merges in the thumbnail url' do
+          Fabricate(:image,
+            submission: @submission1,
+            image_urls: { square: 'https://square.jpg', thumbnail: 'https://thumbnail-1.jpg' })
+
+          get :index, format: 'json', params: { term: 'hi' }
+          submissions = JSON.parse(response.body)
+          expect(submissions.length).to eq 1
+          expect(submissions.first['id']).to eq @submission1.id
+          expect(submissions.first['thumbnail']).to eq 'https://thumbnail-1.jpg'
+        end
       end
     end
   end

--- a/spec/views/admin/offers/new_step_0.html.erb_spec.rb
+++ b/spec/views/admin/offers/new_step_0.html.erb_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 describe 'admin/offers/new_step_0.html.erb', type: :feature do
-  context 'with a submission' do
-    let(:submission) { Fabricate(:submission) }
-    let(:partner) { Fabricate(:partner, name: 'First Partner') }
-    let(:partner) { Fabricate(:partner, name: 'Second Partner') }
+  let(:submission) { Fabricate(:submission) }
+  let(:partner) { Fabricate(:partner, name: 'First Partner') }
+  let(:partner2) { Fabricate(:partner, name: 'Second Partner') }
 
+  context 'with a submission' do
     before do
       allow_any_instance_of(Admin::OffersController).to receive(:require_artsy_authentication)
-      page.visit "/admin/offers/new_step_0?submission_id=#{submission.id}"
+      page.visit new_step_0_admin_offers_path(submission_id: submission.id)
     end
 
     it 'displays the page title and content' do
@@ -27,6 +27,44 @@ describe 'admin/offers/new_step_0.html.erb', type: :feature do
       click_button('Next')
       expect(page).to have_content('Offer requires type, submission, and partner.')
       expect(find('input#offer_type_purchase')).to be_checked
+    end
+  end
+
+  context 'without a submission', js: true do
+    before do
+      allow_any_instance_of(Admin::OffersController).to receive(:require_artsy_authentication)
+      page.visit new_step_0_admin_offers_path
+    end
+
+    it 'displays the page title and content' do
+      expect(page).to have_content('New Offer')
+    end
+
+    it 'displays an error message if a submission and partner are not selected' do
+      expect(find('input#offer_type_auction_consignment')).to be_checked
+      click_button('Next')
+      expect(page).to have_content('Offer requires type, submission, and partner.')
+    end
+
+    it 'allows you to select a submission and partner' do
+      evaluate_script("$('#submission_id').val(#{submission.id})")
+      evaluate_script("$('#partner_id').val(#{partner.id})")
+      click_button('Next')
+      expect(page).to have_content("Auction consignment offer for Submission ##{submission.id} by First Partner")
+    end
+
+    it 'keeps the partner selected if you revisit the page on error' do
+      evaluate_script("$('#partner_id').val(#{partner.id})")
+      click_button('Next')
+      expect(page).to have_content('Partner First Partner')
+      expect(page).to have_content('Offer requires type, submission, and partner.')
+    end
+
+    it 'keeps the submission selected if you revisit the page on error' do
+      evaluate_script("$('#submission_id').val(#{submission.id})")
+      click_button('Next')
+      expect(page).to have_content("Submission ##{submission.id}")
+      expect(page).to have_content('Offer requires type, submission, and partner.')
     end
   end
 end

--- a/spec/views/admin/submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/submissions/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
             'Content-Type' => 'application/json'
           }
         )
-      page.visit '/admin/submissions'
+      page.visit admin_submissions_path
     end
 
     it 'displays the page title' do
@@ -41,7 +41,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
     context 'with submissions' do
       before do
         3.times { Fabricate(:submission, user_id: 'userid', artist_id: 'artistid', state: 'submitted') }
-        page.visit '/admin/submissions'
+        page.visit admin_submissions_path
       end
 
       it 'displays all of the submissions' do
@@ -75,7 +75,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
         click_link('Unreviewed')
         expect(page).to have_content('Submissions')
         expect(page).to have_selector('.list-group-item', count: 3)
-        expect(current_path).to eq '/admin/submissions'
+        expect(current_path).to eq admin_submissions_path
       end
     end
 
@@ -104,7 +104,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
               'Content-Type' => 'application/json'
             }
           )
-        page.visit '/admin/submissions'
+        page.visit admin_submissions_path
       end
 
       it 'shows the correct artist names' do


### PR DESCRIPTION
This PR adds the ability to create an offer "from scratch" (meaning, the submission and partner are blank).

It reuses the `new_step_0` template, but adds a small amount of javascript for rendering the autocomplete box. A submission, partner, and offer type are required to advance to the next form page.

![offer-from-scratch](https://user-images.githubusercontent.com/2081340/34535856-50415936-f091-11e7-951b-06257ba2ec57.gif)

