### PR TITLE
@joeyAghion=> point submission#user_id at the user  #migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,7 @@ Rails/SkipsModelValidations:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 134
+  Max: 136
 
 Style/SymbolArray:
   Enabled: false

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -29,12 +29,12 @@ module Admin
     end
 
     def create
-      @submission = Submission.new(submission_params.merge(state: 'submitted'))
-      if @submission.save
-        redirect_to admin_submission_path(@submission)
-      else
-        render 'new'
-      end
+      @submission = SubmissionService.create_submission(submission_params.merge(state: 'submitted'), params[:submission][:user_id])
+      redirect_to admin_submission_path(@submission)
+    rescue SubmissionService::SubmissionError => e
+      @submission = Submission.new(submission_params)
+      flash.now[:error] = e.message
+      render 'new'
     end
 
     def show
@@ -98,7 +98,6 @@ module Admin
         :signature,
         :state,
         :title,
-        :user_id,
         :width,
         :year
       )

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -30,7 +30,7 @@ module Api
     end
 
     def require_authorized_submission
-      raise ApplicationController::NotAuthorized unless current_user && current_user == @submission.user_id
+      raise ApplicationController::NotAuthorized unless current_user && current_user == @submission.user&.gravity_user_id
     end
 
     private

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -24,7 +24,8 @@ module Api
     def index
       param! :completed, :boolean, default: nil
 
-      submissions = Submission.where(user_id: current_user)
+      user = User.where(gravity_user_id: current_user).first
+      submissions = Submission.where(user: user)
       if params.include? :completed
         submissions = params[:completed] ? submissions.completed : submissions.draft
       end

--- a/app/events/submission_event.rb
+++ b/app/events/submission_event.rb
@@ -13,8 +13,8 @@ class SubmissionEvent < Events::BaseEvent
 
   def subject
     {
-      id: @object.user_id,
-      display: "#{@object.user_id} (#{@object.location_city})"
+      id: @object.user.gravity_user_id,
+      display: "#{@object.user.gravity_user_id} (#{@object.location_city})"
     }
   end
 

--- a/app/graph/mutations.rb
+++ b/app/graph/mutations.rb
@@ -7,7 +7,7 @@ module Mutations
       argument :submission, Inputs::SubmissionInput::Create
       permit :user
       resolve ->(_obj, args, context) {
-        Submission.create!(args[:submission].to_h.merge(user_id: context[:current_user]))
+        SubmissionService.create_submission(args[:submission].to_h, context[:current_user])
       }
     end
 
@@ -20,7 +20,7 @@ module Mutations
         submission = Submission.find_by(id: args[:submission][:id])
         raise(GraphQL::ExecutionError, 'Submission from ID Not Found') unless submission
 
-        is_same_as_user = submission&.user_id == context[:current_user]
+        is_same_as_user = submission&.user&.gravity_user_id == context[:current_user]
         is_admin = context[:current_user_roles].include?(:admin)
 
         raise(GraphQL::ExecutionError, 'Submission Not Found') unless is_same_as_user || is_admin
@@ -39,7 +39,7 @@ module Mutations
         submission = Submission.find_by(id: args[:submission_id])
         raise(GraphQL::ExecutionError, 'Submission from ID Not Found') unless submission
 
-        is_same_as_user = submission&.user_id == context[:current_user]
+        is_same_as_user = submission&.user&.gravity_user_id == context[:current_user]
         is_admin = context[:current_user_roles].include?(:admin)
 
         raise(GraphQL::ExecutionError, 'Submission from ID Not Found') unless is_same_as_user || is_admin

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -47,6 +47,7 @@ class Submission < ApplicationRecord
   has_many :assets, dependent: :destroy
   has_many :partner_submissions, dependent: :destroy
   has_many :offers, dependent: :destroy
+  belongs_to :user
   belongs_to :primary_image, class_name: 'Asset' # rubocop:disable Rails/InverseOf
   belongs_to :consigned_partner_submission, class_name: 'PartnerSubmission' # rubocop:disable Rails/InverseOf
 
