### PR TITLE
AUCT-47: Do not truncate artwork provenance

### DIFF
--- a/app/views/shared/email/_submission_digest_block.html.erb
+++ b/app/views/shared/email/_submission_digest_block.html.erb
@@ -53,7 +53,7 @@
                 <% if submission.provenance.present? %>
                   <tr>
                     <td>
-                      <i><%= submission.provenance.truncate(45) %></i>
+                      <i><%= submission.provenance %></i>
                     </td>
                   </tr>
                 <% end %>


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AUCT-47

> Details about the artwork's provenance is important, and we'd like to be able to surface all of that information in the digest, without cutting it short (see attached). The information allows partners to assess the works better, and make offers if they prefer.

In order to test this with actual data in production, I picked up https://convection.artsy.net/admin/submissions/2083 with a provenance that length is 1140 (second longest provenance in the db). The screenshot doesn't look bad, so I believe this should be too destructive even when the provenance could be relatively long.

There doesn't seem to be any tests and it might be nice to have one (maybe test that the mailer renders properly), but I'm also okay with not doing this.

## Before:

![screencapture-localhost-3000-rails-mailers-partner_mailer-submission_digest_auction-2019-04-08-12_13_24](https://user-images.githubusercontent.com/386234/55739866-f3960480-59f7-11e9-9930-ba42433a2154.png)

## After:

![screencapture-localhost-3000-rails-mailers-partner_mailer-submission_digest_auction-2019-04-08-12_12_53](https://user-images.githubusercontent.com/386234/55739880-fabd1280-59f7-11e9-9c35-c11d3844f4d3.png)
