### PR TITLE
@orta => Convert category to an enum

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,7 +21,7 @@ LineLength:
   Exclude:
     - config/environments/*
     - config/initializers/*
-  Max: 139
+  Max: 145
   IgnoreCopDirectives: true
 
 Layout/AlignParameters:

--- a/app/graph/mutations.rb
+++ b/app/graph/mutations.rb
@@ -5,7 +5,7 @@ module Mutations
     input_field :additional_info, types.String
     input_field :artist_id, !types.String
     input_field :authenticity_certificate, types.Boolean
-    input_field :category, types.String
+    input_field :category, Types::CategoryType
     input_field :depth, types.String
     input_field :dimensions_metric, types.String
     input_field :edition, types.Boolean
@@ -33,7 +33,7 @@ module Mutations
     input_field :additional_info, types.String
     input_field :artist_id, types.String
     input_field :authenticity_certificate, types.Boolean
-    input_field :category, types.String
+    input_field :category, Types::CategoryType
     input_field :depth, types.String
     input_field :dimensions_metric, types.String
     input_field :edition, types.Boolean

--- a/app/graph/types/category_type.rb
+++ b/app/graph/types/category_type.rb
@@ -1,0 +1,20 @@
+module Types
+  CategoryType = GraphQL::EnumType.define do
+    name 'Category'
+    value('PAINTING', nil, value: 'Painting')
+    value('SCULPTURE', nil, value: 'Sculpture')
+    value('PHOTOGRAPHY', nil, value: 'Photography')
+    value('PRINT', nil, value: 'Print')
+    value('DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER', nil, value: 'Drawing, Collage or other Work on Paper')
+    value('MIXED_MEDIA', nil, value: 'Mixed Media')
+    value('PERFORMANCE_ART', nil, value: 'Performance Art')
+    value('INSTALLATION', nil, value: 'Installation')
+    value('VIDEO_FILM_ANIMATION', nil, value: 'Video/Film/Animation')
+    value('ARCHITECTURE', nil, value: 'Architecture')
+    value('FASHION_DESIGN_AND_WEARABLE_ART', nil, value: 'Fashion Design and Wearable Art')
+    value('JEWELRY', nil, value: 'Jewelry')
+    value('DESIGN_DECORATIVE_ART', nil, value: 'Design/Decorative Art')
+    value('TEXTILE_ARTS', nil, value: 'Textile Arts')
+    value('OTHER', nil, value: 'Other')
+  end
+end

--- a/app/graph/types/submission_type.rb
+++ b/app/graph/types/submission_type.rb
@@ -8,7 +8,7 @@ module Types
     field :user_id, !types.String
     field :artist_id, !types.String
     field :authenticity_certificate, types.Boolean
-    field :category, types.String
+    field :category, Types::CategoryType
     field :depth, types.String
     field :dimensions_metric, types.String
     field :edition, types.String

--- a/spec/requests/api/graphql/create_spec.rb
+++ b/spec/requests/api/graphql/create_spec.rb
@@ -8,11 +8,12 @@ describe 'Create Submission With Graphql' do
   let(:create_mutation) do
     <<-GRAPHQL
     mutation {
-      createConsignmentSubmission(input: { clientMutationId: "2", artist_id: "andy", title: "soup" }){
+      createConsignmentSubmission(input: { clientMutationId: "2", artist_id: "andy", title: "soup", category: JEWELRY }){
         clientMutationId
         consignment_submission {
           id
           title
+          category
         }
       }
     }
@@ -72,6 +73,7 @@ describe 'Create Submission With Graphql' do
         body = JSON.parse(response.body)
         expect(body['data']['createConsignmentSubmission']['consignment_submission']['id']).not_to be_nil
         expect(body['data']['createConsignmentSubmission']['consignment_submission']['title']).to eq 'soup'
+        expect(body['data']['createConsignmentSubmission']['consignment_submission']['category']).to eq 'JEWELRY'
         expect(body['data']['createConsignmentSubmission']['clientMutationId']).to eq '2'
       end.to change(Submission, :count).by(1)
     end

--- a/spec/requests/api/graphql/update_spec.rb
+++ b/spec/requests/api/graphql/update_spec.rb
@@ -4,15 +4,16 @@ describe 'Update Submission With Graphql' do
   let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid', roles: 'user' }, Convection.config.jwt_secret) }
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
   let(:submission) do
-    Fabricate(:submission, artist_id: 'abbas-kiarostami', title: 'rain', user: Fabricate(:user, gravity_user_id: 'userid'))
+    Fabricate(:submission, category: 'Painting', artist_id: 'abbas-kiarostami', title: 'rain', user: Fabricate(:user, gravity_user_id: 'userid'))
   end
 
   let(:update_mutation) do
     <<-GRAPHQL
     mutation {
-      updateConsignmentSubmission(input: { clientMutationId: "test", id: #{submission.id}, artist_id: "andy-warhol", title: "soup" }){
+      updateConsignmentSubmission(input: { category: JEWELRY, clientMutationId: "test", id: #{submission.id}, artist_id: "andy-warhol", title: "soup" }){
         clientMutationId
         consignment_submission {
+          category
           id
           artist_id
           title
@@ -85,6 +86,7 @@ describe 'Update Submission With Graphql' do
       expect(body['data']['updateConsignmentSubmission']['consignment_submission']['id'].to_i).to eq submission.id
       expect(body['data']['updateConsignmentSubmission']['consignment_submission']['title']).to eq 'soup'
       expect(body['data']['updateConsignmentSubmission']['consignment_submission']['artist_id']).to eq 'andy-warhol'
+      expect(body['data']['updateConsignmentSubmission']['consignment_submission']['category']).to eq 'JEWELRY'
     end
   end
 end


### PR DESCRIPTION
So now that the mutations have all been updated to match the correct input/output signatures, I was going thru the flow, and noticed this error:

<img width="731" alt="screen shot 2018-03-23 at 2 20 47 pm" src="https://user-images.githubusercontent.com/1457859/37846900-79132a68-2ea5-11e8-80ff-155cf05c978e.png">

This converts them from strings to the expected enums.