@@ -118,22 +119,6 @@ class Submission < ApplicationRecord
 
   def artist_name
     artist.try(:name)
-  end
-
-  def user
-    Gravity.client.user(id: user_id)._get if user_id
-  rescue Faraday::ResourceNotFound
-    nil
-  end
-
-  def user_name
-    user.try(:name)
-  end
-
-  def user_detail
-    user.try(:user_detail)
-  rescue Faraday::ResourceNotFound
-    nil
   end
 
   def validate_primary_image

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,21 @@
 class User < ApplicationRecord
   validates :gravity_user_id, presence: true, uniqueness: true
+
+  has_many :submissions, dependent: :nullify
+
+  def gravity_user
+    Gravity.client.user(id: gravity_user_id)._get
+  rescue Faraday::ResourceNotFound
+    nil
+  end
+
+  def name
+    gravity_user.try(:name)
+  end
+
+  def user_detail
+    gravity_user.try(:user_detail)._get
+  rescue Faraday::ResourceNotFound
+    nil
+  end
 end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -74,7 +74,7 @@ class OfferService
     def deliver_rejection_notification(offer_id)
       offer = Offer.find(offer_id)
       artist = Gravity.client.artist(id: offer.submission.artist_id)._get
-      user_name = offer.submission.user_name
+      user_name = offer.submission.user.name
 
       PartnerMailer.offer_rejection_notification(
         offer: offer,

--- a/app/views/admin/submissions/_collector_info.html.erb
+++ b/app/views/admin/submissions/_collector_info.html.erb
@@ -2,13 +2,13 @@
   <div class='bold-label'>Collector info</div>
   <div class='single-padding-top'>
     <div>
-      <%= submission.user_name %>
+      <%= submission.user&.name %>
     </div>
     <div>
-      <%= submission.user_detail.try(:email) %>
+      <%= submission.user&.user_detail&.email %>
     </div>
     <div>
-      <%= submission.user_detail.try(:phone) %>
+      <%= submission.user&.user_detail&.phone %>
     </div>
   </div>
 </div>

--- a/app/views/admin/submissions/_form.html.erb
+++ b/app/views/admin/submissions/_form.html.erb
@@ -21,7 +21,7 @@
                 User
               </label>
               <div class='col-sm-10' id='user_selections_form'>
-                <%= f.text_field :user_name, class: 'form-control', id: 'user_search' %>
+                <%= f.text_field :user, class: 'form-control', id: 'user_search' %>
                 <%= f.hidden_field :user_id %>
               </div>
             </div>

--- a/db/migrate/20180131182229_rename_submission_table.rb
+++ b/db/migrate/20180131182229_rename_submission_table.rb
@@ -1,0 +1,7 @@
+class RenameSubmissionTable < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :submissions, :user_id, :ext_user_id
+
+    add_reference :submissions, :user, foreign_key: true, type: :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180131172252) do
+ActiveRecord::Schema.define(version: 20180131182229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 20180131172252) do
   end
 
   create_table "submissions", id: :serial, force: :cascade do |t|
-    t.string "user_id"
+    t.string "ext_user_id"
     t.boolean "qualified"
     t.string "artist_id"
     t.string "title"
@@ -133,7 +133,9 @@ ActiveRecord::Schema.define(version: 20180131172252) do
     t.integer "primary_image_id"
     t.integer "consigned_partner_submission_id"
     t.string "user_email"
+    t.integer "user_id"
     t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
+    t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
     t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"
     t.index ["user_id"], name: "index_submissions_on_user_id"
   end
@@ -154,4 +156,5 @@ ActiveRecord::Schema.define(version: 20180131172252) do
   add_foreign_key "partner_submissions", "submissions"
   add_foreign_key "submissions", "assets", column: "primary_image_id", on_delete: :nullify
   add_foreign_key "submissions", "partner_submissions", column: "consigned_partner_submission_id"
+  add_foreign_key "submissions", "users"
 end

