### PR TITLE
Fix rabbit

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       omniauth-artsy (>= 0.2.2)
       omniauth-oauth2
       rails (>= 4.2.0)
-    artsy-eventservice (1.0.7)
+    artsy-eventservice (1.0.8)
       bunny
     ast (2.4.0)
     autoprefixer-rails (8.5.0)


### PR DESCRIPTION
# Problem
`artsy-eventservice` version `1.0.7` has issues in creating connection to RabbitMQ, version `1.0.8` fixes it.
Because of this issue, events haven't been posted since https://github.com/artsy/convection/pull/196

# Solution
Upgrade to latest `artsy-eventservice`.

🌮  