### PR TITLE
@joeyAghion => update locked state to be a boolean #stagingmigration

### DIFF
--- a/app/assets/images/lock.svg
+++ b/app/assets/images/lock.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="30px" height="34px" viewBox="0 0 30 34" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Lock</title>
+    <defs>
+        <rect id="path-1" x="0" y="11" width="30" height="21" rx="2"></rect>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group" transform="translate(0.000000, 2.000000)">
+            <g id="Rectangle">
+                <use fill="#000000" fill-rule="evenodd" xlink:href="#path-1"></use>
+                <rect stroke="#000000" stroke-width="1" x="0.5" y="11.5" width="29" height="20" rx="2"></rect>
+            </g>
+            <path d="M4.5,11.5 C6.89621042,4.15199119 10.4795438,0.477986787 15.25,0.477986787 C20.0204562,0.477986787 23.6037896,4.15199119 26,11.5" id="Line" stroke="#000000" stroke-width="3" stroke-linecap="square"></path>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -25,6 +25,14 @@ $green: #0EDA83;
   justify-content: space-between;
 }
 
+.locked {
+  padding-bottom: 5px;
+  img {
+    width: 16px;
+    height: 16px;
+  }
+}
+
 .sidebar-link {
   padding-top: 5px;
   padding-bottom: 5px;

--- a/app/controllers/admin/offers_controller.rb
+++ b/app/controllers/admin/offers_controller.rb
@@ -60,7 +60,7 @@ module Admin
     end
 
     expose(:artist) do
-      artists_query([offer.submission.artist_id])
+      artists_query([offer.submission.artist_id])&.values&.first
     end
 
     def new_step_0

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -27,7 +27,6 @@ class Offer < ApplicationRecord
     rejected
     lapsed
     review
-    locked
     consigned
   ].freeze
 
@@ -37,6 +36,7 @@ class Offer < ApplicationRecord
     'High shipping/marketing costs',
     'Took competing offer',
     'Lost interest',
+    'Inconvenient partner location',
     'Other'
   ].freeze
 
@@ -66,6 +66,10 @@ class Offer < ApplicationRecord
 
   def reviewed?
     !draft? && !sent? && !review?
+  end
+
+  def locked?
+    submission.consigned_partner_submission_id.present? && submission.consigned_partner_submission.accepted_offer_id != id
   end
 
   def rejected_by_user

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -25,7 +25,7 @@ class OfferService
       case offer.state
       when 'sent' then send_offer!(offer, current_user)
       when 'review' then review!(offer)
-      when 'consigned' then consign!(offer, current_user)
+      when 'consigned' then consign!(offer)
       when 'rejected' then reject!(offer, current_user)
       end
     end
@@ -34,13 +34,9 @@ class OfferService
       delay.deliver_offer(offer.id, current_user)
     end
 
-    def consign!(offer, _current_user)
+    def consign!(offer)
       offer.update_attributes!(consigned_at: Time.now.utc)
       offer.submission.update_attributes!(consigned_partner_submission: offer.partner_submission)