--- a/spec/controllers/admin/assets_controller_spec.rb
+++ b/spec/controllers/admin/assets_controller_spec.rb
@@ -9,7 +9,7 @@ describe Admin::AssetsController, type: :controller do
       stub_gravity_user
       stub_gravity_user_detail
       stub_gravity_artist
-      @submission = Fabricate(:submission, artist_id: 'artistid', user_id: 'userid')
+      @submission = Fabricate(:submission, artist_id: 'artistid', user: Fabricate(:user, gravity_user_id: 'userid'))
     end
 
     context 'fetching an asset' do

--- a/spec/events/submission_event_spec.rb
+++ b/spec/events/submission_event_spec.rb
@@ -4,7 +4,7 @@ describe SubmissionEvent do
   let(:submission) do
     Fabricate(:submission,
       artist_id: 'artistid',
-      user_id: 'userid',
+      user: Fabricate(:user, gravity_user_id: 'userid'),
       title: 'My Artwork',
       state: 'submitted',
       medium: 'painting',

--- a/spec/fabricators/submission_fabricator.rb
+++ b/spec/fabricators/submission_fabricator.rb
@@ -1,5 +1,5 @@
 Fabricator(:submission) do
-  user_id { Fabricate.sequence(:user_id) }
+  user { Fabricate(:user) }
   artist_id { Fabricate.sequence(:artist_id) }
   title { Fabricate.sequence(:title) { |i| "The Last Supper #{i}" } }
   year 2010

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,0 +1,4 @@
+Fabricator(:user) do
+  gravity_user_id { Fabricate.sequence(:gravity_user_id) { |i| "user-id-#{i}" } }
+  email { Fabricate.sequence(:email) { |i| "jon-jonson#{i}@test.com" } }
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -104,37 +104,6 @@ describe Submission do
     end
   end
 
-  context 'user' do
-    it 'returns nil if it cannot find the object' do
-      stub_gravity_root
-      stub_request(:get, "#{Convection.config.gravity_api_url}/users/#{submission.user_id}")
-        .to_raise(Faraday::ResourceNotFound)
-      expect(submission.user).to be_nil
-      expect(submission.user_name).to be_nil
-    end
-    it 'returns the object if it can find it' do
-      stub_gravity_root
-      stub_gravity_user(id: submission.user_id, name: 'Buster Bluth')
-      expect(submission.user_name).to eq 'Buster Bluth'
-    end
-  end
-
-  context 'user detail' do
-    it 'returns nil if it cannot find the object' do
-      stub_gravity_root
-      stub_gravity_user(id: submission.user_id, name: 'Buster Bluth')
-      stub_request(:get, "#{Convection.config.gravity_api_url}/user_details/#{submission.user_id}")
-        .to_raise(Faraday::ResourceNotFound)
-      expect(submission.user_name).to eq 'Buster Bluth'
-    end
-    it 'returns the object if it can find it' do
-      stub_gravity_root
-      stub_gravity_user(id: submission.user_id, name: 'Buster Bluth')
-      stub_gravity_user_detail(id: submission.user_id, email: 'buster@bluth.com')
-      expect(submission.user_name).to eq 'Buster Bluth'
-    end
-  end
-
   context 'thumbnail' do
     it 'returns nil if there is no thumbnail image' do
       Fabricate(:unprocessed_image, submission: submission)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe User do
+  let!(:user) { Fabricate(:user, gravity_user_id: 'userid') }
+
+  context 'gravity_user' do
+    it 'returns nil if it cannot find the object' do
+      stub_gravity_root
+      stub_request(:get, "#{Convection.config.gravity_api_url}/users/#{user.gravity_user_id}")
+        .to_raise(Faraday::ResourceNotFound)
+      expect(user.gravity_user).to be_nil
+      expect(user.name).to be_nil
+    end
+
+    it 'returns the object if it can find it' do
+      stub_gravity_root
+      stub_gravity_user(id: user.gravity_user_id, name: 'Buster Bluth')
+      expect(user.name).to eq 'Buster Bluth'
+    end
+  end
+
+  context 'user detail' do
+    it 'returns nil if it cannot find the object' do
+      stub_gravity_root
+      stub_gravity_user(id: user.gravity_user_id, name: 'Buster Bluth')
+      stub_request(:get, "#{Convection.config.gravity_api_url}/user_details/#{user.gravity_user_id}")
+        .to_raise(Faraday::ResourceNotFound)
+      expect(user.name).to eq 'Buster Bluth'
+      expect(user.user_detail).to be_nil
+      expect(user.user_detail&.email).to be_nil
+    end
+
+    it 'returns the object if it can find it' do
+      stub_gravity_root
+      stub_gravity_user(id: user.gravity_user_id, name: 'Buster Bluth')
+      stub_gravity_user_detail(id: user.gravity_user_id, email: 'buster@bluth.com')
+      expect(user.name).to eq 'Buster Bluth'
+      expect(user.user_detail.email).to eq 'buster@bluth.com'
+    end
+  end
+end

--- a/spec/requests/api/assets/create_spec.rb
+++ b/spec/requests/api/assets/create_spec.rb
@@ -4,7 +4,7 @@ require 'support/gravity_helper'
 describe 'Create Asset' do
   let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
-  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid') }
+  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid')) }
 
   describe 'POST /assets' do
     it 'rejects unauthorized requests' do

--- a/spec/requests/api/assets/index_spec.rb
+++ b/spec/requests/api/assets/index_spec.rb
@@ -4,7 +4,7 @@ require 'support/gravity_helper'
 describe 'Assets Index' do
   let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
-  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid') }
+  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid')) }
 
   describe 'GET /assets' do
     it 'rejects unauthorized requests' do
@@ -20,7 +20,7 @@ describe 'Assets Index' do
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'buster-bluth')
+      submission = Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
       asset = submission.assets.create!(asset_type: 'image', gemini_token: 'gemini', submission_id: submission.id)
       get "/api/assets/#{asset.id}", headers: headers
       expect(response.status).to eq 401

