### PR TITLE
@joeyAghion => generalize currency support

### DIFF
--- a/app/controllers/admin/consignments_controller.rb
+++ b/app/controllers/admin/consignments_controller.rb
@@ -53,7 +53,7 @@ module Admin
 
     def consignment_params
       params.require(:partner_submission).permit(
-        :sale_currency,
+        :currency,
         :sale_price_cents,
         :sale_name,
         :sale_date,

--- a/app/models/concerns/currency.rb
+++ b/app/models/concerns/currency.rb
@@ -1,0 +1,21 @@
+module Currency
+  extend ActiveSupport::Concern
+
+  SUPPORTED = %w[
+    USD
+    EUR
+    GBP
+    CAD
+    HKD
+  ].freeze
+
+  included do
+    validates :currency, inclusion: { in: SUPPORTED }, allow_nil: true
+
+    before_validation :set_currency
+  end
+
+  def set_currency
+    self.currency ||= 'USD'
+  end
+end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,6 +1,7 @@
 class Offer < ApplicationRecord
   include ReferenceId
   include PgSearch
+  include Currency
 
   pg_search_scope :search,
     against: [:id, :reference_id],
@@ -28,13 +29,6 @@ class Offer < ApplicationRecord
     consigned
   ].freeze
 
-  CURRENCIES = %w[
-    USD
-    EUR
-    GBP
-    CAD
-  ].freeze
-
   REJECTION_REASONS = [
     'Low estimate',
     'High commission',
@@ -50,11 +44,9 @@ class Offer < ApplicationRecord
 
   validates :state, inclusion: { in: STATES }
   validates :offer_type, inclusion: { in: OFFER_TYPES }, allow_nil: true
-  validates :currency, inclusion: { in: CURRENCIES }, allow_nil: true
   validates :rejection_reason, inclusion: { in: REJECTION_REASONS }, allow_nil: true
 
   before_validation :set_state, on: :create
-  before_validation :set_currency
   before_create :set_submission
 
   scope :sent, -> { where(state: 'sent') }
@@ -82,10 +74,6 @@ class Offer < ApplicationRecord
 
   def set_submission
     self.submission ||= partner_submission&.submission
-  end
-
-  def set_currency
-    self.currency ||= 'USD'
   end
 
   def best_price_display

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -1,6 +1,7 @@
 class PartnerSubmission < ApplicationRecord
   include ReferenceId
   include PgSearch
+  include Currency
 
   pg_search_scope :search,
     against: [:id, :reference_id],

--- a/app/views/admin/consignments/edit.html.erb
+++ b/app/views/admin/consignments/edit.html.erb
@@ -25,7 +25,7 @@
                   Currency
                 </label>
                 <div class='col-sm-9'>
-                  <%= f.select :sale_currency, Offer::CURRENCIES, class: 'form-control' %>
+                  <%= f.select :currency, Currency::SUPPORTED, class: 'form-control' %>
                 </div>
               </div>
             </div>

--- a/app/views/admin/consignments/show.html.erb
+++ b/app/views/admin/consignments/show.html.erb
@@ -23,7 +23,7 @@
                 Currency
               </div>
               <div class='overview-item-value'>
-                <%= @consignment.sale_currency %>
+                <%= @consignment.currency %>
               </div>
             </div>
             <div class='overview-item'>

--- a/app/views/admin/offers/_shared_form.html.erb
+++ b/app/views/admin/offers/_shared_form.html.erb
@@ -4,7 +4,7 @@
       Currency
     </label>
     <div class='col-sm-9'>
-      <%= f.select :currency, Offer::CURRENCIES, class: 'form-control' %>
+      <%= f.select :currency, Currency::SUPPORTED, class: 'form-control' %>
     </div>
   </div>
 </div>

--- a/db/migrate/20180212170737_add_currency_to_ps.rb
+++ b/db/migrate/20180212170737_add_currency_to_ps.rb
@@ -1,0 +1,5 @@
+class AddCurrencyToPs < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :partner_submissions, :sale_currency, :currency
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180131182229) do
+ActiveRecord::Schema.define(version: 20180212170737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
 
   create_table "assets", id: :serial, force: :cascade do |t|
@@ -78,7 +79,7 @@ ActiveRecord::Schema.define(version: 20180131182229) do
     t.string "sale_lot_number"
     t.datetime "sale_date"
     t.integer "sale_price_cents"
-    t.string "sale_currency"
+    t.string "currency"
     t.datetime "partner_invoiced_at"
     t.datetime "partner_paid_at"
     t.text "notes"

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -31,6 +31,7 @@ describe Offer do
       expect(Offer.new(currency: 'USD')).to be_valid
       expect(Offer.new(currency: 'EUR')).to be_valid
       expect(Offer.new(currency: 'GBP')).to be_valid
+      expect(Offer.new(currency: 'HKD')).to be_valid
     end
   end
 

--- a/spec/models/partner_submission_spec.rb
+++ b/spec/models/partner_submission_spec.rb
@@ -21,4 +21,13 @@ describe PartnerSubmission do
       expect(ps.reference_id).to_not be_nil
     end
   end
+
+  context 'currency' do
+    it 'allows only certain currencies' do
+      expect(PartnerSubmission.new(currency: 'blah')).not_to be_valid
+      expect(PartnerSubmission.new(currency: 'USD')).to be_valid
+      expect(PartnerSubmission.new(currency: 'EUR')).to be_valid
+      expect(PartnerSubmission.new(currency: 'GBP')).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
We need to capture a `currency` for both an `Offer` and a `PartnerSubmission` (that is consigned). Previously, we had a `currency` field on an offer and a `sale_currency` on the consignment, but it was a little bit hacky.

This PR adds the `Currency` concern that is now included in both models, and renames the db field. It also adds support for `HKD` per request.