### PR TITLE
@sweir27 => Rename some GraphQL mutations to match Metaphysics version

### DIFF
--- a/app/graph/mutations.rb
+++ b/app/graph/mutations.rb
@@ -2,38 +2,38 @@ module Mutations
   Root = GraphQL::ObjectType.define do
     name 'Mutation'
 
-    field :createSubmission, Types::SubmissionType do
+    field :createConsignmentSubmission, Types::SubmissionType do
       description 'Create a submission'
-      argument :submission, Inputs::SubmissionInput::Create
+      argument :input, Inputs::SubmissionInput::Create
       permit :user
       resolve ->(_obj, args, context) {
-        SubmissionService.create_submission(args[:submission].to_h, context[:current_user])
+        SubmissionService.create_submission(args[:input].to_h, context[:current_user])
       }
     end
 
-    field :updateSubmission, Types::SubmissionType do
+    field :updateConsignmentSubmission, Types::SubmissionType do
       description 'Create a submission'
-      argument :submission, Inputs::SubmissionInput::Update
+      argument :input, Inputs::SubmissionInput::Update
       permit :user
 
       resolve ->(_obj, args, context) {
-        submission = Submission.find_by(id: args[:submission][:id])
+        submission = Submission.find_by(id: args[:input][:id])
         raise(GraphQL::ExecutionError, 'Submission from ID Not Found') unless submission
 
         is_same_as_user = submission&.user&.gravity_user_id == context[:current_user]
         is_admin = context[:current_user_roles].include?(:admin)
 
         raise(GraphQL::ExecutionError, 'Submission Not Found') unless is_same_as_user || is_admin
-        SubmissionService.update_submission(submission, args[:submission].to_h.except(:id))
+        SubmissionService.update_submission(submission, args[:input].to_h.except(:id))
         submission
       }
     end
 
-    field :createAsset, Types::AssetType do
+    field :addAssetToConsignmentSubmission, Types::AssetType do
       description 'Create an asset'
       argument :submission_id, !types.ID, 'The ID for a submission'
       argument :gemini_token, !types.String, 'The token returned from Gemini'
-      argument :type, types.String, 'The type of asset', default_value: 'image'
+      argument :asset_type, types.String, 'The type of asset', default_value: 'image'
 
       resolve ->(_obj, args, context) {
         submission = Submission.find_by(id: args[:submission_id])
@@ -45,8 +45,7 @@ module Mutations
         raise(GraphQL::ExecutionError, 'Submission from ID Not Found') unless is_same_as_user || is_admin
 
         asset_props = args.to_h
-        asset_props['asset_type'] = asset_props['type']
-        asset = submission.assets.create!(asset_props.except('type'))
+        asset = submission.assets.create!(asset_props)
         SubmissionService.notify_user(submission.id) if submission.submitted?
         asset
       }

--- a/spec/requests/api/graphql/create_spec.rb
+++ b/spec/requests/api/graphql/create_spec.rb
@@ -8,7 +8,7 @@ describe 'Create Submission With Graphql' do
   let(:create_mutation) do
     <<-GRAPHQL
     mutation {
-      createSubmission(submission: { artist_id: "andy", title: "soup" }){
+      createConsignmentSubmission(input: { artist_id: "andy", title: "soup" }){
         id,
         title
       }
@@ -19,7 +19,7 @@ describe 'Create Submission With Graphql' do
   let(:create_mutation_no_artist_id) do
     <<-GRAPHQL
     mutation {
-      createSubmission(submission: { title: "soup" }){
+      createConsignmentSubmission(input: { title: "soup" }){
         id,
         title
       }
@@ -34,8 +34,8 @@ describe 'Create Submission With Graphql' do
       }, headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body['data']['createSubmission']).to eq nil
-      expect(body['errors'][0]['message']).to eq "Can't access createSubmission"
+      expect(body['data']['createConsignmentSubmission']).to eq nil
+      expect(body['errors'][0]['message']).to eq "Can't access createConsignmentSubmission"
     end
 
     it 'rejects requests without an app token' do
@@ -45,8 +45,8 @@ describe 'Create Submission With Graphql' do
       }, headers: { 'Authorization' => "Bearer #{user_token}" }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body['data']['createSubmission']).to eq nil
-      expect(body['errors'][0]['message']).to eq "Can't access createSubmission"
+      expect(body['data']['createConsignmentSubmission']).to eq nil
+      expect(body['errors'][0]['message']).to eq "Can't access createConsignmentSubmission"
     end
 
     it 'rejects when missing artist_id' do
@@ -65,8 +65,8 @@ describe 'Create Submission With Graphql' do
         }, headers: headers
         expect(response.status).to eq 200
         body = JSON.parse(response.body)