--- a/spec/requests/api/assets/show_spec.rb
+++ b/spec/requests/api/assets/show_spec.rb
@@ -19,14 +19,14 @@ describe 'Show Asset' do
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'buster-bluth')
+      submission = Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
       asset = Fabricate(:image, submission: submission)
       get "/api/assets/#{asset.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid')
+      submission = Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid'))
       asset = Fabricate(:image, submission: submission)
       get "/api/assets/#{asset.id}", headers: headers
       expect(response.status).to eq 200

--- a/spec/requests/api/callbacks/gemini_spec.rb
+++ b/spec/requests/api/callbacks/gemini_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Gemini Callback' do
-  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid') }
+  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid')) }
 
   before do
     allow(Convection.config).to receive(:access_token).and_return('auth-token')

--- a/spec/requests/api/graphql/create_spec.rb
+++ b/spec/requests/api/graphql/create_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/gravity_helper'
 
 describe 'Create Submission With Graphql' do
   let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid', roles: 'user' }, Convection.config.jwt_secret) }
@@ -54,6 +55,10 @@ describe 'Create Submission With Graphql' do
     end
 
     it 'creates a submission' do
+      stub_gravity_root
+      stub_gravity_user
+      stub_gravity_user_detail(email: 'michael@bluth.com')
+
       expect do
         post '/api/graphql', params: {
           query: create_mutation
@@ -67,7 +72,7 @@ describe 'Create Submission With Graphql' do
 
     it 'creates an asset' do
       expect do
-        submission = Fabricate(:submission, user_id: 'userid')
+        submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'userid'))
 
         create_asset = <<-GRAPHQL
         mutation {

--- a/spec/requests/api/graphql/update_spec.rb
+++ b/spec/requests/api/graphql/update_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 describe 'Update Submission With Graphql' do
   let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid', roles: 'user' }, Convection.config.jwt_secret) }
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
-  let(:submission) { Fabricate(:submission, artist_id: 'abbas-kiarostami', title: 'rain', user_id: 'userid') }
+  let(:submission) do
+    Fabricate(:submission, artist_id: 'abbas-kiarostami', title: 'rain', user: Fabricate(:user, gravity_user_id: 'userid'))
+  end
 
   let(:update_mutation) do
     <<-GRAPHQL

--- a/spec/requests/api/submissions/show_spec.rb
+++ b/spec/requests/api/submissions/show_spec.rb
@@ -12,24 +12,24 @@ describe 'Show Submission' do
     end
 
     it 'returns an error if it cannot find the submission' do
-      Fabricate(:submission, user_id: 'buster-bluth')
+      Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
       get '/api/submissions/foo', headers: headers
       expect(response.status).to eq 404
       expect(JSON.parse(response.body)['error']).to eq 'Not Found'
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Fabricate(:submission, user_id: 'buster-bluth')
+      submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
       get "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Fabricate(:submission, user_id: 'userid')
+      submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'userid'))
       get "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body['user_id']).to eq 'userid'
