### PR TITLE
@mzikherman => adds consignments index and dashboard views

### DIFF
--- a/app/controllers/admin/consignments_controller.rb
+++ b/app/controllers/admin/consignments_controller.rb
@@ -3,6 +3,24 @@ module Admin
     include GraphqlHelper
 
     before_action :set_consignment, only: [:show, :edit, :update]
+    before_action :set_pagination_params, only: [:index]
+
+    expose(:consignments) do
+      matching_consignments = params[:state] ? PartnerSubmission.consigned.where(state: params[:state]) : PartnerSubmission.consigned
+      matching_consignments.order(id: :desc).page(@page).per(@size)
+    end
+
+    expose(:filters) do
+      { state: params[:state] }
+    end
+
+    expose(:counts) do
+      PartnerSubmission.consigned.group(:state).count
+    end
+
+    expose(:consignments_count) do
+      PartnerSubmission.consigned.count
+    end
 
     def show
       @artist_details = artists_query([@consignment.submission.artist_id])
@@ -19,6 +37,8 @@ module Admin
       end
     end
 
+    def index; end
+
     private
 
     def set_consignment
@@ -33,6 +53,7 @@ module Admin
         :sale_date,
         :sale_location,
         :sale_lot_number,
+        :state,
         :partner_commission_percent,
         :artsy_commission_percent,
         :partner_invoiced_at,

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -10,12 +10,20 @@ module Admin
       Offer.sent.order(id: :desc).take(4)
     end
 
+    expose(:consignments) do
+      PartnerSubmission.consigned.order(id: :desc).take(4)
+    end
+
     expose(:submissions_count) do
       Submission.submitted.count
     end
 
     expose(:offers_count) do
       Offer.sent.count
+    end
+
+    expose(:consignments_count) do
+      PartnerSubmission.consigned.count
     end
 
     def index

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -6,10 +6,14 @@ class PartnerSubmission < ApplicationRecord
   has_many :offers
   belongs_to :accepted_offer, class_name: 'Offer'
 
-  STATES = %w(
-    open
-    unconfirmed
-  ).freeze
+  STATES = [
+    'open',
+    'unconfirmed',
+    'signed',
+    'sold',
+    'bought in',
+    'closed'
+  ].freeze
 
   scope :group_by_day, -> { group("date_trunc('day', notified_at) ") }
   scope :consigned, -> { where.not(accepted_offer_id: nil) }

--- a/app/views/admin/consignments/index.html.erb
+++ b/app/views/admin/consignments/index.html.erb
@@ -1,0 +1,40 @@
+<div class='page-title'>
+  <h2>Consignments</h2>
+</div>
+
+<div class='container'>
+  <div class='row triple-padding-top'>
+    <div class='col-md-2'>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'All', admin_consignments_path %></div>
+        <div class='right'><%= consignments_count %></div>
+      </div>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'Unconfirmed', admin_consignments_path(state: 'unconfirmed') %></div>
+        <div class='right'><%= counts['unconfirmed'] || 0 %></div>
+      </div>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'Signed', admin_consignments_path(state: 'signed') %></div>
+        <div class='right'><%= counts['signed'] || 0 %></div>
+      </div>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'Sold', admin_consignments_path(state: 'sold') %></div>
+        <div class='right'><%= counts['sold'] || 0 %></div>
+      </div>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'Bought in', admin_consignments_path(state: 'bought in') %></div>
+        <div class='right'><%= counts['bought in'] || 0 %></div>
+      </div>
+      <div class='flex-label'>
+        <div class='left'><%= link_to 'Closed', admin_consignments_path(state: 'closed') %></div>
+        <div class='right'><%= counts['closed'] || 0 %></div>
+      </div>
+    </div>
+    <div class='col-md-10'>
+      <div class='list-group'>
+        <%= render partial: 'admin/consignments/consignment', collection: consignments %>
+      </div>
+    </div>
+  </div>
+  <%= render 'shared/watt/paginator', total_items_count: consignments.total_count, items_count: consignments.length, per_page: @size, current_page: @page, base_url: admin_consignments_url(filters) %>
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class='container'>
-  <div class='row'>
+  <div class='row unreviewed-submissions'>
     <div class='row section-header col-sm-12'>
       <div class='col-sm-9'>
         <h3>
@@ -27,7 +27,7 @@
       </div>
     </div>
   </div>
-  <div class='row'>
+  <div class='row open-offers'>
     <div class='row section-header col-sm-12'>
       <div class='col-sm-9'>
         <h3>
@@ -51,6 +51,34 @@
       <div class='section-actions'>
         <div class='pull-right'>
           <%= link_to 'See All', admin_offers_path(state: 'sent'), class: 'btn btn-secondary btn-small' %>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class='row active-consignments'>
+    <div class='row section-header col-sm-12'>
+      <div class='col-sm-9'>
+        <h3>
+          Active Consignments
+        </h3>
+      </div>
+      <div class='col-sm-3'>
+        <div class='pull-right gray-label'>
+          <h3>
+            <%= consignments_count %>
+          </h3>
+        </div>
+      </div>
+    </div>
+    <div class='row col-sm-12'>
+      <div class='list-group'>
+        <%= render partial: 'admin/consignments/consignment', collection: consignments %>
+      </div>
+    </div>
+    <div class='row col-sm-12'>
+      <div class='section-actions'>
+        <div class='pull-right'>
+          <%= link_to 'See All', admin_consignments_path, class: 'btn btn-secondary btn-small' %>
         </div>
       </div>
     </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -9,6 +9,7 @@
 <div class='nav'>
   <%= link_to 'Submissions', admin_submissions_url %>
   <%= link_to 'Offers', admin_offers_url %>
