### PR TITLE
@mzikherman => ability to search on submission or consignment pages

### DIFF
--- a/app/controllers/admin/consignments_controller.rb
+++ b/app/controllers/admin/consignments_controller.rb
@@ -6,7 +6,11 @@ module Admin
     before_action :set_pagination_params, only: [:index]
 
     expose(:consignments) do
-      matching_consignments = params[:state] ? PartnerSubmission.consigned.where(state: params[:state]) : PartnerSubmission.consigned
+      if params[:term].present?
+        matching_consignments = PartnerSubmission.consigned.search(params[:term]) if params[:term]
+      else
+        matching_consignments = params[:state] ? PartnerSubmission.consigned.where(state: params[:state]) : PartnerSubmission.consigned
+      end
       matching_consignments.order(id: :desc).page(@page).per(@size)
     end
 
@@ -20,6 +24,10 @@ module Admin
 
     expose(:consignments_count) do
       PartnerSubmission.consigned.count
+    end
+
+    expose(:term) do
+      params[:term]
     end
 
     def show

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -9,9 +9,13 @@ module Admin
       @counts = Submission.group(:state).count
       @completed_submissions_count = Submission.completed.count
       @filters = { state: params[:state] }
+      @term = params[:term]
 
-      @submissions = params[:state] ? Submission.where(state: params[:state]) : Submission.completed
-      @submissions = @submissions.search(params[:term]) if params[:term]
+      @submissions = if params[:term].present?
+                       Submission.search(params[:term])
+                     else
+                       params[:state] ? Submission.where(state: params[:state]) : Submission.completed
+                     end
       @submissions = @submissions.order(id: :desc).page(@page).per(@size)
       @artist_details = artists_query(@submissions.map(&:artist_id))
 

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -1,5 +1,15 @@
 class PartnerSubmission < ApplicationRecord
   include ReferenceId
+  include PgSearch
+
+  pg_search_scope :search,
+    against: [:id, :reference_id],
+    associated_against: {
+      partner: [:name]
+    },
+    using: {
+      tsearch: { prefix: true }
+    }
 
   belongs_to :partner
   belongs_to :submission

--- a/app/views/admin/consignments/_consignment.html.erb
+++ b/app/views/admin/consignments/_consignment.html.erb
@@ -1,8 +1,8 @@
-<div class='list-group-item list-item--consignment' data-id=<%= consignment.id %>>
+<%= link_to admin_consignment_path(consignment), class: 'list-group-item list-item--consignment', data: { id: consignment.id } do %>
   <div class='list-group-item-info list-group-item-info--id'>
     #<%= consignment.reference_id %>
   </div>
-  <div class='list-group-item-info'>
+  <div class='list-group-item-info list-group-item-info--partner-name'>
     <%= consignment.partner.name %>
   </div>
   <div class='list-group-item-info'>
@@ -14,7 +14,5 @@
   <div class='list-group-item-info'>
     <%= consignment.state %>
   </div>
-  <div class='actions'>
-    <%= link_to 'View', admin_consignment_path(consignment), class: 'btn btn-tiny' %>
-  </div>
-</div>
+  <span class='icon-chevron-right'></span>
+<% end %>

--- a/app/views/admin/consignments/index.html.erb
+++ b/app/views/admin/consignments/index.html.erb
@@ -31,8 +31,22 @@
       </div>
     </div>
     <div class='col-md-10'>
-      <div class='list-group'>
-        <%= render partial: 'admin/consignments/consignment', collection: consignments %>
+      <div class='row col-md-12'>
+        <%= form_tag admin_consignments_url, method: 'get' do %>
+          <div class='form-group'>
+            <div class='col-sm-10'>
+              <%= text_field_tag 'term', term, class: 'form-control', placeholder: 'Search by ID or partner' %>
+            </div>
+            <div class='col-sm-2'>
+              <%= submit_tag 'Search', class: 'btn btn-primary btn-full-width btn-tiny' %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <div class='row col-md-12 double-padding-top'>
+        <div class='list-group'>
+          <%= render partial: 'admin/consignments/consignment', collection: consignments %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/admin/offers/_offer.html.erb
+++ b/app/views/admin/offers/_offer.html.erb
@@ -1,4 +1,4 @@
-<div class='list-group-item list-item--offer' data-id=<%= offer.id %>>
+<%= link_to admin_offer_path(offer), class: 'list-group-item list-item--offer', data: { id: offer.id } do %>
   <div class='list-group-item-info list-group-item-info--id'>
     <%= offer.id %>
   </div>