+      expect(body['user_id']).to eq submission.user.id
       expect(body['id']).to eq submission.id
     end
   end

--- a/spec/requests/api/submissions/update_spec.rb
+++ b/spec/requests/api/submissions/update_spec.rb
@@ -12,33 +12,33 @@ describe 'Update Submission' do
     end
 
     it 'returns an error if it cannot find the submission' do
-      Fabricate(:submission, user_id: 'buster-bluth')
+      Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
       put '/api/submissions/foo', headers: headers
       expect(response.status).to eq 404
       expect(JSON.parse(response.body)['error']).to eq 'Not Found'
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Fabricate(:submission, user_id: 'buster-bluth')
+      submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
       put "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Fabricate(:submission, artist_id: 'andy-warhol', user_id: 'userid')
+      submission = Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid'))
       put "/api/submissions/#{submission.id}", params: {
         artist_id: 'kara-walker'
       }, headers: headers
       expect(response.status).to eq 201
       body = JSON.parse(response.body)
-      expect(body['user_id']).to eq 'userid'
+      expect(body['id']).to eq submission.id
       expect(body['artist_id']).to eq 'kara-walker'
     end
 
     describe 'submitting' do
       describe 'with a valid submission' do
         before do
-          @submission = Fabricate(:submission, user_id: 'userid', artist_id: 'artistid')
+          @submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'userid'), artist_id: 'artistid')
         end
 
         it 'sends a receipt when your state is updated to submitted' do
