### PR TITLE
@ashkan18 => update consignment states and add canceled reason #migration

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,3 +28,4 @@
 //= require new_partner
 //= require new_offer
 //= require offer
+//= require consignment

--- a/app/assets/javascripts/consignment.js.coffee
+++ b/app/assets/javascripts/consignment.js.coffee
@@ -1,0 +1,14 @@
+$ ->
+  updateCanceledReasonDisplay = ($selectInput) ->
+    if $selectInput.val() == 'canceled'
+      $('.canceled-reason-field').removeClass('hidden')
+    else
+      $('.canceled-reason-field').addClass('hidden')
+
+  if $('select[name="partner_submission[state]"]').length > 0
+    $selectInput = $('select[name="partner_submission[state]"]')
+    updateCanceledReasonDisplay($selectInput)
+
+    # Show canceled reason input only if "canceled" is selected as the state
+    $selectInput.on 'change', ->
+      updateCanceledReasonDisplay($selectInput)

--- a/app/controllers/admin/consignments_controller.rb
+++ b/app/controllers/admin/consignments_controller.rb
@@ -53,6 +53,7 @@ module Admin
 
     def consignment_params
       params.require(:partner_submission).permit(
+        :canceled_reason,
         :currency,
         :sale_price_cents,
         :sale_name,

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -19,11 +19,9 @@ class PartnerSubmission < ApplicationRecord
 
   STATES = [
     'open',
-    'unconfirmed',
-    'signed',
     'sold',
     'bought in',
-    'closed'
+    'canceled'
   ].freeze
 
   scope :group_by_day, -> { group("date_trunc('day', notified_at) ") }

--- a/app/views/admin/consignments/edit.html.erb
+++ b/app/views/admin/consignments/edit.html.erb
@@ -19,6 +19,17 @@
               </div>
             </div>
 
+            <div class='row single-padding-top hidden canceled-reason-field'>
+              <div class='col-sm-12'>
+                <label class='col-sm-3 control-label'>
+                  Canceled Reason
+                </label>
+                <div class='col-sm-9'>
+                  <%= f.text_area :canceled_reason, class: 'form-control' %>
+                </div>
+              </div>
+            </div>
+
             <div class='row single-padding-top'>
               <div class='col-sm-12'>
                 <label class='col-sm-3 control-label'>

--- a/app/views/admin/consignments/show.html.erb
+++ b/app/views/admin/consignments/show.html.erb
@@ -18,6 +18,16 @@
                 <%= @consignment.state %>
               </div>
             </div>
+            <% if @consignment.state == 'canceled' %>
+              <div class='overview-item'>
+                <div class='overview-item-title'>
+                  Canceled Reason
+                </div>
+                <div class='overview-item-value'>
+                  <%= @consignment.canceled_reason %>
+                </div>
+              </div>
+            <% end %>
             <div class='overview-item'>
               <div class='overview-item-title'>
                 Currency

--- a/db/migrate/20180214173948_add_cancelled_reason.rb
+++ b/db/migrate/20180214173948_add_cancelled_reason.rb
@@ -1,0 +1,5 @@
+class AddCancelledReason < ActiveRecord::Migration[5.1]
+  def change
+    add_column :partner_submissions, :canceled_reason, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180212170737) do
+ActiveRecord::Schema.define(version: 20180214173948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 20180212170737) do
     t.text "notes"
     t.string "state"
     t.string "reference_id"
+    t.text "canceled_reason"
     t.index ["accepted_offer_id"], name: "index_partner_submissions_on_accepted_offer_id"
     t.index ["partner_id"], name: "index_partner_submissions_on_partner_id"
     t.index ["submission_id"], name: "index_partner_submissions_on_submission_id"

--- a/spec/models/partner_submission_spec.rb
+++ b/spec/models/partner_submission_spec.rb
@@ -7,7 +7,8 @@ describe PartnerSubmission do
   context 'state' do
     it 'allows only certain states' do
       expect(PartnerSubmission.new(state: 'blah')).not_to be_valid
