### PR TITLE
Fixes an issue where GraphQL calls were failing due to type errors

### DIFF
--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -2,7 +2,7 @@ module GraphqlHelper
   extend ActiveSupport::Concern
 
   ARTISTS_DETAILS_QUERY = %|
-  query artistsDetails($ids: [ID]!){
+  query artistsDetails($ids: [ID!]!){
     artists(ids: $ids){
       id
       name
@@ -11,7 +11,7 @@ module GraphqlHelper
   |.freeze
 
   MATCH_PARTNERS_QUERY = %|
-  query matchPartners($term: String) {
+  query matchPartners($term: String!) {
     match_partners(term: $term){
       id
       given_name


### PR DESCRIPTION
fixes https://artsyproduct.atlassian.net/browse/AUCT-494

Apparently https://github.com/artsy/gravity/pull/12425 has removed the `artist.id` field by accident, and we have fixed it with https://github.com/artsy/gravity/pull/12472 on the Gravity side. I also had to tweak the types in Convection to fix a really strict type check done by GraphQL (e.g. `"Nullability mismatch on variable $ids and argument ids ([ID]! / [ID!]!)"`).

## Screenshots

### Artists details query

<img width="1920" alt="AUCT-494-1" src="https://user-images.githubusercontent.com/386234/61410893-37c85900-a8b3-11e9-8ac0-421fb15cf859.png">


### Match partners query

![AUCT-494-2](https://user-images.githubusercontent.com/386234/61410799-05b6f700-a8b3-11e9-81f1-0f669315fde4.gif)
