### PR TITLE
@yuki24 => adds sentry for error reporting #migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'hyperclient' # consume Gravity's v2 API
 gem 'premailer-rails' # generate text parts from HTML automatically
 
 gem 'newrelic_rpm' # for monitoring
+gem 'sentry-raven' # for error reporting
 
 gemini_gem_spec = { git: 'https://github.com/artsy/gemini_upload-rails.git', branch: 'master' }
 gem 'gemini_upload-rails', gemini_gem_spec # for admins to upload images

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sentry-raven (2.7.1)
+      faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.9.0)
     sidekiq (4.2.9)
       concurrent-ruby (~> 1.0)
@@ -380,6 +382,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 5.0)
+  sentry-raven
   sidekiq
   uglifier (>= 1.3.0)
   watt!

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   helper Watt::Engine.helpers
 
   before_action :set_current_user
+  before_action :set_raven_context
 
   NotAuthorized = Class.new(StandardError)
 
@@ -23,5 +24,9 @@ class ApplicationController < ActionController::Base
   def set_pagination_params
     @page = (params[:page] || 1).to_i
     @size = (params[:size] || 10).to_i
+  end
+
+  def set_raven_context
+    Raven.user_context(id: @current_user)
   end
 end

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -25,6 +25,7 @@ Convection.config = OpenStruct.new(
   jwt_secret: ENV['JWT_SECRET'] || 'replace-me',
   processing_grace_seconds: (ENV['PROCESSING_GRACE_SECONDS'] || 600).to_i,
   second_reminder_days_after: (ENV['SECOND_REMINDER_DAYS_AFTER'] || 1).to_i,
+  sentry_dsn: ENV['SENTRY_DSN'],
   sidekiq_username: ENV['SIDEKIQ_USERNAME'] || 'admin',
   sidekiq_password: ENV['SIDEKIQ_PASSWORD'] || 'replace-me',
   smtp_address: ENV['SMTP_ADDRESS'],

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,4 @@
+Raven.configure do |config|
+  config.dsn = Convection.config.sentry_dsn if Convection.config.sentry_dsn
+  config.processors -= [Raven::Processor::PostData]
+end


### PR DESCRIPTION
This PR adds sentry so we have more visibility into errors.

I've already created the projects in staging and production:
https://sentry.io/artsynet/convection-staging
https://sentry.io/artsynet/convection-production

### Migration
Add the correct `SENTRY_DSN` environment variables to staging and production.