### PR TITLE
Fix default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,10 @@ if Rails.env.development? || Rails.env.test?
   desc 'Run RuboCop'
   RuboCop::RakeTask.new(:rubocop)
 
+  Rake::Task[:spec].clear
   RSpec::Core::RakeTask.new(:spec) do |t|
     test_output = File.join(ENV.fetch('CIRCLE_TEST_REPORTS', 'tmp'), 'rspec', 'junit.xml')
-    t.rspec_opts = %W[-f JUnit -o #{test_output}]
+    t.rspec_opts = %W[--format progress --format JUnit --out #{test_output}]
   end
 
   task 'print_schema' => :environment do
@@ -17,5 +18,6 @@ if Rails.env.development? || Rails.env.test?
     puts GraphQL::Schema::Printer.new(RootSchema).print_schema
   end
 
+  Rake::Task[:default].clear
   task default: [:rubocop, :spec]
 end


### PR DESCRIPTION
I've suspected that convection was somehow running rspec twice when you use the default rake task, so I spent a little time today trying to confirm that hunch and then fix it. Here's my proof and solution.

When you run just `rspec`, the timing looks like this:

```
jon@magneto:~/code/convection(fix-default-rake-task*)% time rspec
Randomized with seed 51312
......................................................................................................................................2018-03-01 08:49:41.894 webkit_server[88441:13092816] Cannot find executable for CFBundle 0x7ffa2be5fe50 </Library/Internet Plug-Ins/Disabled Plug-Ins> (not loaded)........................................................................................................................................................................................................................................................................................................

Finished in 1 minute 20.97 seconds (files took 2.95 seconds to load)
430 examples, 0 failures

Randomized with seed 51312

rspec  62.51s user 5.87s system 80% cpu 1:24.42 total
```

So we're looking at about a minute and a half - nice!

I started by reviewing the Rakefile and the rspec docs. In the Rakefile, we define a `spec` task that outputs in the JUnit format. I confirmed in [the rspec docs][docs] that you can add multiple formats to a single rspec run, so now that task will output both progress and JUnit formats.

[docs]: https://relishapp.com/rspec/rspec-core/v/2-5/docs/command-line/format-option

When you run the default rake task, the timing looks like this:

```
jon@magneto:~/code/convection(fix-default-rake-task*)% time rake
/Users/jon/.rvm/rubies/ruby-2.5.0/bin/ruby -I/Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-core-3.7.1/lib:/Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-support-3.7.0/lib /Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-core-3.7.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

Randomized with seed 14317
.........................................................2018-03-01 08:44:10.713 webkit_server[88303:13088743] Cannot find executable for CFBundle 0x7fbee5beeb40 </Library/Internet Plug-Ins/Disabled Plug-Ins> (not loaded).....................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1 minute 20.41 seconds (files took 2.97 seconds to load)
430 examples, 0 failures

Randomized with seed 14317

/Users/jon/.rvm/rubies/ruby-2.5.0/bin/ruby -I/Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-core-3.7.1/lib:/Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-support-3.7.0/lib /Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-core-3.7.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --format progress --format JUnit --out tmp/rspec/junit.xml

Randomized with seed 65526
....................................................................2018-03-01 08:45:24.859 webkit_server[88343:13089781] Cannot find executable for CFBundle 0x7ff15b41e030 </Library/Internet Plug-Ins/Disabled Plug-Ins> (not loaded)..........................................................................................................................................................................................................................................................................................................................................................................

Finished in 1 minute 22.47 seconds (files took 3.03 seconds to load)
430 examples, 0 failures

Randomized with seed 65526

Running RuboCop...
.rubocop.yml: Style/AlignParameters has the wrong namespace - should be Layout
Inspecting 146 files
..................................................................................................................................................

146 files inspected, no offenses detected
rake  126.99s user 12.67s system 80% cpu 2:53.28 total

```

Close to three minutes, which just happens to be about twice the time of an individual rspec run. Then, upon further examination you'll see two chunks of rspec output. Since the rspec-rails gem already defines the `spec` task and we haven't cleared that task before defining it again, rake just happily runs them both. Ugh. 😭 

Once we clear the `spec` task before defining it, we get timing like this:

```
jon@magneto:~/code/convection(fix-default-rake-task*)% time rake
/Users/jon/.rvm/rubies/ruby-2.5.0/bin/ruby -I/Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-core-3.7.1/lib:/Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-support-3.7.0/lib /Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-core-3.7.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --format progress --format JUnit --out tmp/rspec/junit.xml

Randomized with seed 43377
........................................................................................................................................................................................................................................................................................................................................................................................2018-03-01 08:42:42.250 webkit_server[88235:13085829] Cannot find executable for CFBundle 0x7fe57af31770 </Library/Internet Plug-Ins/Disabled Plug-Ins> (not loaded) ......................................................

Finished in 1 minute 21.58 seconds (files took 3.17 seconds to load)
430 examples, 0 failures

Randomized with seed 43377

Running RuboCop...
.rubocop.yml: Style/AlignParameters has the wrong namespace - should be Layout
Inspecting 146 files
..................................................................................................................................................

146 files inspected, no offenses detected
rake  65.96s user 6.77s system 81% cpu 1:28.91 total
```

Boom, back to about a minute and a half.

But we've also defined the default task to be rubocop first and then spec - what gives? Same thing - rspec-rails has defined the default task to be running spec, so when we have to clear that too. Once we do that, then we get this output:

```
jon@magneto:~/code/convection(fix-default-rake-task*)% time rake
Running RuboCop...
.rubocop.yml: Style/AlignParameters has the wrong namespace - should be Layout
Inspecting 146 files
..................................................................................................................................................

146 files inspected, no offenses detected
/Users/jon/.rvm/rubies/ruby-2.5.0/bin/ruby -I/Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-core-3.7.1/lib:/Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-support-3.7.0/lib /Users/jon/.rvm/gems/ruby-2.5.0@convection/gems/rspec-core-3.7.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb --format progress --format JUnit --out tmp/rspec/junit.xml

Randomized with seed 31870
...............................................2018-03-01 08:51:52.215 webkit_server[88521:13095344] Cannot find executable for CFBundle 0x7fab0b4ce960 </Library/Internet Plug-Ins/Disabled Plug-Ins> (not loaded)...............................................................................................................................................................................................................................................................................................................................................................................................

Finished in 1 minute 22.88 seconds (files took 2.97 seconds to load)
430 examples, 0 failures

Randomized with seed 31870

rake  64.96s user 6.77s system 79% cpu 1:29.85 total
```

RuboCop first, then RSpec, but only once - phew!

Finally, let's talk about this redefining of the spec task in the Rakefile. I think this was done in order to have historic timing at Circle - correct me if I'm wrong! If so, then I think this is premature optimization. With a test suite at a minute and a half, I see no reason to not use the default task that the rspec-rails gem gives us. I didn't go this direction in this PR just because I didn't want to muddy the waters, but I'm happy to add a commit if people agree.

Note: I don't quite understand that webkit_server message in the test output, but maybe it's something with my machine? Would love to know more about it if anyone knows!!