### PR TITLE
@ashkinas => update dashboard to work with zero consignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /tmp
 .env
 public
+latest.dump
 
 .DS_Store
 .byebug_history

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -27,8 +27,8 @@ module Admin
     end
 
     expose(:artist_details) do
-      submission_artists = artists_query(submissions.map(&:artist_id))
-      consignment_artists = artists_query(consignments.map(&:submission).map(&:artist_id))
+      submission_artists = artists_query(submissions.map(&:artist_id)) || {}
+      consignment_artists = artists_query(consignments.map(&:submission).map(&:artist_id)) || {}
       submission_artists.merge(consignment_artists)
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -135,8 +135,8 @@ ActiveRecord::Schema.define(version: 20180226122325) do
     t.integer "primary_image_id"
     t.integer "consigned_partner_submission_id"
     t.string "user_email"
-    t.integer "offers_count", default: 0
     t.integer "user_id"
+    t.integer "offers_count", default: 0
     t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
     t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
     t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"

--- a/spec/views/admin/dashboard/index.html.erb_spec.rb
+++ b/spec/views/admin/dashboard/index.html.erb_spec.rb
@@ -32,6 +32,34 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
       expect(page).not_to have_selector('.list-group-item')
     end
 
+    context 'with just submissions' do
+      before do
+        6.times { Fabricate(:submission, state: 'submitted') }
+        page.visit '/'
+      end
+
+      it 'displays four submissions' do
+        expect(page).to have_selector('.list-item--offer', count: 0)
+        expect(page).to have_selector('.list-item--submission', count: 4)
+        expect(page).to have_selector('.list-item--consignment', count: 0)
+        expect(page).to have_content('Unreviewed Submissions 6')
+        expect(page).to have_content('Open Offers 0')
+        expect(page).to have_content('Active Consignments 0')
+      end
+
+      it 'lets you click a submission' do
+        submission = Submission.submitted.order(id: :desc).first
+        stub_gravity_root
+        stub_gravity_user(id: submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: submission.user.gravity_user_id)
+        stub_gravity_artist(id: submission.artist_id)
+
+        find(".list-item--submission[data-id='#{submission.id}']").click
+        expect(page).to have_content("Submission ##{submission.id}")
+        expect(page).to have_content('State submitted')
+      end
+    end
+
     context 'with some offers and submissions and consignments' do
       before do
         5.times { Fabricate(:offer, state: 'sent') }


### PR DESCRIPTION
Noticed this bug in production! There are no consignments, so we were trying to `merge` with `nil`.