-
-      # mark other offers on the same submission as "locked"
-      other_offers = offer.submission.offers.to_a - [offer]
-      other_offers.each { |o| o.update_attributes!(state: 'locked') }
 
       offer.partner_submission.update_attributes!(
         accepted_offer: offer,

--- a/app/views/admin/offers/_offer.html.erb
+++ b/app/views/admin/offers/_offer.html.erb
@@ -1,6 +1,16 @@
 <% truncated = false if local_assigns[:truncated].nil? %>
 
 <%= link_to admin_offer_path(offer), class: 'list-group-item list-item--offer', data: { id: offer.id } do %>
+  <span>
+    <% if offer.locked? %>
+      <div class='locked'>
+        <%= image_tag(image_url('lock.svg'), id: 'lock') %>
+      </div>
+    <% else %>
+      <div class='spacer'>
+      </div>
+    <% end %>
+  </span>
   <div class='list-group-item-info'>
     <%= offer.state %>
   </div>

--- a/app/views/admin/offers/_state_actions.html.erb
+++ b/app/views/admin/offers/_state_actions.html.erb
@@ -1,4 +1,4 @@
-<% unless @offer.rejected? || @offer.lapsed? || @offer.consigned? || @offer.locked? %>
+<% unless @offer.rejected? || @offer.lapsed? || @offer.consigned? %>
   <% if @offer.draft? %>
     <div class='overview-section offer-draft-actions'>
       <div class='single-padding-top'>
@@ -31,20 +31,26 @@
           <%= link_to('Offer Lapsed', admin_offer_path(@offer, offer: { state: 'lapsed' }), method: :put, class: 'btn btn-secondary btn-small btn-full-width',
                 data: { confirm: 'This action will mark the consignment as lapsed. This action cannot be undone.' }) %>
         </div>
-        <div class='double-padding-top'>
-          <%= check_box_tag 'terms_signed' %>
-          <span class='purple-label'>Required:</span> Terms signed.
+        <% if @offer.locked? %>
           <div class='single-padding-top'>
-            <%= link_to('Complete Consignment',
-                  admin_offer_path(@offer, offer: { state: 'consigned' }),
-                  method: :put,
-                  class: 'btn btn-primary btn-small btn-full-width offer-consign-button disabled-button',
-                  data: { confirm: 'This action will complete the consignment. This action cannot be undone.' }) %>
+            <i>This offer is locked since a competing offer is in review.</i>
           </div>
-          <div class='single-padding-top'>
-            <i>When offer is consigned, all other competing offers will lock.</i>
+        <% else %>
+          <div class='double-padding-top'>
+            <%= check_box_tag 'terms_signed' %>
+            <span class='purple-label'>Required:</span> Terms signed.
+            <div class='single-padding-top'>
+              <%= link_to('Complete Consignment',
+                    admin_offer_path(@offer, offer: { state: 'consigned' }),
+                    method: :put,
+                    class: 'btn btn-primary btn-small btn-full-width offer-consign-button disabled-button',
+                    data: { confirm: 'This action will complete the consignment. This action cannot be undone.' }) %>
+            </div>
+            <div class='single-padding-top'>
+              <i>When offer is consigned, all other competing offers will lock.</i>
+            </div>
           </div>
-        </div>
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/admin/offers/index.html.erb
+++ b/app/views/admin/offers/index.html.erb
@@ -31,6 +31,8 @@
     </div>
     <div class='row col-md-12'>
       <div class='list-group-item list-item--offer'>
+        <div class='spacer'>
+        </div>
         <div class='list-group-item-info bold-label'>
           State
         </div>

--- a/app/views/admin/offers/show.html.erb
+++ b/app/views/admin/offers/show.html.erb
@@ -32,6 +32,11 @@
           <div class='overview-section'>
             <div class='overview-section-title--inline'>
               Offer #<%= offer.reference_id %>
+              <% if @offer.locked? %>
+                <span class='locked'>
+                  <%= image_tag(image_url('lock.svg'), id: 'lock') %>
+                </span>
+              <% end %>
             </div>
           </div>
           <%= render 'state_actions' %>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -21,7 +21,7 @@
             </div>
             <%= render @submission.assets %>
           </div>
-          <%= render 'admin/consignments/consignment_section', consignment: @submission.consigned_partner_submission, artist: @submission.artist %>
+          <%= render 'admin/consignments/consignment_section', consignment: @submission.consigned_partner_submission, artist: @submission.artist&.name %>
           <%= render 'admin/offers/offers_section', offers: @offers, truncated: true %>
         </div>
       </div>

--- a/app/views/partner_mailer/offer_rejection_notification.html.erb
+++ b/app/views/partner_mailer/offer_rejection_notification.html.erb
@@ -157,7 +157,7 @@
         </tr>
         <tr>
           <td class='email-sub-title-serif'>
-            If you would like, you may submit a counteroffer. If not, no further action is required.
+            If you would like, you may submit a counter-offer. If not, no further action is required.
           </td>
         </tr>
         <tr>
@@ -168,7 +168,7 @@
             <table class='full-width-button'>
               <tr>
                 <td class='offer-response-button'>
-                  <%= link_to('Create counteroffer', offer_form_url) %>
+                  <%= link_to('Create counter-offer', offer_form_url) %>
                 </td>
               </tr>
             </table>

--- a/app/views/user_mailer/offer.html.erb
+++ b/app/views/user_mailer/offer.html.erb
@@ -35,7 +35,7 @@
             <%= render 'shared/email/offer_block', include_description: true %>
           </td>
         </tr>
-        <%= render 'shared/email/offer_note', label: 'Note from our partner' %>
+        <%= render 'shared/email/offer_note', label: 'Note' %>
         <tr>
           <td class='spacer'></td>
         </tr>

--- a/spec/helpers/offers_helper_spec.rb
+++ b/spec/helpers/offers_helper_spec.rb
@@ -205,6 +205,11 @@ describe OffersHelper, type: :helper do
       expect(helper.commission_display(offer)).to eq '14.0%'
     end
 
+    it 'works for an offer with a 0 comission_percent' do
+      offer = double('offer', commission_percent: 0)
+      expect(helper.commission_display(offer)).to eq '0%'
+    end
+
     it 'returns nil if the offer has no commission_percent' do
       offer = double('offer', commission_percent: nil)
       expect(helper.commission_display(offer)).to eq nil

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -49,6 +49,25 @@ describe Offer do
     end
   end
 
+  context 'locked?' do
+    it 'returns true if this offer is not the accepted_offer and the partner submission is consigned' do
+      ps = offer.partner_submission
+      consigned_offer = Fabricate(:offer, partner_submission: ps)
+      OfferService.consign!(consigned_offer)
+      expect(offer.locked?).to eq true
+      expect(consigned_offer.locked?).to eq false
+    end
+
+    it 'returns false if the submission has not been consigned at all' do
+      expect(offer.locked?).to eq false
+    end
+
+    it 'returns false if this offer is the accepted_offer' do
+      OfferService.consign!(offer)
+      expect(offer.locked?).to eq false
+    end
+  end
+
   context 'rejection_reason' do
     it 'allows only certain rejection reasons' do
       expect(Offer.new(rejection_reason: 'blah')).not_to be_valid

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -156,17 +156,6 @@ describe OfferService do
         expect(ps.submission.consigned_partner_submission).to eq offer.partner_submission
         expect(offer.consigned_at).to_not be_nil
       end
-
-      it 'marks all other offers as locked' do
-        additional_offer = Fabricate(:offer,
-          offer_type: 'purchase',
-          price_cents: 10_000,
-          state: 'review',
-          partner_submission: Fabricate(:partner_submission, submission: submission))
-        OfferService.update_offer(offer, 'userid', state: 'consigned')
-        expect(offer.state).to eq 'consigned'
-        expect(additional_offer.reload.state).to eq 'locked'
-      end
     end
 
     describe 'rejecting an offer' do

--- a/spec/views/admin/offers/index.html.erb_spec.rb
+++ b/spec/views/admin/offers/index.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
           }
         )
 
