### PR TITLE
Add bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'sass-rails'
 gem 'sentry-raven' # for error reporting
 gem 'sidekiq', '4.2.9' # for sending emails in the background
 gem 'uglifier'
+gem 'bootsnap', require: false # Speed up boot time by caching expensive operations.
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (8.5.0)
       execjs
+    bootsnap (1.4.1)
+      msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -192,6 +194,7 @@ GEM
     minitest (5.11.3)
     money (6.11.3)
       i18n (>= 0.6.4, < 1.1)
+    msgpack (1.2.7)
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -376,6 +379,7 @@ PLATFORMS
 DEPENDENCIES
   artsy-auth
   artsy-eventservice
+  bootsnap
   bootstrap-sass
   bourbon (= 4.2.3)
   capybara

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,3 +3,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
[The bootsnap gem](https://github.com/Shopify/bootsnap) is a gem that optimizes and caches expensive computations. This reduces about 3s of Convection's booting time:

## Before:

<img width="1624" alt="Screen Shot 2019-04-08 at 11 34 40 AM" src="https://user-images.githubusercontent.com/386234/55740133-74550080-59f8-11e9-901e-cdfdd3a53c57.png">


## After:
<img width="1624" alt="Screen Shot 2019-04-08 at 11 34 47 AM" src="https://user-images.githubusercontent.com/386234/55740144-76b75a80-59f8-11e9-8ec8-980c20146159.png">

