### PR TITLE
@sweir27 => Update create submission mutation to match Metaphysics/Relay style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ LineLength:
   Max: 139
   IgnoreCopDirectives: true
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
 Style/FrozenStringLiteralComment:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "rebornix.ruby",
-    "jemmyw.rails-fast-nav"
+    "jemmyw.rails-fast-nav",
+    "kumar-harsh.graphql-for-vscode"
   ]
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.8)
       rails
-    graphql (1.7.8)
+    graphql (1.7.13)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt

--- a/app/graph/mutations.rb
+++ b/app/graph/mutations.rb
@@ -1,13 +1,42 @@
 module Mutations
+  CreateConsignmentSubmission = GraphQL::Relay::Mutation.define do
+    name 'CreateConsignmentSubmission'
+
+    input_field :additional_info, types.String
+    input_field :artist_id, !types.String
+    input_field :authenticity_certificate, types.Boolean
+    input_field :category, types.String
+    input_field :depth, types.String
+    input_field :dimensions_metric, types.String
+    input_field :edition, types.Boolean
+    input_field :edition_number, types.String
+    input_field :edition_size, types.Int
+    input_field :height, types.String
+    input_field :location_city, types.String
+    input_field :location_country, types.String
+    input_field :location_state, types.String
+    input_field :medium, types.String
+    input_field :provenance, types.String
+    input_field :signature, types.Boolean
+    input_field :state, types.String
+    input_field :title, types.String
+    input_field :width, types.String
+    input_field :year, types.String
+
+    return_field :consignment_submission, Types::SubmissionType
+  end
+
   Root = GraphQL::ObjectType.define do
     name 'Mutation'
 
-    field :createConsignmentSubmission, Types::SubmissionType do
-      description 'Create a submission'
-      argument :input, Inputs::SubmissionInput::Create
+    field :createConsignmentSubmission, CreateConsignmentSubmission.return_type do
       permit :user
+      argument :input, CreateConsignmentSubmission.input_type
       resolve ->(_obj, args, context) {
-        SubmissionService.create_submission(args[:input].to_h, context[:current_user])
+        params = args.to_h['input'].except('clientMutationId')
+        client_mutation_id = args.to_h['input']['clientMutationId']
+        submission = SubmissionService.create_submission(params, context[:current_user])
+        OpenStruct.new(consignment_submission: submission, client_mutation_id: client_mutation_id)
       }
     end
 

--- a/spec/requests/api/graphql/create_spec.rb
+++ b/spec/requests/api/graphql/create_spec.rb
@@ -8,9 +8,12 @@ describe 'Create Submission With Graphql' do
   let(:create_mutation) do
     <<-GRAPHQL
     mutation {
-      createConsignmentSubmission(input: { artist_id: "andy", title: "soup" }){
-        id,
-        title
+      createConsignmentSubmission(input: { clientMutationId: "2", artist_id: "andy", title: "soup" }){
+        clientMutationId
+        consignment_submission {
+          id
+          title
+        }
       }
     }
     GRAPHQL
@@ -20,8 +23,10 @@ describe 'Create Submission With Graphql' do
     <<-GRAPHQL
     mutation {
       createConsignmentSubmission(input: { title: "soup" }){
-        id,
-        title
+        consignment_submission {
+          id
+          title
+        }
       }
     }
     GRAPHQL
@@ -65,8 +70,9 @@ describe 'Create Submission With Graphql' do
         }, headers: headers
         expect(response.status).to eq 200
         body = JSON.parse(response.body)
-        expect(body['data']['createConsignmentSubmission']['id']).not_to be_nil
-        expect(body['data']['createConsignmentSubmission']['title']).to eq 'soup'
+        expect(body['data']['createConsignmentSubmission']['consignment_submission']['id']).not_to be_nil
+        expect(body['data']['createConsignmentSubmission']['consignment_submission']['title']).to eq 'soup'
+        expect(body['data']['createConsignmentSubmission']['clientMutationId']).to eq '2'
       end.to change(Submission, :count).by(1)
     end
 


### PR DESCRIPTION
This starts updating the GraphQL API to match the existing Metaphysics one. Essentially we need to update the mutations here to be relay-style.

This starts by updating the 'create a submission' mutation to match MP.