@@ -17,7 +17,5 @@
   <div class='list-group-item-info'>
     <%= offer.state %>
   </div>
-  <div class='actions'>
-    <%= link_to 'View', admin_offer_path(offer), class: 'btn btn-tiny' %>
-  </div>
-</div>
+  <span class='icon-chevron-right'></span>
+<% end %>

--- a/app/views/admin/submissions/_submission.html.erb
+++ b/app/views/admin/submissions/_submission.html.erb
@@ -1,4 +1,4 @@
-<div class='list-group-item list-item--submission' data-id=<%= submission.id %>>
+<%= link_to admin_submission_path(submission), class: 'list-group-item list-item--submission', data: { id: submission.id } do %>
   <div class='list-group-item-info list-group-item-info--id'>
     <%= submission.id %>
   </div>
@@ -11,7 +11,9 @@
     <%= submission.created_at.strftime('%m/%d/%Y') %>
   </div>
   <div class='list-group-item-info'>
-    <%= artist_details[submission.artist_id] %>
+    <% if artist_details.present? %>
+      <%= artist_details[submission.artist_id] %>
+    <% end %>
   </div>
   <div class='list-group-item-info'>
     <%= submission.category %>
@@ -19,7 +21,5 @@
   <div class='list-group-item-info'>
     <%= submission.state %>
   </div>
-  <div class='actions'>
-    <%= link_to 'View', admin_submission_path(submission), class: 'btn btn-tiny' %>
-  </div>
-</div>
+  <span class='icon-chevron-right'></span>
+<% end %>

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <div class='container'>
-  <div class='row triple-padding-top'>
+  <div class='row double-padding-top'>
     <div class='col-md-2'>
       <div class='flex-label'>
         <div class='left'><%= link_to 'All', admin_submissions_path %></div>
@@ -26,8 +26,22 @@
       </div>
     </div>
     <div class='col-md-10'>
-      <div class='list-group'>
-        <%= render @submissions, artist_details: @artist_details %>
+      <div class='row col-md-12'>
+        <%= form_tag admin_submissions_url, method: 'get' do %>
+          <div class='form-group'>
+            <div class='col-sm-10'>
+              <%= text_field_tag 'term', @term, class: 'form-control', placeholder: 'Search by ID or title' %>
+            </div>
+            <div class='col-sm-2'>
+              <%= submit_tag 'Search', class: 'btn btn-primary btn-full-width btn-tiny' %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+      <div class='row col-md-12 double-padding-top'>
+        <div class='list-group'>
+          <%= render @submissions, artist_details: @artist_details %>
+        </div>
       </div>
     </div>
   </div>

--- a/spec/views/admin/consignments/show.html.erb_spec.rb
+++ b/spec/views/admin/consignments/show.html.erb_spec.rb
@@ -64,9 +64,9 @@ describe 'admin/consignments/show.html.erb', type: :feature do
         within(:css, '.list-item--offer') do
           expect(page).to have_content 'accepted'
           expect(page).to have_content '12000'
-          click_link('View')
-          expect(page.current_path).to eq(admin_offer_path(offer))
         end
+        find('.list-item--offer').click
+        expect(page.current_path).to eq(admin_offer_path(offer))
       end
 
       it 'shows information about the submission and lets you navigate' do
@@ -74,9 +74,9 @@ describe 'admin/consignments/show.html.erb', type: :feature do
         within(:css, '.list-item--submission') do
           expect(page).to have_content 'approved'
           expect(page).to have_content 'Painting'
-          click_link('View')
-          expect(page.current_path).to eq(admin_submission_path(submission))
         end
+        find('.list-item--submission').click
+        expect(page.current_path).to eq(admin_submission_path(submission))
       end
 
       it 'lets you enter the edit view' do

--- a/spec/views/admin/dashboard/index.html.erb_spec.rb
+++ b/spec/views/admin/dashboard/index.html.erb_spec.rb
@@ -58,9 +58,7 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
         stub_gravity_user_detail(id: offer.submission.user_id)
         stub_gravity_artist(id: offer.submission.artist_id)
 
