### PR TITLE
Fixes an issue where asset:precompile fails due to Uglify

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Deploys to heroku has been failing since https://github.com/artsy/convection/commit/de347e772ee313c6723ebaf58e4d9fee50e7acdc due to https://github.com/rmosolgo/graphiql-rails/issues/44 and this should fix the issue by switching to `Uglifier.new(harmony: true)`.