### PR TITLE
Post an event when a submission is approved

### DIFF
--- a/app/events/submission_event.rb
+++ b/app/events/submission_event.rb
@@ -1,7 +1,8 @@
 class SubmissionEvent < Events::BaseEvent
   TOPIC = 'consignments'.freeze
   ACTIONS = [
-    SUBMITTED = 'submitted'.freeze
+    SUBMITTED = 'submitted'.freeze,
+    APPROVED = 'approved'.freeze
   ].freeze
 
   def object
@@ -34,7 +35,17 @@ class SubmissionEvent < Events::BaseEvent
       category: @object.category,
       medium: @object.medium,
       minimum_price: @object.minimum_price_display,
-      currency: @object.currency
+      currency: @object.currency,
+      provenance: @object.provenance,
+      signature: @object.signature,
+      authenticity_certificate: @object.authenticity_certificate,
+      thumbnail: @object.thumbnail,
+      image_urls: large_image_urls,
+      offer_link: Convection.config.auction_offer_form_url
     }
+  end
+
+  def large_image_urls
+    @object.large_images&.map { |img| img.image_urls['large'] }
   end
 end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -39,6 +39,7 @@ class SubmissionService
     def approve!(submission, current_user)
       submission.update!(approved_by: current_user, approved_at: Time.now.utc)
       delay.deliver_approval_notification(submission.id)
+      NotificationService.delay.post_submission_event(submission.id, SubmissionEvent::APPROVED)
       PartnerSubmissionService.delay.generate_for_all_partners(submission.id)
     end
 

--- a/spec/events/submission_event_spec.rb
+++ b/spec/events/submission_event_spec.rb
@@ -16,21 +16,63 @@ describe SubmissionEvent do
       location_city: 'New York',
       location_state: 'NY',
       location_country: 'US',
-      category: 'Painting')
+      category: 'Painting',
+      signature: true,
+      authenticity_certificate: true,
+      provenance: 'This is the provenance')
   end
+
+  let!(:image1) do
+    Fabricate(:image,
+      submission: submission,
+      image_urls: {
+        'square' => 'http://square1.jpg',
+        'large' => 'http://foo1.jpg',
+        'thumbnail' => 'http://thumb1.jpg'
+      })
+  end
+
+  let!(:image2) do
+    Fabricate(:image,
+      submission: submission,
+      image_urls: {
+        'square' => 'http://square2.jpg',
+        'large' => 'http://foo2.jpg',
+        'thumbnail' => 'http://thumb2.jpg'
+      })
+  end
+
+  let!(:image3) do
+    Fabricate(:image,
+      submission: submission,
+      image_urls: {
+        'square' => 'http://square3.jpg',
+        'large' => 'http://foo3.jpg',
+        'thumbnail' => 'http://thumb3.jpg'
+      })
+  end
+
   let(:event) { SubmissionEvent.new(model: submission, action: 'submitted') }
+
+  before do
+    allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction')
+    submission.update!(primary_image: image2)
+  end
+
   describe '#object' do
     it 'returns proper id and display' do
       expect(event.object[:id]).to eq submission.id
       expect(event.object[:display]).to eq "#{submission.id} (submitted)"
     end
   end
+
   describe '#subject' do
     it 'returns proper id and display' do
       expect(event.subject[:id]).to eq 'userid'
       expect(event.subject[:display]).to eq 'userid (New York)'
     end
   end
+
   describe '#properties' do
     it 'returns proper properties' do
       expect(event.properties[:title]).to eq 'My Artwork'
@@ -46,6 +88,29 @@ describe SubmissionEvent do
       expect(event.properties[:dimensions_metric]).to eq 'in'
       expect(event.properties[:category]).to eq 'Painting'
       expect(event.properties[:medium]).to eq 'painting'
