### PR TITLE
@joeyAghion => adds user table #migration

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  validates :gravity_user_id, presence: true, uniqueness: true
+end

--- a/db/migrate/20180131172252_add_users_table.rb
+++ b/db/migrate/20180131172252_add_users_table.rb
@@ -1,0 +1,12 @@
+class AddUsersTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      t.string :gravity_user_id, null: false
+      t.string :email
+
+      t.timestamps
+    end
+
+    add_index :users, [:gravity_user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180126212637) do
+ActiveRecord::Schema.define(version: 20180131172252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,11 +138,20 @@ ActiveRecord::Schema.define(version: 20180126212637) do
     t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 
+  create_table "users", force: :cascade do |t|
+    t.string "gravity_user_id", null: false
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["gravity_user_id"], name: "index_users_on_gravity_user_id", unique: true
+  end
+
   add_foreign_key "assets", "submissions"
   add_foreign_key "offers", "partner_submissions"
   add_foreign_key "offers", "submissions"
   add_foreign_key "partner_submissions", "offers", column: "accepted_offer_id"
   add_foreign_key "partner_submissions", "partners"
   add_foreign_key "partner_submissions", "submissions"
+  add_foreign_key "submissions", "assets", column: "primary_image_id", on_delete: :nullify
   add_foreign_key "submissions", "partner_submissions", column: "consigned_partner_submission_id"
 end


### PR DESCRIPTION
I'm working on building out the various sort/search/filter views and noticed that things were getting a little complicated, especially thinking about things like:
- How can we easily autocomplete by users who have consigned?
- How can we easily keep submissions in sync with things like `user_email`?
- How can we easily aggregate submissions by `User`?

I _think_ the most straightforward way to accomplish these is to graduate to a proper `User` model, which will have a `gravity_user_id` and an `email`.

This PR sets the groundwork for that by adding the users table. My next PR will include the migration for pointing `Submission#user_id` at the internal table instead of at a gravity ID. That will include some additional refactoring.

The migration is to populate the `User` table:

```ruby
user_ids = Submission.all.pluck(:user_id).uniq
user_ids.each do |user_id|
  User.create!(gravity_user_id: user_id)
end
```
