### PR TITLE
[release] group consignments by consignor in digest email (#235)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,8 @@ Metrics/AbcSize:
 
 Metrics/MethodLength:
   Max: 33
+  Exclude:
+    - spec/mailers/previews/*
 
 Metrics/CyclomaticComplexity:
   Max: 8

--- a/app/assets/stylesheets/emails.css.scss
+++ b/app/assets/stylesheets/emails.css.scss
@@ -508,6 +508,24 @@ table.bordered-email {
       width: 100%;
     }
 
+    td.consignor-header {
+      font-size: 14px;
+      line-height: 17px;
+      color: #808080;
+      border-top: 1px solid #e5e5e5;
+
+      p.consignor-id {
+        color: #000000;
+        font-weight: bold;
+        margin-top: 30px;
+        margin-bottom: 4px;  
+      }
+    }
+
+    td.consignor-border {
+      margin-bottom: 20px;
+    }
+ 
     .email-title {
       padding-bottom: 0px;
     }
@@ -530,14 +548,12 @@ table.bordered-email {
       font-size: 16px;
       color: gray;
       font-family: sans-serif;
-      padding-bottom: 16px;
+      padding-bottom: 30px;
     }
 
     .submission-digest-block {
       width: 100%;
       max-width: 600px;
-
-      border-top: 1px solid #e5e5e5;
 
       .two-column {
         text-align: left;
@@ -574,6 +590,10 @@ table.bordered-email {
           font-size: 14px;
         }
       }
+    }
+
+    table.submission-batch-todo {
+      border-top: 1px solid #e5e5e5;
     }
 
     table.image-links-table {

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -1,8 +1,8 @@
 class PartnerMailer < ApplicationMailer
   helper :url, :submissions, :offers, :application
 
-  def submission_digest(submissions:, partner_name:, partner_type:, email:)
-    @submissions = submissions
+  def submission_digest(users_to_submissions:, partner_name:, partner_type:, email:, submissions_count:)
+    @users_to_submissions = users_to_submissions
     @partner_type = partner_type
     @utm_params = utm_params(source: 'consignment-partner-digest', campaign: 'consignment-complete')
     smtpapi category: ['submission_digest'], unique_args: {
@@ -13,7 +13,7 @@ class PartnerMailer < ApplicationMailer
     mail(
       to: email,
       from: Convection.config.admin_email_address,
-      subject: "New Artsy Consignments #{current_date}: #{@submissions.count} works"
+      subject: "New Artsy Consignments #{current_date}: #{submissions_count} works"
     ) do |format|
       format.html { render layout: 'mailer_no_footer' }
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,4 +26,8 @@ class User < ApplicationRecord
   rescue Faraday::ResourceNotFound
     nil
   end
+
+  def unique_code_for_digest
+    created_at.to_i % 100_000 + id + (submissions.first&.id || 0)
+  end
 end

--- a/app/services/partner_submission_service.rb
+++ b/app/services/partner_submission_service.rb
@@ -49,11 +49,13 @@ class PartnerSubmissionService
     def deliver_partner_contact_email(submission_ids, partner_name, partner_type, email)
       submissions = Submission.find(submission_ids)
       return if submissions.empty?
+      users_to_submissions = submissions.group_by(&:user)
       PartnerMailer.submission_digest(
-        submissions: submissions,
+        users_to_submissions: users_to_submissions,
         partner_name: partner_name,
         partner_type: partner_type,
-        email: email
+        email: email,
+        submissions_count: submissions.count
       ).deliver_now
     end
 

--- a/app/views/partner_mailer/submission_digest.html.erb
+++ b/app/views/partner_mailer/submission_digest.html.erb
@@ -26,11 +26,22 @@
         </tr>
         <tr>
           <td>
-            <% @submissions.each do |submission| %>
+            <% @users_to_submissions.each do |user, submissions| %>
               <tr>
-                <td>
-                  <%= render 'shared/email/submission_digest_block', submission: submission %>
+                <td class='consignor-header'>
+                  <p class='consignor-id'>Consignor <%= user.unique_code_for_digest %></p>
+                  <span class='consignor-works-count'><%= pluralize(submissions.count, 'work') %></span>
                 </td>
+              </tr>
+              <% submissions.each do |submission| %>
+                <tr>
+                  <td>
+                    <%= render 'shared/email/submission_digest_block', submission: submission %>
+                  </td>
+                </tr>
+              <% end %>
+              <tr>
+                <td class='consignor-border'><p></p></td>
               </tr>
             <% end %>
           </td>
@@ -40,7 +51,7 @@
             <table class='submission-batch-todo sans-serif'>
               <% if @partner_type == 'Auction' %>
                 <tr>
-                  <td class='email-sub-title email-sub-title--extra-padding-bottom'>
+                  <td class='email-sub-title email-sub-title--extra-padding-bottom email-sub-title--extra-padding-top'>
                     Please click below to send one proposal per submission and respond directly to this email if you have any questions.
                   </td>
                 </tr>

--- a/app/views/shared/email/_submission_digest_block.html.erb
+++ b/app/views/shared/email/_submission_digest_block.html.erb
@@ -27,7 +27,7 @@
               <table class='submission-batch-metadata'>
                 <tr>
                   <td class='gray'>
-                    <%= submission.id %>
+                    Submission <%= submission.id %>
                   </td>
                 </tr>
                 <tr>

--- a/spec/mailers/previews/base_preview.rb
+++ b/spec/mailers/previews/base_preview.rb
@@ -22,7 +22,9 @@ class BasePreview < ActionMailer::Preview
 
   def base_submission
     OpenStruct.new(
-      id: '12',
+      id: 12,
+      user_id: 'userid',
+      user: OpenStruct.new(unique_code_for_digest: 12),
       processed_images: [],
       images: [],
       title: 'My Favorite Artwork',

--- a/spec/mailers/previews/partner_mailer_preview.rb
+++ b/spec/mailers/previews/partner_mailer_preview.rb
@@ -28,12 +28,14 @@ class PartnerMailerPreview < BasePreview
   private
 
   def submission_digest_mail_params
+    sub1 = base_submission
+    sub2 = base_submission
+    sub2.user = OpenStruct.new(unique_code_for_digest: 12_312)
+    users_to_submissions = [sub1, sub2, base_submission_with_minimum_price].group_by(&:user)
+
     {
-      submissions: [
-        base_submission_with_minimum_price,
-        base_submission,
-        base_submission
-      ]
+      users_to_submissions: users_to_submissions,
+      submissions_count: 3
     }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,24 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe User do
-  let!(:user) { Fabricate(:user, gravity_user_id: 'userid') }
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { Fabricate(:user, gravity_user_id: 'userid') }
+
+  it 'generates a consistent consignor number' do
+    travel_to Time.zone.local(2019, 1, 1, 0, 0, 0) do
+      user.id = 1
+      expect(user.unique_code_for_digest).to eq(801)
+      user.id = 9
+      expect(user.unique_code_for_digest).to eq(809)
+    end
+
+    travel_to Time.zone.local(2019, 8, 7, 6, 5, 4) do
+      user1 = Fabricate(:user)
+      user1.id = 1
+      expect(user1.unique_code_for_digest).to eq(57_905)
+    end
+  end
 
   context 'gravity_user' do
     it 'returns nil if it cannot find the object' do


### PR DESCRIPTION
* group consignments by consignor in digest email

* repeatable consignor_number for users

* test consignor_number using time travel

* make sure consignor number is different each time we send out new digests

* change consignor_number to unique_code_for_digest

* remove redundant test