### PR TITLE
Downgrade graphiql-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'bootstrap-sass' # required for watt
 gem 'bourbon', '4.2.3' # required for watt
 gem 'coffee-rails' # required for watt
 gem 'decent_exposure' # for safely referencing variables in views
-gem 'graphiql-rails' # A lovely interface to the API
+gem 'graphiql-rails', '1.4.8' # A lovely interface to the API
 gem 'graphql' # A lovely API
 gem 'haml-rails' # required for watt layouts
 gem 'hyperclient' # consume Gravity's v2 API

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,9 +123,8 @@ GEM
       thor (~> 0.19.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    graphiql-rails (1.4.10)
-      railties
-      sprockets-rails
+    graphiql-rails (1.4.8)
+      rails
     graphql (1.7.13)
     haml (5.0.4)
       temple (>= 0.8.0)
@@ -371,7 +370,7 @@ DEPENDENCIES
   fabrication
   foreman
   gemini_upload-rails!
-  graphiql-rails
+  graphiql-rails (= 1.4.8)
   graphql
   haml-rails
   hyperclient


### PR DESCRIPTION
I found that I was not able to precompile assets in production mode with the newer version of this gem - see this failing build:

https://circleci.com/gh/artsy/convection/505

So I ended up trying to reproduce this locally and was able to. I compared precompiles in dev and production mode and found that it was the `/public/assets/graphiql/rails/application.js` file that it was barfing on. Then I rolled back the graphiql-rails gem and tried again - it worked. 🤷‍♂️ 

I took a look at the changelog for that gem:

https://github.com/rmosolgo/graphiql-rails/blob/master/changelog.md

But I'm not seeing much here. I also scanned issues and PRs, but nothing jumped out at me. Would need to do more investigation in order to have a theory on what's going on here, but I want to fix the issue and get production deployed so that's the focus for now.