@@ -84,7 +84,7 @@ describe 'Update Submission' do
       it 'returns an error if you try to submit without all of the relevant fields' do
         submission = Fabricate(:submission,
           artist_id: 'andy-warhol',
-          user_id: 'userid',
+          user: Fabricate(:user, gravity_user_id: 'userid'),
           title: nil)
         put "/api/submissions/#{submission.id}", params: {
           artist_id: 'kara-walker',

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -19,7 +19,7 @@ describe 'Submission Flow' do
     # first create the submission, without a location_city
     post '/api/submissions', params: {
       artist_id: 'artistid',
-      user_id: 'userid',
+      user: Fabricate(:user, gravity_user_id: 'userid'),
       title: 'My Artwork',
       medium: 'painting',
       year: '1992',
@@ -63,7 +63,7 @@ describe 'Submission Flow' do
       # first create the submission
       post '/api/submissions', params: {
         artist_id: 'artistid',
-        user_id: 'userid',
+        user: Fabricate(:user, gravity_user_id: 'userid'),
         title: 'My Artwork',
         medium: 'painting',
         year: '1992',
@@ -108,7 +108,7 @@ describe 'Submission Flow' do
       # first create the submission
       post '/api/submissions', params: {
         artist_id: 'artistid',
-        user_id: 'userid',
+        user: Fabricate(:user, gravity_user_id: 'userid'),
         title: 'My Artwork',
         medium: 'painting',
         year: '1992',

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -4,7 +4,7 @@ describe NotificationService do
   let(:submission) do
     Fabricate(:submission,
       artist_id: 'artistid',
-      user_id: 'userid',
+      user: Fabricate(:user, gravity_user_id: 'userid'),
       title: 'My Artwork',
       medium: 'painting',
       year: '1992',

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -96,8 +96,8 @@ describe OfferService do
 
     before do
       stub_gravity_root
-      stub_gravity_user(id: offer.submission.user_id)
-      stub_gravity_user_detail(email: 'michael@bluth.com', id: offer.submission.user_id)
+      stub_gravity_user(id: offer.submission.user.gravity_user_id)
+      stub_gravity_user_detail(email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id)
       stub_gravity_artist(id: submission.artist_id)
     end
 

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -3,6 +3,7 @@ require 'support/gravity_helper'
 
 describe PartnerSubmissionService do
   before do
+    @user = Fabricate(:user, gravity_user_id: 'userid')
     stub_gravity_root
     stub_gravity_user
     stub_gravity_user_detail
@@ -25,7 +26,7 @@ describe PartnerSubmissionService do
 
     it 'generates new partner submissions' do
       partner = Fabricate(:partner)
-      submission = Fabricate(:submission, state: 'submitted', user_id: 'userid', artist_id: 'artistid')
+      submission = Fabricate(:submission, state: 'submitted', user: @user, artist_id: 'artistid')
       SubmissionService.update_submission(submission, state: 'approved')
       expect(PartnerSubmission.where(submission: submission, partner: partner).count).to eq 1
       Fabricate(:submission, state: 'approved')
@@ -77,19 +78,19 @@ describe PartnerSubmissionService do
         @approved1 = Fabricate(:submission,
           state: 'submitted',
           artist_id: 'artistid',
-          user_id: 'userid',
+          user: @user,
           title: 'First approved artwork',
           year: '1992')
         @approved2 = Fabricate(:submission,
           state: 'submitted',
           artist_id: 'artistid',
-          user_id: 'userid',
+          user: @user,
           title: 'Second approved artwork',
           year: '1993')
         @approved3 = Fabricate(:submission,
           state: 'submitted',
           artist_id: 'artistid',
-          user_id: 'userid',
+          user: @user,
           title: 'Third approved artwork',
           year: '1997')
         Fabricate(:submission, state: 'rejected')

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe SubmissionService do
+  let!(:user) { Fabricate(:user, gravity_user_id: 'userid', email: 'michael@bluth.com') }
   let(:submission) do
-    Fabricate(:submission, artist_id: 'artistid', user_id: 'userid', title: 'My Artwork')
+    Fabricate(:submission, artist_id: 'artistid', user: user, title: 'My Artwork')
   end
 
   before do
@@ -24,8 +25,8 @@ describe SubmissionService do
 
       new_submission = SubmissionService.create_submission(params, 'userid')
       expect(new_submission.reload.state).to eq 'draft'
-      expect(new_submission.user_id).to eq 'userid'
-      expect(new_submission.user_email).to eq 'michael@bluth.com'
+      expect(new_submission.user_id).to eq user.id
+      expect(new_submission.user.email).to eq 'michael@bluth.com'
     end
 
     it 'raises an exception if the user_detail cannot be found' do

--- a/spec/views/admin/consignments/edit.html.erb_spec.rb
+++ b/spec/views/admin/consignments/edit.html.erb_spec.rb
@@ -29,8 +29,8 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
       stub_gravity_root
       stub_gravity_user(name: 'Lucille Bluth')
       stub_gravity_artist(id: submission.artist_id)
-      stub_gravity_user(id: submission.user_id)
-      stub_gravity_user_detail(id: submission.user_id)
+      stub_gravity_user(id: submission.user.gravity_user_id)
+      stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
       allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
       gravql_artists_response = {

--- a/spec/views/admin/consignments/index.html.erb_spec.rb
+++ b/spec/views/admin/consignments/index.html.erb_spec.rb
@@ -60,8 +60,8 @@ describe 'admin/consignments/index.html.erb', type: :feature do
           )
 
         stub_gravity_root
-        stub_gravity_user(id: consignment.submission.user_id)
-        stub_gravity_user_detail(id: consignment.submission.user_id)
+        stub_gravity_user(id: consignment.submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: consignment.submission.user.gravity_user_id)
         stub_gravity_artist(id: consignment.submission.artist_id)
         page.visit admin_consignments_path
 

--- a/spec/views/admin/consignments/show.html.erb_spec.rb
+++ b/spec/views/admin/consignments/show.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'support/jwt_helper'
 
 describe 'admin/consignments/show.html.erb', type: :feature do
   context 'always' do
-    let(:submission) { Fabricate(:submission, category: 'Painting', state: 'approved') }
+    let(:submission) { Fabricate(:submission, category: 'Painting', state: 'approved', user: Fabricate(:user, gravity_user_id: 'userid')) }
     let(:partner) { Fabricate(:partner) }
     let(:partner_submission) { Fabricate(:partner_submission, submission: submission, partner: partner) }
     let(:offer) do
@@ -29,8 +29,8 @@ describe 'admin/consignments/show.html.erb', type: :feature do
       stub_gravity_root
       stub_gravity_user(name: 'Lucille Bluth')
       stub_gravity_artist(id: submission.artist_id)
-      stub_gravity_user(id: submission.user_id)
-      stub_gravity_user_detail(id: submission.user_id)
+      stub_gravity_user(id: submission.user.gravity_user_id)
+      stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
       allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
       gravql_artists_response = {

--- a/spec/views/admin/dashboard/index.html.erb_spec.rb
+++ b/spec/views/admin/dashboard/index.html.erb_spec.rb
@@ -54,8 +54,8 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
       it 'lets you click an offer' do
         offer = Offer.sent.order(id: :desc).first
         stub_gravity_root
-        stub_gravity_user(id: offer.submission.user_id)
-        stub_gravity_user_detail(id: offer.submission.user_id)
+        stub_gravity_user(id: offer.submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: offer.submission.user.gravity_user_id)
         stub_gravity_artist(id: offer.submission.artist_id)
 
         find(".list-item--offer[data-id='#{offer.id}']").click
@@ -67,8 +67,8 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
       it 'lets you click a submission' do
         submission = Submission.submitted.order(id: :desc).first
         stub_gravity_root
-        stub_gravity_user(id: submission.user_id)
-        stub_gravity_user_detail(id: submission.user_id)
+        stub_gravity_user(id: submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: submission.user.gravity_user_id)
         stub_gravity_artist(id: submission.artist_id)
 
         find(".list-item--submission[data-id='#{submission.id}']").click
@@ -79,8 +79,8 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
       it 'lets you click a consignment' do
         consignment = PartnerSubmission.consigned.order(id: :desc).first
         stub_gravity_root
-        stub_gravity_user(id: consignment.submission.user_id)
-        stub_gravity_user_detail(id: consignment.submission.user_id)
+        stub_gravity_user(id: consignment.submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: consignment.submission.user.gravity_user_id)
         stub_gravity_artist(id: consignment.submission.artist_id)
 
         find(".list-item--consignment[data-id='#{consignment.id}']").click

--- a/spec/views/admin/offers/index.html.erb_spec.rb
+++ b/spec/views/admin/offers/index.html.erb_spec.rb
@@ -56,8 +56,8 @@ describe 'admin/offers/index.html.erb', type: :feature do
       it 'lets you click an offer' do
         offer = Offer.first
         stub_gravity_root
-        stub_gravity_user(id: offer.submission.user_id)
-        stub_gravity_user_detail(id: offer.submission.user_id)
+        stub_gravity_user(id: offer.submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: offer.submission.user.gravity_user_id)
         stub_gravity_artist(id: offer.submission.artist_id)
 
         find(".list-item--offer[data-id='#{offer.id}']").click

--- a/spec/views/admin/offers/new_step_1.html.erb_spec.rb
+++ b/spec/views/admin/offers/new_step_1.html.erb_spec.rb
@@ -43,8 +43,8 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
 
       it 'allows you to create an offer' do
         stub_gravity_root
-        stub_gravity_user(id: submission.user_id)
-        stub_gravity_user_detail(id: submission.user_id)
+        stub_gravity_user(id: submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
         allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
         gravql_artists_response = {
@@ -100,8 +100,8 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
 
       it 'allows you to create an offer' do
         stub_gravity_root
-        stub_gravity_user(id: submission.user_id)
-        stub_gravity_user_detail(id: submission.user_id)
+        stub_gravity_user(id: submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
         allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
         gravql_artists_response = {
@@ -159,8 +159,8 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
 
       it 'allows you to create an offer' do
         stub_gravity_root
-        stub_gravity_user(id: submission.user_id)
-        stub_gravity_user_detail(id: submission.user_id)
+        stub_gravity_user(id: submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
         allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
         gravql_artists_response = {

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -15,8 +15,8 @@ describe 'admin/offers/show.html.erb', type: :feature do
 
       stub_gravity_root
       stub_gravity_user(name: 'Lucille Bluth')
-      stub_gravity_user(id: submission.user_id)
-      stub_gravity_user_detail(id: submission.user_id)
+      stub_gravity_user(id: submission.user.gravity_user_id)
+      stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
       allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
       gravql_artists_response = {

--- a/spec/views/admin/submissions/edit.html.erb_spec.rb
+++ b/spec/views/admin/submissions/edit.html.erb_spec.rb
@@ -12,7 +12,7 @@ describe 'admin/submissions/edit.html.erb', type: :feature do
         edition_size: 100,
         edition_number: '23a',
         category: 'Painting',
-        user_id: 'userid')
+        user: Fabricate(:user, gravity_user_id: 'userid'))
 
       stub_gravity_root
       stub_gravity_user

--- a/spec/views/admin/submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/submissions/index.html.erb_spec.rb
@@ -43,7 +43,8 @@ describe 'admin/submissions/index.html.erb', type: :feature do
 
     context 'with submissions' do
       before do
-        3.times { Fabricate(:submission, user_id: 'userid', artist_id: 'artistid', state: 'submitted') }
+        user = Fabricate(:user, gravity_user_id: 'userid')
+        3.times { Fabricate(:submission, user: user, artist_id: 'artistid', state: 'submitted') }
         page.visit admin_submissions_path
       end
 
@@ -76,28 +77,29 @@ describe 'admin/submissions/index.html.erb', type: :feature do
 
     context 'with a variety of submissions' do
       before do
+        user = Fabricate(:user, gravity_user_id: 'userid')
         3.times do
           Fabricate(:submission,
-            user_id: 'userid',
+            user: user,
             artist_id: 'artistid',
             state: 'submitted',
             title: 'blah',
             user_email: 'sarah@test.com')
         end
         @submission = Fabricate(:submission,
-          user_id: 'userid',
+          user: user,
           artist_id: 'artistid2',
           state: 'approved',
           title: 'my work',
           user_email: 'percy@test.com')
         Fabricate(:submission,
-          user_id: 'userid',
+          user: user,
           artist_id: 'artistid4',
           state: 'rejected',
           title: 'title',
           user_email: 'sarah@test.com')
         Fabricate(:submission,
-          user_id: 'userid',
+          user: user,
           artist_id: 'artistid4',
           state: 'draft',
           title: 'blah blah',

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
         edition_size: 100,
         edition_number: '23a',
         category: 'Painting',
-        user_id: 'userid',
+        user: Fabricate(:user, gravity_user_id: 'userid'),
         state: 'submitted')
 
       stub_jwt_header('userid')


### PR DESCRIPTION
This is the follow-up to: https://github.com/artsy/convection/pull/155

In order to point the `Submission#user_id` column at convection's internal `User` table and not a gravity user ID, this PR includes a migration to:
- Rename the `user_id` column to `ext_user_id` (after this PR/migration, that field can be removed completely)
- Add a foreign key reference to the `user_id` column

### Migration
```ruby
Submission.find_each do |sub|
  print '.'
  return if sub.user.present?
  user = User.find_or_create_by(gravity_user_id: sub.ext_user_id)
  sub.update_attributes!(user: user)
end
```

Most of the changes are in specs, since fabrication/stubbing is different now.

A follow-up PR will address the `user_email` field (which we'll no longer need, now that we're storing `email` on the `User` table).