### PR TITLE
@mzikherman => allow percent/dollar fields to be unset + don't truncate note from partner

### DIFF
--- a/app/models/concerns/dollarize.rb
+++ b/app/models/concerns/dollarize.rb
@@ -15,9 +15,12 @@ module Dollarize
         end
 
         define_method "#{method_name.to_s.gsub(/_cents$/, '_dollars')}=" do |dollars|
-          return if dollars.blank?
-          cents = dollars.to_f * 100
-          self[method_name] = cents
+          if dollars.blank?
+            self[method_name] = nil
+          else
+            cents = dollars.to_f * 100
+            self[method_name] = cents
+          end
         end
 
         define_method method_name.to_s.gsub(/_cents$/, '_display') do

--- a/app/models/concerns/percentize.rb
+++ b/app/models/concerns/percentize.rb
@@ -15,9 +15,12 @@ module Percentize
         end
 
         define_method "#{method_name}_whole=" do |percent_whole|
-          return if percent_whole.blank?
-          percentage = percent_whole.to_f / 100
-          self[method_name] = percentage
+          if percent_whole.blank?
+            self[method_name] = nil
+          else
+            percentage = percent_whole.to_f / 100
+            self[method_name] = percentage
+          end
         end
       end
     end

--- a/app/views/shared/email/_offer_note.html.erb
+++ b/app/views/shared/email/_offer_note.html.erb
@@ -12,7 +12,7 @@
         </tr>
         <tr>
           <td class='email-content-serif email-content-serif--small bottom-element top-element'>
-            <%= @offer.notes.try(:truncate, 600) %>
+            <%= @offer.notes %>
           </td>
         </tr>
       </table>

--- a/spec/controllers/admin/offers_controller_spec.rb
+++ b/spec/controllers/admin/offers_controller_spec.rb
@@ -199,6 +199,16 @@ describe Admin::OffersController, type: :controller do
         expect(retail_offer.reload).to have_attributes(new_params)
       end
 
+      it 'allows you to un-set fields' do
+        retail_offer = Fabricate(:offer, offer_type: 'retail', insurance_dollars: 10, insurance_percent_whole: 12)
+        put :update, params: {
+          id: retail_offer.id,
+          offer: { insurance_dollars: nil, insurance_percent_whole: nil }
+        }
+        expect(retail_offer.reload.insurance_cents).to eq nil
+        expect(retail_offer.reload.insurance_percent_whole).to eq nil
+      end
+
       it 'remains on the edit view and shows an error on failure' do
         put :update, params: { id: offer.id, offer: { offer_type: 'bogus type' } }
         expect(response).to render_template(:edit)


### PR DESCRIPTION
For the setter methods on `dollarize` and `percentize`, we need to explicitly set them to nil (instead of returning if blank, otherwise they'll never be un-settable).

It was requested by Erin to remove the word-limit on the notes field for now, so this adds that as well.