-        expect(body['data']['createSubmission']['id']).not_to be_nil
-        expect(body['data']['createSubmission']['title']).to eq 'soup'
+        expect(body['data']['createConsignmentSubmission']['id']).not_to be_nil
+        expect(body['data']['createConsignmentSubmission']['title']).to eq 'soup'
       end.to change(Submission, :count).by(1)
     end
 
@@ -76,7 +76,7 @@ describe 'Create Submission With Graphql' do
 
         create_asset = <<-GRAPHQL
         mutation {
-          createAsset(submission_id: #{submission.id}, gemini_token: "gemini-token-hash"){
+          addAssetToConsignmentSubmission(submission_id: #{submission.id}, gemini_token: "gemini-token-hash"){
             id,
             submission {
               id
@@ -91,8 +91,8 @@ describe 'Create Submission With Graphql' do
         expect(response.status).to eq 200
 
         body = JSON.parse(response.body)
-        expect(body['data']['createAsset']['id']).not_to be_nil
-        expect(body['data']['createAsset']['submission']).not_to be_nil
+        expect(body['data']['addAssetToConsignmentSubmission']['id']).not_to be_nil
+        expect(body['data']['addAssetToConsignmentSubmission']['submission']).not_to be_nil
       end.to change(Asset, :count).by(1)
     end
   end

--- a/spec/requests/api/graphql/update_spec.rb
+++ b/spec/requests/api/graphql/update_spec.rb
@@ -10,7 +10,7 @@ describe 'Update Submission With Graphql' do
   let(:update_mutation) do
     <<-GRAPHQL
     mutation {
-      updateSubmission(submission: { id: #{submission.id}, artist_id: "andy-warhol", title: "soup" }){
+      updateConsignmentSubmission(input: { id: #{submission.id}, artist_id: "andy-warhol", title: "soup" }){
         id,
         artist_id,
         title
@@ -22,7 +22,7 @@ describe 'Update Submission With Graphql' do
   let(:update_mutation_random_id) do
     <<-GRAPHQL
     mutation {
-      updateSubmission(submission: { id: 999999, artist_id: "andy-warhol", title: "soup" }){
+      updateConsignmentSubmission(input: { id: 999999, artist_id: "andy-warhol", title: "soup" }){
         id,
         title
       }
@@ -37,8 +37,8 @@ describe 'Update Submission With Graphql' do
       }, headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body['data']['updateSubmission']).to eq nil
-      expect(body['errors'][0]['message']).to eq "Can't access updateSubmission"
+      expect(body['data']['updateConsignmentSubmission']).to eq nil
+      expect(body['errors'][0]['message']).to eq "Can't access updateConsignmentSubmission"
     end
 
     it 'rejects requests without and app token' do
@@ -48,8 +48,8 @@ describe 'Update Submission With Graphql' do
       }, headers: { 'Authorization' => "Bearer #{user_token}" }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body['data']['updateSubmission']).to eq nil
-      expect(body['errors'][0]['message']).to eq "Can't access updateSubmission"
+      expect(body['data']['updateConsignmentSubmission']).to eq nil
+      expect(body['errors'][0]['message']).to eq "Can't access updateConsignmentSubmission"
     end
 
     it 'rejects requests to update a submission that you do not own' do
@@ -59,7 +59,7 @@ describe 'Update Submission With Graphql' do
       }, headers: { 'Authorization' => "Bearer #{another_token}" }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body['data']['updateSubmission']).to eq nil
+      expect(body['data']['updateConsignmentSubmission']).to eq nil
       expect(body['errors'][0]['message']).to eq 'Submission Not Found'
     end
 
@@ -75,9 +75,9 @@ describe 'Update Submission With Graphql' do
       }, headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body['data']['updateSubmission']['id'].to_i).to eq submission.id
-      expect(body['data']['updateSubmission']['title']).to eq 'soup'
-      expect(body['data']['updateSubmission']['artist_id']).to eq 'andy-warhol'
+      expect(body['data']['updateConsignmentSubmission']['id'].to_i).to eq submission.id
+      expect(body['data']['updateConsignmentSubmission']['title']).to eq 'soup'
+      expect(body['data']['updateConsignmentSubmission']['artist_id']).to eq 'andy-warhol'
     end
   end
 end


### PR DESCRIPTION
If nothing is using this directly yet, then this might be the best/easiest change (I think...).

cc @orta 

So with stitching enabled in production, I get the following error on device:

<img width="774" alt="screen shot 2018-03-22 at 3 29 21 pm" src="https://user-images.githubusercontent.com/1457859/37793714-d3e5682c-2de5-11e8-9c71-f533e2552cf4.png">


Looking at the mutations that are used, they are all named slightly differently in Metaphysics' version.

Since we can't break deployed devices, we have two options:
  - handle this mapping/rename in Metaphysics
  - just rename it here

I'm not sure how to do that first thing, it seems like it _might_ be possible using the stitching libraries but I'm not familiar enough yet to say that confidently. So, figured I'd PR this and see what people think.