### PR TITLE
@jonallured => make sure partners dont receive digest if we add an offer for them (and the submission was created manually)

### DIFF
--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -14,6 +14,7 @@ class OfferService
       submission = Submission.find(submission_id)
       partner = Partner.find(partner_id)
       partner_submission = PartnerSubmission.find_or_create_by!(submission_id: submission.id, partner_id: partner.id)
+      partner_submission.update!(notified_at: Time.now.utc) if partner_submission.notified_at.blank?
       offer = partner_submission.offers.new(offer_params.merge(state: 'draft', created_by_id: current_user))
       offer.save!
       offer

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -14,6 +14,7 @@ describe OfferService do
         ps = PartnerSubmission.where(submission: submission, partner: partner).first
         expect(ps.offers.count).to eq 1
         expect(ps.offers.first.state).to eq 'draft'
+        expect(ps.notified_at).to_not be_nil
       end
     end
 


### PR DESCRIPTION
Super minor thing but I noticed this non-ideal thing as I've been having to create some submissions/offers manually (via bulk submissions).

In the normal flow, when a submission is `approved`, we create `PartnerSubmission` objects for that submission, and the ones that haven't been included in a previous digest (i.e. `notified_at` is nil) are added to the next one.

However, sometimes we're asked to upload a bunch of submissions that were sent to partners _outside_ of the digest flow. In those cases, when we create an offer for them in convection, we don't want that `PartnerSubmission` to appear in a future digest (since the offer already exists).

There are multiple ways to do this-- this is one idea. Since `notified_at` means generally that the "partner saw the submission", I think it makes sense to set that field. We could also add another state.