+  <%= link_to 'Consignments', admin_consignments_url %>
   <%= link_to 'Partners', admin_partners_url %>
   <%= link_to 'log out', '/sign_out' %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
         get 'new_step_1'
       end
     end
-    resources :consignments, only: [:show, :edit, :update]
+    resources :consignments, only: [:show, :edit, :update, :index]
     root to: 'dashboard#index'
   end
   get '/match_artist', to: 'admin/submissions#match_artist'

--- a/spec/fabricators/partner_submission_fabricator.rb
+++ b/spec/fabricators/partner_submission_fabricator.rb
@@ -2,3 +2,9 @@ Fabricator(:partner_submission) do
   submission { Fabricate(:submission) }
   partner { Fabricate(:partner) }
 end
+
+Fabricator(:consignment, from: :partner_submission) do
+  submission { Fabricate(:submission) }
+  partner { Fabricate(:partner) }
+  accepted_offer { Fabricate(:offer, state: 'accepted') }
+end

--- a/spec/views/admin/consignments/index.html.erb_spec.rb
+++ b/spec/views/admin/consignments/index.html.erb_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe 'admin/consignments/index.html.erb', type: :feature do
+  context 'always' do
+    before do
+      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      page.visit admin_consignments_path
+    end
+
+    it 'displays the page title' do
+      expect(page).to have_content('Consignments')
+      expect(page).not_to have_selector('.list-group-item')
+    end
+
+    it 'displays zeros for the counts' do
+      expect(page).to have_content('All 0')
+      expect(page).to have_content('Unconfirmed 0')
+      expect(page).to have_content('Signed 0')
+      expect(page).to have_content('Sold 0')
+      expect(page).to have_content('Bought in 0')
+      expect(page).to have_content('Closed 0')
+    end
+
+    context 'with some consignments' do
+      before do
+        3.times do
+          Fabricate(:consignment, state: 'unconfirmed')
+        end
+        page.visit admin_consignments_path
+      end
+
+      it 'displays all of the consignments' do
+        expect(page).to have_content('Consignments')
+        expect(page).to have_selector('.list-group-item', count: 3)
+      end
+
+      it 'lets you click a consignment' do
+        consignment = PartnerSubmission.consigned.first
+
+        allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+        gravql_artists_response = {
+          data: {
+            artists: [
+              { id: 'artist1', name: 'Andy Warhol' }
+            ]
+          }
+        }
+        stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
+          .to_return(body: gravql_artists_response.to_json)
+          .with(
+            headers: {
+              'X-XAPP-TOKEN' => 'xapp_token',
+              'Content-Type' => 'application/json'
+            }
+          )
+
+        stub_gravity_root
+        stub_gravity_user(id: consignment.submission.user_id)
+        stub_gravity_user_detail(id: consignment.submission.user_id)
+        stub_gravity_artist(id: consignment.submission.artist_id)
+        page.visit admin_consignments_path
+
+        within(:css, ".list-item--consignment[data-id='#{consignment.id}']") do
+          click_link('View')
+        end
+        expect(page).to have_content("Consignment ##{consignment.reference_id} (unconfirmed)")
+      end
+
+      it 'shows the counts of consignments' do
+        expect(page).to have_content('All 3')
+        expect(page).to have_content('Unconfirmed 3')
+        expect(page).to have_content('Signed 0')
+        expect(page).to have_content('Sold 0')
+        expect(page).to have_content('Bought in 0')
+        expect(page).to have_content('Closed 0')
+      end
+
+      it 'lets you click a filter option' do
+        click_link('Signed')
+        expect(page).to have_selector('.list-group-item', count: 0)
+        expect(current_url).to include admin_consignments_path(state: 'signed')
+      end
+    end
+
+    context 'with a variety of consignments' do
+      before do
+        3.times { Fabricate(:consignment, state: 'unconfirmed') }
+        Fabricate(:consignment, state: 'signed')
+        Fabricate(:consignment, state: 'sold')
+        Fabricate(:consignment, state: 'closed')
+        page.visit admin_consignments_path
+      end
+
+      it 'shows the correct counts' do
+        expect(page).to have_content('All 6')
+        expect(page).to have_content('Unconfirmed 3')
+        expect(page).to have_content('Signed 1')
+        expect(page).to have_content('Sold 1')
+        expect(page).to have_content('Bought in 0')
+        expect(page).to have_content('Closed 1')
+      end
+
+      it 'lets you click into a filter option' do
+        click_link('Signed')
+        expect(page).to have_content('Consignments')
+        expect(page).to have_selector('.list-group-item', count: 1)
+      end
+
+      it 'filters by changing the url' do
+        page.visit('/admin/consignments?state=bought+in')
+        expect(page).to have_content('Consignments')
+        expect(page).to have_selector('.list-group-item', count: 0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the "consignments" index view and a consignments section to the "dashboard" view:

![image](https://user-images.githubusercontent.com/2081340/34794940-5f894e0c-f61e-11e7-98c2-11e89b275735.png)

![image](https://user-images.githubusercontent.com/2081340/34794945-66373070-f61e-11e7-8701-06554fc72516.png)

The consignment list item UI is non-ideal but I'm gonna be showing it to the team soon so I can fix it up then. 😄 