-        within(:css, ".list-item--offer[data-id='#{offer.id}']") do
-          click_link('View')
-        end
+        find(".list-item--offer[data-id='#{offer.id}']").click
         expect(page).to have_content("Offer ##{offer.reference_id} (sent)")
         expect(page).to have_content('Offer Lapsed')
       end
@@ -72,9 +70,7 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
         stub_gravity_user_detail(id: submission.user_id)
         stub_gravity_artist(id: submission.artist_id)
 
-        within(:css, ".list-item--submission[data-id='#{submission.id}']") do
-          click_link('View')
-        end
+        find(".list-item--submission[data-id='#{submission.id}']").click
         expect(page).to have_content("Submission ##{submission.id} (submitted)")
       end
 
@@ -85,9 +81,7 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
         stub_gravity_user_detail(id: consignment.submission.user_id)
         stub_gravity_artist(id: consignment.submission.artist_id)
 
-        within(:css, ".list-item--consignment[data-id='#{consignment.id}']") do
-          click_link('View')
-        end
+        find(".list-item--consignment[data-id='#{consignment.id}']").click
         expect(page).to have_content("Consignment ##{consignment.reference_id} (unconfirmed)")
       end
 

--- a/spec/views/admin/offers/index.html.erb_spec.rb
+++ b/spec/views/admin/offers/index.html.erb_spec.rb
@@ -57,9 +57,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
         stub_gravity_user_detail(id: offer.submission.user_id)
         stub_gravity_artist(id: offer.submission.artist_id)
 
-        within(:css, ".list-item--offer[data-id='#{offer.id}']") do
-          click_link('View')
-        end
+        find(".list-item--offer[data-id='#{offer.id}']").click
         expect(page).to have_content("Offer ##{offer.reference_id} (sent)")
         expect(page).to have_content('Offer Lapsed')
       end

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -117,10 +117,8 @@ describe 'admin/offers/show.html.erb', type: :feature do
         expect(page).to_not have_content('Accept Offer')
         expect(page).to have_content('Accepted by Lucille Bluth')
         expect(page).to have_selector('.list-item--consignment')
-        within(:css, '.list-item--consignment') do
-          click_link('View')
-          expect(page.current_path).to include('/admin/consignment')
-        end
+        find('.list-item--consignment').click
+        expect(page.current_path).to include('/admin/consignment')
       end
     end
 

--- a/spec/views/admin/submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/submissions/index.html.erb_spec.rb
@@ -55,9 +55,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
         stub_gravity_artist
 
         submission = Submission.order(id: :desc).first
-        within(:css, ".list-item--submission[data-id='#{submission.id}']") do
-          click_link('View')
-        end
+        find(".list-item--submission[data-id='#{submission.id}']").click
         expect(page).to have_content("Submission ##{submission.id}")
         expect(page).to have_content('Edit')
         expect(page).to have_content('Add Asset')
@@ -82,7 +80,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
     context 'with a variety of submissions' do
       before do
         3.times { Fabricate(:submission, user_id: 'userid', artist_id: 'artistid', state: 'submitted') }
-        Fabricate(:submission, user_id: 'userid', artist_id: 'artistid2', state: 'approved')
+        @submission = Fabricate(:submission, user_id: 'userid', artist_id: 'artistid2', state: 'approved')
         Fabricate(:submission, user_id: 'userid', artist_id: 'artistid4', state: 'rejected')
         Fabricate(:submission, user_id: 'userid', artist_id: 'artistid4', state: 'draft')
 
@@ -131,6 +129,13 @@ describe 'admin/submissions/index.html.erb', type: :feature do
         page.visit('/admin/submissions?state=rejected')
         expect(page).to have_content('Submissions')
         expect(page).to have_selector('.list-group-item', count: 1)
+      end
+
+      it 'allows you to search by submission ID' do
+        fill_in('term', with: @submission.id)
+        click_button('Search')
+        expect(page).to have_selector('.list-group-item', count: 1)
+        expect(page).to have_content(@submission.id)
       end
     end
   end


### PR DESCRIPTION
This PR adds the ability to search on the consignment or submission index views.

![image](https://user-images.githubusercontent.com/2081340/35127125-9bea8c24-fc7e-11e7-9d2a-2625b99a235e.png)

![image](https://user-images.githubusercontent.com/2081340/35127139-ad98780a-fc7e-11e7-9cfc-2f4e293f3206.png)

I also made a small change to make the entire list item clickable in the various views instead of needing a "View" button.