### PR TITLE
AUCT-59: Track user_agent when submissions are created

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -59,7 +59,7 @@ module Api
         :title,
         :width,
         :year
-      )
+      ).merge(user_agent: request.user_agent)
     end
   end
 end

--- a/db/migrate/20190408181209_add_user_agent_to_submissions.rb
+++ b/db/migrate/20190408181209_add_user_agent_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddUserAgentToSubmissions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :user_agent, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_21_221301) do
+ActiveRecord::Schema.define(version: 2019_04_08_181209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -140,6 +140,7 @@ ActiveRecord::Schema.define(version: 2018_08_21_221301) do
     t.integer "offers_count", default: 0
     t.bigint "minimum_price_cents"
     t.string "currency"
+    t.string "user_agent"
     t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
     t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
     t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"

--- a/spec/requests/api/submissions/create_spec.rb
+++ b/spec/requests/api/submissions/create_spec.rb
@@ -66,11 +66,12 @@ describe 'Create Submission' do
           category: 'Painting',
           minimum_price_dollars: 50_000,
           currency: 'GBP'
-        }, headers: headers
+        }, headers: headers.merge('User-Agent' => 'Eigen')
 
         expect(JSON.parse(response.body)['edition_size']).to eq 100
         expect(JSON.parse(response.body)['minimum_price_dollars']).to eq 50_000
         expect(JSON.parse(response.body)['currency']).to eq 'GBP'
+        expect(JSON.parse(response.body)['user_agent']).to eq 'Eigen'
       end.to change { Submission.count }.by(1)
     end
   end


### PR DESCRIPTION
finishes https://artsyproduct.atlassian.net/browse/AUCT-59

 * Adds a `user_agent` column to the `submissions` table
 * Captures `request.user_agent` on `submissions#create` and save it

## Why does this work?

 * In Force (desktop/mobile web), the client side code directly makes a request to Convection with a restful client. The browser will automatically sets the default user agent to the request so Convection should be able to capture that: <img width="1216" alt="AUCT-59-force" src="https://user-images.githubusercontent.com/386234/55886701-3da6f380-5b7a-11e9-90c6-ae4b56181623.png">

 * In iOS, Emission has its own GraphQL client for Metaphysics [with a specific user agent set](https://github.com/artsy/emission/blob/feb1a0e54b80ee43dd5d0d1e144525da323ff717/src/lib/metaphysics.ts#L14). Metaphysics then delegates the request to Convection with [a suffixed user agent](https://github.com/artsy/metaphysics/blob/21e5e36d8597d991aa0b8e469522727a963d529b/src/lib/loaders/api/index.ts#L121) that looks like:
    ```
    x86_64 Mozilla/5.0 Artsy-Mobile/5.0.1 Eigen/2019.02.28.17/5.0.1 (iPhone; iOS 12.1; Scale/3.00) AppleWebKit/601.1.46 (KHTML, like Gecko); Metaphysics
    ```

So in theory this should work fine, but I think we need a little heavier QA in case we missed something.