### PR TITLE
@ashkan18 => use correct google forms url and actually send emails

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -8,12 +8,13 @@ module UrlHelper
     utm_url("#{Convection.config.artsy_url}/#{path}", utm_params)
   end
 
-  def offer_form_url
-    Convection.config.auction_offer_form_url
+  def offer_form_url(submission_id: '')
+    Convection.config.auction_offer_form_url.gsub('SUBMISSION_NUMBER', submission_id.to_s)
   end
 
-  def offer_response_form_url
-    Convection.config.offer_response_form_url
+  def offer_response_form_url(submission_id: '', partner_name: '')
+    url = Convection.config.offer_response_form_url.gsub('SUBMISSION_NUMBER', submission_id.to_s)
+    url.gsub('PARTNER_NAME', partner_name)
   end
 
   private

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'Artsy <support@artsy.net>'
+  default from: 'Artsy <consign@artsy.net>'
   default bcc: Convection.config.bcc_email_address
   layout 'mailer'
 

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -19,7 +19,7 @@ class PartnerMailer < ApplicationMailer
     end
   end
 
-  def offer_introduction(offer:, artist:)
+  def offer_introduction(offer:, artist:, email:)
     @offer = offer
     @submission = offer.submission
     @artist = artist
@@ -28,21 +28,20 @@ class PartnerMailer < ApplicationMailer
     smtpapi category: ['offer'], unique_args: {
       offer_id: offer.id
     }
