### PR TITLE
Upgrade to the latest version of capybara and webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'bootsnap', require: false # Speed up boot time by caching expensive operati
 group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails'
+  gem 'webdrivers', '~> 4.0'
 end
 
 group :development do
@@ -48,8 +49,7 @@ group :development do
 end
 
 group :test do
-  gem 'capybara'
-  gem 'webdrivers', require: false
+  gem 'capybara', '~> 3.29.0'
   gem 'database_cleaner'
   gem 'fabrication'
   gem 'rack_session_access'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,13 +74,14 @@ GEM
     bunny (2.14.2)
       amq-protocol (~> 2.3, >= 2.3.0)
     byebug (11.0.1)
-    capybara (2.18.0)
+    capybara (3.29.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     childprocess (3.0.0)
     coderay (1.1.2)
     coffee-rails (5.0.0)
@@ -193,7 +194,7 @@ GEM
     net-http-digest_auth (1.4.1)
     newrelic_rpm (6.7.0.359)
     nio4r (2.5.2)
-    nokogiri (1.10.5)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
@@ -273,11 +274,12 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (13.0.0)
+    rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.1.3)
+    regexp_parser (1.6.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -365,7 +367,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    xpath (3.0.0)
+    xpath (3.2.0)
       nokogiri (~> 1.8)
     yarjuf (2.0.0)
       builder
@@ -380,7 +382,7 @@ DEPENDENCIES
   bootsnap
   bootstrap-sass
   bourbon (= 4.2.3)
-  capybara
+  capybara (~> 3.29.0)
   coffee-rails
   database_cleaner
   ddtrace (~> 0.30.0)
@@ -415,7 +417,7 @@ DEPENDENCIES
   sidekiq (< 6)
   uglifier
   watt!
-  webdrivers
+  webdrivers (~> 4.0)
   webmock
   yarjuf
 

--- a/hokusai/ci.sh
+++ b/hokusai/ci.sh
@@ -22,7 +22,7 @@ retry() {
   done
 
   # set up test database
-  bundle exec rake db:migrate
+  bundle exec rake db:setup
 
   # run specs
   bundle exec rake

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,8 +34,9 @@ RSpec.configure do |config|
   end
 end
 
+Capybara.server = :puma, { Silent: true }
 Capybara.configure do |config|
-  config.javascript_driver = :headless_chrome
+  config.javascript_driver = ENV['NO_HEADLESS'] ? :selenium_chrome : :headless_chrome
   config.default_max_wait_time = 10
   config.ignore_hidden_elements = false
 end

--- a/spec/views/admin/consignments/index.html.erb_spec.rb
+++ b/spec/views/admin/consignments/index.html.erb_spec.rb
@@ -84,6 +84,9 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         Fabricate(:consignment, state: 'sold', partner: @partner2)
         Fabricate(:consignment, state: 'canceled', partner: @partner2)
         page.visit admin_consignments_path
+
+        stub_gravity_user(id: @consignment1.submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: @consignment1.submission.user.gravity_user_id)
       end
 
       it 'lets you click into a filter option', js: true do
@@ -104,7 +107,7 @@ describe 'admin/consignments/index.html.erb', type: :feature do
       it 'allows you to search by partner name', js: true do
         fill_in('term', with: 'gallery')
         expect(page).to have_selector('.ui-autocomplete')
-        expect(page).to have_content('Partner Gagosian Gallery')
+        expect(page).to have_content('Partner   Gagosian Gallery')
         click_link("partner-#{@partner1.id}")
         expect(current_url).to include "partner=#{@partner1.id}"
         partner_names = page.all('.list-group-item-info--partner-name').map(&:text)
@@ -123,7 +126,7 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         select('bought in', from: 'state')
         fill_in('term', with: 'herit')
         expect(page).to have_selector('.ui-autocomplete')
-        expect(page).to have_content('Partner Heritage Auctions')
+        expect(page).to have_content('Partner   Heritage Auctions')
         click_link("partner-#{@partner2.id}")
         partner_names = page.all('.list-group-item-info--partner-name').map(&:text)
         expect(partner_names.count).to eq 1
@@ -136,7 +139,7 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         select('bought in', from: 'state')
         fill_in('term', with: 'herit')
         expect(page).to have_selector('.ui-autocomplete')
-        expect(page).to have_content('Partner Heritage Auctions')
+        expect(page).to have_content('Partner   Heritage Auctions')
         click_link("partner-#{@partner2.id}")
         expect(current_url).to include "state=bought+in&partner=#{@partner2.id}"
         click_link('Price')

--- a/spec/views/admin/offers/index.html.erb_spec.rb
+++ b/spec/views/admin/offers/index.html.erb_spec.rb
@@ -4,6 +4,8 @@ require 'support/gravity_helper'
 describe 'admin/offers/index.html.erb', type: :feature do
   context 'always' do
     before do
+      stub_gravity_root
+
       allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
 
       allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
@@ -91,6 +93,10 @@ describe 'admin/offers/index.html.erb', type: :feature do
         @offer1 = Fabricate(:offer, state: 'accepted', partner_submission: Fabricate(:partner_submission, partner: @partner2))
         Fabricate(:offer, state: 'rejected', partner_submission: Fabricate(:partner_submission, partner: @partner2))
         Fabricate(:offer, state: 'draft', partner_submission: Fabricate(:partner_submission, partner: @partner1))
+
+        stub_gravity_user(id: @offer1.submission.user.gravity_user_id)
+        stub_gravity_user_detail(id: @offer1.submission.user.gravity_user_id)
+
         page.visit admin_offers_path
       end
 
@@ -110,7 +116,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
       it 'lets you search by partner name', js: true do
         fill_in('term', with: 'Gag')
         expect(page).to have_selector('.ui-autocomplete')
-        expect(page).to have_content('Partner Gagosian')
+        expect(page).to have_content('Partner   Gagosian')
         click_link("partner-#{@partner1.id}")
         expect(current_url).to include "&partner=#{@partner1.id}"
         expect(page).to have_selector('.list-group-item', count: 5)
@@ -129,7 +135,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
         select('sent', from: 'state')
         fill_in('term', with: 'Gag')
         expect(page).to have_selector('.ui-autocomplete')
-        expect(page).to have_content('Partner Gagosian')
+        expect(page).to have_content('Partner   Gagosian')
         click_link("partner-#{@partner1.id}")
         expect(current_url).to include "state=sent&partner=#{@partner1.id}"
         expect(page).to have_selector('.list-group-item', count: 4)
@@ -141,7 +147,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
         select('sent', from: 'state')
         fill_in('term', with: 'Gag')
         expect(page).to have_selector('.ui-autocomplete')
-        expect(page).to have_content('Partner Gagosian')
+        expect(page).to have_content('Partner   Gagosian')
         click_link("partner-#{@partner1.id}")
         expect(current_url).to include "state=sent&partner=#{@partner1.id}"
         click_link('Price')

--- a/spec/views/admin/submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/submissions/index.html.erb_spec.rb
@@ -5,6 +5,9 @@ describe 'admin/submissions/index.html.erb', type: :feature do
   context 'always' do
     before do
       stub_gravity_root
+      stub_gravity_artist(id: 'artistid2')
+      stub_gravity_user(id: 'userid2')
+      stub_gravity_user_detail(id: 'userid2')
 
       allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
       allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
@@ -164,7 +167,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
       it 'allows you to search by user email', js: true do
         fill_in('term', with: 'percy')
         expect(page).to have_selector('.ui-autocomplete')
-        expect(page).to have_content('User percy')
+        expect(page).to have_content('User   percy')
         click_link("user-#{@user2.id}")
         expect(current_url).to include "&user=#{@user2.id}"
         expect(page).to have_selector('.list-group-item', count: 4)
@@ -176,7 +179,7 @@ describe 'admin/submissions/index.html.erb', type: :feature do
         select('approved', from: 'state')
         fill_in('term', with: 'percy')
         expect(page).to have_selector('.ui-autocomplete')
-        expect(page).to have_content('User percy')
+        expect(page).to have_content('User   percy')
         click_link("user-#{@user2.id}")
         expect(current_url).to include("user=#{@user2.id}", 'state=approved')
         click_link('ID')


### PR DESCRIPTION
We have been using a very old version of Capybara and webdrivers and CI builds are full of [deprecation warnings](https://circleci.com/gh/artsy/convection/1161). This PR updates these two gems so it'll be easier to track what's failing and what's not.