-      page.visit '/admin/offers'
+      page.visit admin_offers_path
     end
 
     it 'displays the page title' do
@@ -45,7 +45,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
     context 'with some offers' do
       before do
         3.times { Fabricate(:offer, state: 'sent') }
-        page.visit '/admin/offers'
+        page.visit admin_offers_path
       end
 
       it 'displays all of the offers' do
@@ -70,7 +70,16 @@ describe 'admin/offers/index.html.erb', type: :feature do
         expect(current_url).to include '&state=sent'
         expect(page).to have_content('Offers')
         expect(page).to have_selector('.list-group-item', count: 4)
-        expect(current_path).to eq '/admin/offers'
+        expect(current_path).to eq admin_offers_path
+      end
+
+      it 'displays a lock symbol if the offer is locked' do
+        ps = Fabricate(:partner_submission)
+        accepted_offer = Fabricate(:offer, partner_submission: ps)
+        Fabricate(:offer, partner_submission: ps)
+        OfferService.consign!(accepted_offer)
+        page.visit admin_offers_path
+        expect(page).to have_selector('.locked', count: 1)
       end
     end
 
@@ -82,7 +91,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
         @offer1 = Fabricate(:offer, state: 'accepted', partner_submission: Fabricate(:partner_submission, partner: @partner2))
         Fabricate(:offer, state: 'rejected', partner_submission: Fabricate(:partner_submission, partner: @partner2))
         Fabricate(:offer, state: 'draft', partner_submission: Fabricate(:partner_submission, partner: @partner1))
