### PR TITLE
@ashkan18 => round display of percent

### DIFF
--- a/app/helpers/offers_helper.rb
+++ b/app/helpers/offers_helper.rb
@@ -88,7 +88,7 @@ module OffersHelper
 
   def commission_display(offer)
     return if offer.commission_percent.blank?
-    "#{offer.commission_percent * 100}%"
+    "#{(offer.commission_percent * 100).round(2)}%"
   end
 
   def shipping_display(offer)

--- a/spec/helpers/offers_helper_spec.rb
+++ b/spec/helpers/offers_helper_spec.rb
@@ -200,6 +200,11 @@ describe OffersHelper, type: :helper do
       expect(helper.commission_display(offer)).to eq '12.0%'
     end
 
+    it 'works for an offer with a 0.14 comission_percent' do
+      offer = double('offer', commission_percent: 0.14)
+      expect(helper.commission_display(offer)).to eq '14.0%'
+    end
+
     it 'returns nil if the offer has no commission_percent' do
       offer = double('offer', commission_percent: nil)
       expect(helper.commission_display(offer)).to eq nil


### PR DESCRIPTION
Since we store `commission_percent` as a float, when we were displaying that number multiplied by 100 as the percent we'd occasionally be displaying something odd (since [floats are inaccurate](http://floating-point-gui.de/basic/)).