-    mail(to: Convection.config.debug_email_address,
+    mail(to: email,
          subject: 'The consignor has expressed interest in your offer')
   end
 
-  def offer_rejection_notification(offer:, artist:, user_name:)
+  def offer_rejection(offer:, artist:, email:)
     @offer = offer
     @submission = offer.submission
     @artist = artist
-    @user_name = user_name
     @utm_params = utm_params(source: 'consignment-offer-rejected', campaign: 'consignment-offer')
 
     smtpapi category: ['offer'], unique_args: {
       offer_id: offer.id
     }
-    mail(to: Convection.config.debug_email_address,
+    mail(to: email,
          subject: 'A response to your consignment offer')
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -80,16 +80,18 @@ class UserMailer < ApplicationMailer
          subject: 'An important update about your consignment submission')
   end
 
-  def offer(offer:, artist:)
+  def offer(offer:, artist:, user:, user_detail:)
     @offer = offer
     @submission = offer.submission
     @artist = artist
+    @user = user
+    @user_detail = user_detail
     @utm_params = utm_params(source: 'consignment-offer', campaign: 'consignment-offer')
 
     smtpapi category: ['offer'], unique_args: {
       offer_id: offer.id
     }
-    mail(to: Convection.config.debug_email_address,
+    mail(to: user_detail.email,
          subject: 'An offer for your consignment submission')
   end
 end

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -59,23 +59,41 @@ class OfferService
 
     def deliver_introduction(offer_id)
       offer = Offer.find(offer_id)
+
+      partner_emails = PartnerService.fetch_partner_contacts!(offer.partner)
+      partner_emails.each do |email|
+        delay.deliver_partner_contact_introduction(offer.id, email)
+      end
+    end
+
+    def deliver_partner_contact_introduction(offer_id, email)
+      offer = Offer.find(offer_id)
       artist = Gravity.client.artist(id: offer.submission.artist_id)._get
 
       PartnerMailer.offer_introduction(
         offer: offer,
-        artist: artist
+        artist: artist,
+        email: email
       ).deliver_now
     end
 
     def deliver_rejection_notification(offer_id)
       offer = Offer.find(offer_id)
-      artist = Gravity.client.artist(id: offer.submission.artist_id)._get
-      user_name = offer.submission.user.name
 
-      PartnerMailer.offer_rejection_notification(
+      partner_emails = PartnerService.fetch_partner_contacts!(offer.partner)
+      partner_emails.each do |email|
+        delay.deliver_partner_contact_rejection(offer.id, email)
+      end
+    end
+
+    def deliver_partner_contact_rejection(offer_id, email)
+      offer = Offer.find(offer_id)
+      artist = Gravity.client.artist(id: offer.submission.artist_id)._get
+
+      PartnerMailer.offer_rejection(
         offer: offer,
         artist: artist,
-        user_name: user_name
+        email: email
       ).deliver_now
     end
 
@@ -83,11 +101,17 @@ class OfferService
       offer = Offer.find(offer_id)
       return if offer.sent_at
 
+      user = Gravity.client.user(id: offer.submission.user.gravity_user_id)._get
+      user_detail = user.user_detail._get
+      raise 'User lacks email.' if user_detail.email.blank?
+
       artist = Gravity.client.artist(id: offer.submission.artist_id)._get
 
       UserMailer.offer(
         offer: offer,
-        artist: artist
+        artist: artist,
+        user: user,
+        user_detail: user_detail
       ).deliver_now
 
       offer.update_attributes!(sent_at: Time.now.utc, sent_by: current_user)

--- a/app/services/partner_service.rb
+++ b/app/services/partner_service.rb
@@ -1,0 +1,20 @@
+module PartnerService
+  class << self
+    def fetch_partner_contacts!(partner)
+      gravity_partner_id = partner.gravity_partner_id
+      partner_communication = Gravity.client.partner_communications(
+        name: Convection.config.consignment_communication_name
+      ).first
+
+      partner_contacts = Gravity.fetch_all(
+        partner_communication,
+        :partner_contacts,
+        partner_id: gravity_partner_id
+      )
+
+      raise "No contacts for #{partner.id}" unless partner_contacts.any?
+
+      partner_contacts.map(&:email)
+    end
+  end
+end

--- a/app/views/partner_mailer/offer_rejection.html.erb
+++ b/app/views/partner_mailer/offer_rejection.html.erb
@@ -168,7 +168,7 @@
             <table class='full-width-button'>
               <tr>
                 <td class='offer-response-button'>
-                  <%= link_to('Create counter-offer', offer_form_url) %>
+                  <%= link_to('Create counter-offer', offer_form_url(submission_id: @submission.id)) %>
                 </td>
               </tr>
             </table>

--- a/app/views/user_mailer/offer.html.erb
+++ b/app/views/user_mailer/offer.html.erb
@@ -60,7 +60,7 @@
             <table class='full-width-button'>
               <tr>
                   <td class='offer-response-button'>
-                    <%= link_to('Reply to this offer', offer_response_form_url) %>
+                    <%= link_to('Reply to this offer', offer_response_form_url(submission_id: @submission.id, partner_name: @offer.partner.name)) %>
                   </td>
               </tr>
             </table>

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -17,11 +17,33 @@ describe UrlHelper, type: :helper do
 
   describe '#offer_form_url' do
     before do
-      allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction')
+      allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction?entry.blahblah=SUBMISSION_NUMBER')
     end
 
     it 'returns the correct url for an auction' do
-      expect(helper.offer_form_url).to eq('https://google.com/auction')
+      expect(helper.offer_form_url).to eq('https://google.com/auction?entry.blahblah=')
+    end
+
+    it 'correctly replaces the submission number if one is supplied' do
+      expect(helper.offer_form_url(submission_id: 123)).to eq('https://google.com/auction?entry.blahblah=123')
+    end
+  end
+
+  describe '#offer_response_form_url' do
+    before do
+      allow(Convection.config).to receive(:offer_response_form_url).and_return(
+        'https://google.com/response?entry.blahblah=SUBMISSION_NUMBER&entry.blah2=PARTNER_NAME'
+      )
+    end
+
+    it 'returns the correct url for a user to respond' do
+      expect(helper.offer_response_form_url).to eq('https://google.com/response?entry.blahblah=&entry.blah2=')
+    end
+
+    it 'correctly replaces the submission number if one is supplied' do
+      expect(helper.offer_response_form_url(submission_id: 123, partner_name: 'gagosian gallery')).to eq(
+        'https://google.com/response?entry.blahblah=123&entry.blah2=gagosian gallery'
+      )
     end
   end
 end

--- a/spec/mailers/previews/partner_mailer_preview.rb
+++ b/spec/mailers/previews/partner_mailer_preview.rb
@@ -16,8 +16,8 @@ class PartnerMailerPreview < BasePreview
     )
   end
 
-  def offer_rejection_notification
-    PartnerMailer.offer_rejection_notification(
+  def offer_rejection
+    PartnerMailer.offer_rejection(
       offer: auction_offer,
       artist: OpenStruct.new(id: 'artist_id', name: 'Andy Warhol'),
       user_name: 'Lucille Bluth'

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -127,6 +127,7 @@ describe SubmissionService do
       expect(emails.length).to eq 1
       expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
       expect(emails.first.to).to eq(['michael@bluth.com'])
+      expect(emails.first.from).to eq(['consign@artsy.net'])
       expect(emails.first.html_part.body).to include(
         'they do not have a market for this work at the moment'
       )
@@ -171,6 +172,7 @@ describe SubmissionService do
         expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
         expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e01')
         expect(emails.first.to).to eq(['michael@bluth.com'])
+        expect(emails.first.from).to eq(['consign@artsy.net'])
         expect(submission.reload.receipt_sent_at).to be nil
         expect(submission.reload.reminders_sent_count).to eq 1
       end
@@ -185,6 +187,7 @@ describe SubmissionService do
         expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
         expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e02')
         expect(emails.first.to).to eq(['michael@bluth.com'])
+        expect(emails.first.from).to eq(['consign@artsy.net'])
         expect(submission.reload.receipt_sent_at).to be nil
         expect(submission.reload.reminders_sent_count).to eq 2
       end
@@ -199,6 +202,7 @@ describe SubmissionService do
         expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
         expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e03')
         expect(emails.first.to).to eq(['michael@bluth.com'])
+        expect(emails.first.from).to eq(['consign@artsy.net'])
         expect(submission.reload.receipt_sent_at).to be nil
         expect(submission.reload.reminders_sent_count).to eq 3
       end


### PR DESCRIPTION
This PR updates our offers flow to:
- use a pre-filled form link (so the user doesn't have to add the submission numbers themselves)
- send all emails from `consign@artsy.net` (per request by Erin)
- send all emails to the correct addresses