-        page.visit '/admin/offers'
+        page.visit admin_offers_path
       end
 
       it 'lets you click into a filter option', js: true do

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -57,6 +57,14 @@ describe 'admin/offers/show.html.erb', type: :feature do
       expect(page).to_not have_selector('#offer-delete-button')
     end
 
+    it 'shows information about the submission' do
+      expect(page).to have_content 'Submission'
+      within(:css, '.list-item--submission') do
+        expect(page).to have_content('Andy Warhol')
+        expect(page).to_not have_content('artist1')
+      end
+    end
+
     describe 'save & send' do
       it 'shows the save & send button when offer is in draft state' do
         offer.update_attributes!(state: 'draft')
@@ -155,15 +163,17 @@ describe 'admin/offers/show.html.erb', type: :feature do
 
     describe 'offer locked' do
       before do
-        offer.update_attributes!(state: 'locked')
+        accepted_offer = Fabricate(:offer, partner_submission: partner_submission)
+        offer.update_attributes!(state: 'review')
+        OfferService.consign!(accepted_offer)
         stub_gravity_artist(id: submission.artist_id)
         page.visit "/admin/offers/#{offer.id}"
       end
 
       it 'shows no actions' do
-        expect(page).to have_content('State locked')
+        expect(page).to have_content('State review')
+        expect(page).to have_content('This offer is locked')
         expect(page).to_not have_selector('.offer-draft-actions')
-        expect(page).to_not have_selector('.offer-actions')
       end
     end
 

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -197,6 +197,10 @@ describe 'admin/submissions/show.html.erb', type: :feature do
       it 'shows the consignment' do
         expect(page).to have_selector('.list-item--consignment')
         expect(page).to have_content('Consignment')
+
+        within(:css, '.list-item--consignment') do
+          expect(page).to have_content('Gob Bluth')
+        end
       end
     end
   end


### PR DESCRIPTION
It turns out that `locked` is actually a different concept than what I had originally thought. This PR updates based on that new understanding, described below.

If there are multiple offers on a submission...
- When one of the offers is consigned, all other offers are `locked`
- Being `locked` is mostly a visual cue, and it means that the offer cannot _also_ be consigned.
- When/if a consignment is canceled, the other offers will be "unlocked" and go back to the state they were prior to being "locked"
- While an offer is locked, it can still be rejected/lapsed/etc. I'm not sure when or if this will happen, but it seemed arbitrary to prevent us being able to track the state of offers even if another one is consigned.

Note that the fact that an offer is "locked" could be inferred by seeing if it is _not_ the `accepted_offer` on the parent `partner_submission`, but it seemed easier to store this value than to have to do an extra query. Open to discussing though!

![image](https://user-images.githubusercontent.com/2081340/36486769-52d787f6-16ed-11e8-81aa-35238f8c96b0.png)

![image](https://user-images.githubusercontent.com/2081340/36486793-5d0ecdec-16ed-11e8-9ec1-8227f491fd78.png)

The migration is only for staging (where there are a few offers):
```ruby
Offer.where(state: 'locked').each do |offer|
  offer.update_attributes!(state: 'review')
end
```