-      expect(PartnerSubmission.new(state: 'unconfirmed')).to be_valid
+      expect(PartnerSubmission.new(state: 'open')).to be_valid
+      expect(PartnerSubmission.new(state: 'canceled')).to be_valid
     end
 
     it 'sets the default to open' do

--- a/spec/views/admin/consignments/edit.html.erb_spec.rb
+++ b/spec/views/admin/consignments/edit.html.erb_spec.rb
@@ -17,7 +17,7 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
 
     before do
       partner_submission.update_attributes!(
-        state: 'unconfirmed',
+        state: 'open',
         accepted_offer_id: offer.id,
         sale_name: 'July Prints & Multiples',
         sale_location: 'London'
@@ -78,6 +78,16 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
         click_button('Save')
         expect(page.current_path).to eq admin_consignment_path(partner_submission)
         expect(page).to have_content('Name August Sale')
+      end
+
+      it 'shows the canceled reason box when canceled is selected', js: true do
+        select('canceled', from: 'partner_submission_state')
+        expect(page).to have_content 'Canceled Reason'
+        fill_in('partner_submission_canceled_reason', with: 'do not want this piece.')
+        click_button('Save')
+        expect(page.current_path).to eq admin_consignment_path(partner_submission)
+        expect(page).to have_content('State canceled')
+        expect(page).to have_content('Canceled Reason do not want this piece.')
       end
     end
   end

--- a/spec/views/admin/consignments/index.html.erb_spec.rb
+++ b/spec/views/admin/consignments/index.html.erb_spec.rb
@@ -18,18 +18,16 @@ describe 'admin/consignments/index.html.erb', type: :feature do
     it 'shows the consignment states that can be selected' do
       within(:css, '#consignment-filter-form') do
         expect(page).to have_content('all')
-        expect(page).to have_content('unconfirmed')
-        expect(page).to have_content('signed')
         expect(page).to have_content('sold')
         expect(page).to have_content('bought in')
-        expect(page).to have_content('closed')
+        expect(page).to have_content('canceled')
       end
     end
 
     context 'with some consignments' do
       before do
         3.times do
-          Fabricate(:consignment, state: 'unconfirmed')
+          Fabricate(:consignment, state: 'open')
         end
         page.visit admin_consignments_path
       end
@@ -70,9 +68,9 @@ describe 'admin/consignments/index.html.erb', type: :feature do
       end
 
       it 'lets you click a filter option', js: true do
-        select('signed', from: 'state')
+        select('bought in', from: 'state')
         expect(page).to have_selector('.list-group-item', count: 1)
-        expect(current_url).to include '&state=signed'
+        expect(current_url).to include '&state=bought+in'
       end
     end
 
@@ -80,18 +78,18 @@ describe 'admin/consignments/index.html.erb', type: :feature do
       before do
         partner1 = Fabricate(:partner, name: 'Gagosian Gallery')
         partner2 = Fabricate(:partner, name: 'Heritage Auctions')
-        3.times { Fabricate(:consignment, state: 'unconfirmed', partner: partner1) }
-        Fabricate(:consignment, state: 'signed', partner: partner2)
+        3.times { Fabricate(:consignment, state: 'open', partner: partner1) }
+        Fabricate(:consignment, state: 'bought in', partner: partner2)
         Fabricate(:consignment, state: 'sold', partner: partner2)
-        Fabricate(:consignment, state: 'closed', partner: partner2)
+        Fabricate(:consignment, state: 'canceled', partner: partner2)
         page.visit admin_consignments_path
       end
 
       it 'lets you click into a filter option', js: true do
         within(:css, '#consignment-filter-form') do
-          select('signed', from: 'state')
+          select('bought in', from: 'state')
         end
-        expect(current_url).to include '&state=signed'
+        expect(current_url).to include '&state=bought+in'
         expect(page).to have_content('Consignments')
         expect(page).to have_selector('.list-group-item', count: 2)
       end
@@ -99,7 +97,7 @@ describe 'admin/consignments/index.html.erb', type: :feature do
       it 'filters by changing the url' do
         page.visit('/admin/consignments?state=bought+in')
         expect(page).to have_content('Consignments')
-        expect(page).to have_selector('.list-group-item', count: 1)
+        expect(page).to have_selector('.list-group-item', count: 2)
       end
 
       it 'allows you to search by partner name', js: true do
@@ -118,8 +116,8 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         partner_names = page.all('.list-group-item-info--partner-name').map(&:text)
         expect(partner_names.count).to eq 3
         expect(partner_names.uniq).to eq(['Heritage Auctions'])
-        select('signed', from: 'state')
-        expect(current_url).to include '&state=signed&term=herit'
+        select('bought in', from: 'state')
+        expect(current_url).to include '&state=bought+in&term=herit'
         expect(page).to have_selector('.list-group-item', count: 2)
       end
     end

--- a/spec/views/admin/consignments/show.html.erb_spec.rb
+++ b/spec/views/admin/consignments/show.html.erb_spec.rb
@@ -17,7 +17,7 @@ describe 'admin/consignments/show.html.erb', type: :feature do
 
     before do
       partner_submission.update_attributes!(
-        state: 'unconfirmed',
+        state: 'open',
         accepted_offer_id: offer.id,
         sale_name: 'July Prints & Multiples',
         sale_location: 'London'
@@ -57,6 +57,7 @@ describe 'admin/consignments/show.html.erb', type: :feature do
         expect(page).to have_content("Consignment ##{partner_submission.reference_id}")
         expect(page).to have_content('Name July Prints & Multiples')
         expect(page).to have_content('Location London')
+        expect(page).to_not have_content('Canceled Reason')
       end
 
       it 'shows information about the offer and lets you navigate' do
@@ -77,6 +78,13 @@ describe 'admin/consignments/show.html.erb', type: :feature do
         end
         find('.list-item--submission').click
         expect(page.current_path).to eq(admin_submission_path(submission))
+      end
+
+      it 'shows a canceled reason if the consignment has been canceled' do
+        partner_submission.update_attributes!(state: 'canceled', canceled_reason: 'done with this piece.')
+        page.visit admin_consignment_path(partner_submission)
+        expect(page).to have_content 'Canceled Reason'
+        expect(page).to have_content 'done with this piece.'
       end
 
       it 'lets you enter the edit view' do

--- a/spec/views/admin/dashboard/index.html.erb_spec.rb
+++ b/spec/views/admin/dashboard/index.html.erb_spec.rb
@@ -38,7 +38,7 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
         6.times { Fabricate(:submission, state: 'submitted') }
         Fabricate(:submission, state: 'draft')
         Fabricate(:offer, state: 'draft')
-        5.times { Fabricate(:consignment, state: 'unconfirmed') }
+        5.times { Fabricate(:consignment, state: 'open') }
         page.visit '/'
       end
 
@@ -85,7 +85,7 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
 
         find(".list-item--consignment[data-id='#{consignment.id}']").click
         expect(page).to have_content("Consignment ##{consignment.reference_id}")
-        expect(page).to have_content('State unconfirmed')
+        expect(page).to have_content('State open')
       end
 
       it 'lets you view all consignments' do

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -189,7 +189,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
 
     context 'with a consignment' do
       before do
-        consignment = Fabricate(:partner_submission, submission: @submission, state: 'unconfirmed')
+        consignment = Fabricate(:partner_submission, submission: @submission, state: 'open')
         @submission.update_attributes!(consigned_partner_submission: consignment)
         page.visit admin_submission_path(@submission)
       end


### PR DESCRIPTION
This PR updates the consignment states to match our better understanding of needs. 😄 

The migration will be to update all consignments in staging to these new states (as there may be some that refer to old states). No consignments exist in production yet, so this should be fine. (and all of the `PartnerSubmission` objects have a state of 'open')

The small amount of js is to hide or show a "canceled reason" text area if you choose "canceled" as the state of the consignment.