### PR TITLE
Reenable cron tasks

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -153,65 +153,65 @@ spec:
     component: web
   sessionAffinity: None
   type: LoadBalancer
-# ---
-# apiVersion: batch/v1beta1
-# kind: CronJob
-# metadata:
-#   name: convection-partners-update
-# spec:
-#   schedule: "0 2 * * *"
-#   concurrencyPolicy: Forbid
-#   jobTemplate:
-#     spec:
-#       template:
-#         spec:
-#           containers:
-#             - name: convection-partners-update
-#               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/convection:production
-#               command: ["rake", "partners:update"]
-#               imagePullPolicy: Always
-#               envFrom:
-#                 - configMapRef:
-#                     name: convection-environment
-#           restartPolicy: Never
-#           affinity:
-#             nodeAffinity:
-#               preferredDuringSchedulingIgnoredDuringExecution:
-#                 - weight: 1
-#                   preference:
-#                     matchExpressions:
-#                       - key: tier
-#                         operator: In
-#                         values:
-#                           - background
-# ---
-# apiVersion: batch/v1beta1
-# kind: CronJob
-# metadata:
-#   name: convection-partners-daily-digest
-# spec:
-#   schedule: "0 3 * * *"
-#   concurrencyPolicy: Forbid
-#   jobTemplate:
-#     spec:
-#       template:
-#         spec:
-#           containers:
-#             - name: convection-partners-daily-digest
-#               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/convection:production
-#               command: ["rake", "partners:daily_digest"]
-#               imagePullPolicy: Always
-#               envFrom:
-#                 - configMapRef:
-#                     name: convection-environment
-#           restartPolicy: Never
-#           affinity:
-#             nodeAffinity:
-#               preferredDuringSchedulingIgnoredDuringExecution:
-#                 - weight: 1
-#                   preference:
-#                     matchExpressions:
-#                       - key: tier
-#                         operator: In
-#                         values:
-#                           - background
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: convection-partners-update
+spec:
+  schedule: "0 14 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: convection-partners-update
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/convection:production
+              command: ["rake", "partners:update"]
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: convection-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: convection-partners-daily-digest
+spec:
+  schedule: "0 15 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: convection-partners-daily-digest
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/convection:production
+              command: ["rake", "partners:daily_digest"]
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: convection-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: tier
+                        operator: In
+                        values:
+                          - background


### PR DESCRIPTION
Follow up to #355, run cron jobs in Kubernetes (rather than heroku).

**Migration:**
- [x] Disable heroku scheduler
- [x] Deploy production
- [x] Monitor jobs (around 10am tomorrow)

I expect these jobs to run at 2pm and 3pm UTC.
<img width="797" alt="Screen Shot 2019-12-04 at 3 05 23 PM" src="https://user-images.githubusercontent.com/1497424/70177204-ec6ae780-16a7-11ea-868a-354d88e0d63a.png">