+      expect(event.properties[:provenance]).to eq 'This is the provenance'
+      expect(event.properties[:signature]).to eq true
+      expect(event.properties[:authenticity_certificate]).to eq true
+      expect(event.properties[:thumbnail]).to eq 'http://thumb2.jpg'
+      expect(event.properties[:image_urls]).to eq ['http://foo1.jpg', 'http://foo2.jpg', 'http://foo3.jpg']
+      expect(event.properties[:offer_link]).to eq 'https://google.com/auction'
+    end
+
+    it 'returns proper properties for a submission with no processed images and few properties' do
+      minimal_submission = Fabricate(:submission, title: 'My Artwork', artist_id: 'artistid', year: '1992', state: 'approved')
+      minimal_event = SubmissionEvent.new(model: minimal_submission, action: 'approved')
+
+      expect(minimal_event.properties[:title]).to eq 'My Artwork'
+      expect(minimal_event.properties[:artist_id]).to eq 'artistid'
+      expect(minimal_event.properties[:state]).to eq 'approved'
+      expect(minimal_event.properties[:year]).to eq '1992'
+      expect(minimal_event.properties[:depth]).to eq nil
+      expect(minimal_event.properties[:provenance]).to eq nil
+      expect(minimal_event.properties[:signature]).to eq false
+      expect(minimal_event.properties[:authenticity_certificate]).to eq false
+      expect(minimal_event.properties[:thumbnail]).to eq nil
+      expect(minimal_event.properties[:image_urls]).to eq []
+      expect(minimal_event.properties[:offer_link]).to eq 'https://google.com/auction'
     end
   end
 end

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -27,6 +27,7 @@ describe PartnerSubmissionService do
     it 'generates new partner submissions' do
       partner = Fabricate(:partner)
       submission = Fabricate(:submission, state: 'submitted', user: @user, artist_id: 'artistid')
+      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'approved')
       SubmissionService.update_submission(submission, state: 'approved')
       expect(PartnerSubmission.where(submission: submission, partner: partner).count).to eq 1
       Fabricate(:submission, state: 'approved')
@@ -83,6 +84,7 @@ describe PartnerSubmissionService do
           year: '1992',
           minimum_price_cents: 50_000_00,
           currency: 'USD')
+        expect(NotificationService).to receive(:post_submission_event).once.with(@approved1.id, 'approved')
         SubmissionService.update_submission(@approved1, state: 'approved')
       end
 
@@ -103,6 +105,7 @@ describe PartnerSubmissionService do
           user: @user,
           title: 'Approved artwork with minimum price',
           year: '1992')
+        expect(NotificationService).to receive(:post_submission_event).once.with(@approved1.id, 'approved')
         SubmissionService.update_submission(@approved1, state: 'approved')
       end
 
@@ -136,6 +139,9 @@ describe PartnerSubmissionService do
           title: 'Third approved artwork',
           year: '1997')
         Fabricate(:submission, state: 'rejected')
+        expect(NotificationService).to receive(:post_submission_event).once.with(@approved1.id, 'approved')
+        expect(NotificationService).to receive(:post_submission_event).once.with(@approved2.id, 'approved')
+        expect(NotificationService).to receive(:post_submission_event).once.with(@approved3.id, 'approved')
         SubmissionService.update_submission(@approved1, state: 'approved')
         SubmissionService.update_submission(@approved2, state: 'approved')
         SubmissionService.update_submission(@approved3, state: 'approved')

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -94,6 +94,7 @@ describe SubmissionService do
     end
 
     it 'sends an approval notification if the submission state is changed to approved' do
+      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'approved')
       SubmissionService.update_submission(submission, { state: 'approved' }, 'userid')
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
@@ -110,6 +111,7 @@ describe SubmissionService do
     end
 
     it 'generates partner submissions on an approval' do
+      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'approved')
       partner1 = Fabricate(:partner, gravity_partner_id: 'partner1')
       partner2 = Fabricate(:partner, gravity_partner_id: 'partner2')
 

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -65,6 +65,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
     end
 
     it 'does not display partners who have not been notified' do
+      expect(NotificationService).to receive(:post_submission_event).once.with(@submission.id, 'approved')
       partner1 = Fabricate(:partner, gravity_partner_id: 'partnerid')
       partner2 = Fabricate(:partner, gravity_partner_id: 'phillips')
       SubmissionService.update_submission(@submission, state: 'approved')
@@ -77,6 +78,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
     end
 
     it 'displays the partners that a submission has been shown to' do
+      expect(NotificationService).to receive(:post_submission_event).once.with(@submission.id, 'approved')
       stub_gravity_partner_communications
       stub_gravity_partner_contacts
       partner1 = Fabricate(:partner, gravity_partner_id: 'partnerid')
@@ -120,6 +122,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
       end
 
       it 'approves a submission when the Approve button is clicked' do
+        expect(NotificationService).to receive(:post_submission_event).once.with(@submission.id, 'approved')
         expect(page).to_not have_content('Create Offer')
         expect(page).to have_content('submitted')
         click_link 'Approve'


### PR DESCRIPTION
We want to be able to start a slack channel for approved submissions.

This PR updates the `SubmissionService` to post a notification when a submission becomes `approved`.

Erin also had a list of properties she wanted included in this notification, so I updated the properties hash to reflect that.

**Note:** This includes `image_urls` which at the time of approval _will_ exist.