### PR TITLE
Eliminate warnings from the money gem

### DIFF
--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,1 +1,5 @@
 Money.locale_backend = :i18n
+
+# The default rounding mode used to be `BigDecimal::ROUND_HALF_EVEN':
+# https://github.com/RubyMoney/money/pull/863/files#diff-a6d34f32282d8d431a585cdaf0aaf730L159
+Money.rounding_mode = BigDecimal::ROUND_HALF_EVEN


### PR DESCRIPTION
This PR eliminates the following warning:

> [WARNING] The default rounding mode will change to `ROUND_HALF_UP` in the next major release. Set it explicitly using `Money.rounding_mode=` to avoid potential problems.