### PR TITLE
Add image_urls to posted events

### DIFF
--- a/app/events/submission_event.rb
+++ b/app/events/submission_event.rb
@@ -34,7 +34,8 @@ class SubmissionEvent < Events::BaseEvent
       category: @object.category,
       medium: @object.medium,
       minimum_price: @object.minimum_price_display,
-      currency: @object.currency
+      currency: @object.currency,
+      images_urls: @object.images&.map(&:image_urls)
     }
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,6 @@
 ActiveRecord::Schema.define(version: 2018_08_21_221301) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
@@ -136,8 +135,8 @@ ActiveRecord::Schema.define(version: 2018_08_21_221301) do
     t.integer "primary_image_id"
     t.integer "consigned_partner_submission_id"
     t.string "user_email"
-    t.integer "user_id"
     t.integer "offers_count", default: 0
+    t.integer "user_id"
     t.bigint "minimum_price_cents"
     t.string "currency"
     t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"

--- a/spec/events/submission_event_spec.rb
+++ b/spec/events/submission_event_spec.rb
@@ -18,6 +18,13 @@ describe SubmissionEvent do
       location_country: 'US',
       category: 'Painting')
   end
+  let!(:images) do
+    [
+      Fabricate(:image, submission: submission, image_urls: { 'thumbnail' => 'https://thumb.jpg' }),
+      Fabricate(:image, submission: submission, image_urls: { 'thumbnail' => 'https://thumb2.jpg' })
+    ]
+  end
+
   let(:event) { SubmissionEvent.new(model: submission, action: 'submitted') }
   describe '#object' do
     it 'returns proper id and display' do
@@ -46,6 +53,7 @@ describe SubmissionEvent do
       expect(event.properties[:dimensions_metric]).to eq 'in'
       expect(event.properties[:category]).to eq 'Painting'
       expect(event.properties[:medium]).to eq 'painting'
+      expect(event.properties[:images_urls]).to match_array([{ 'thumbnail' => 'https://thumb2.jpg' }, { 'thumbnail' => 'https://thumb.jpg' }])
     end
   end
 end


### PR DESCRIPTION
# Problem
when seeing consignments in the slack channel 
> sometimes we'll get excited and see something like "Alex Katz" but it's actually an artist named Alex putting in the closest match to his name
so it'd be great to see the image

# Solution
Add `image_urls` to posted event.

# Next?
Update APRB