### PR TITLE
Redis migration take 2

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -256,12 +256,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: convection-environment
-          env:
-            - name: "REDIS_URL"
-              valueFrom:
-                configMapKeyRef:
-                  name: shared-redis-db-assignments
-                  key: convection
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/convection:production
           imagePullPolicy: Always
           args: ["bundle", "exec", "sidekiq"]

--- a/hokusai/sidekiq-legacy-production.yml
+++ b/hokusai/sidekiq-legacy-production.yml
@@ -24,6 +24,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: convection-environment
+          env:
+            - name: "REDIS_URL"
+              valueFrom:
+                configMapKeyRef:
+                  name: convection-environment
+                  key: LEGACY_REDIS_URL
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/convection:production
           imagePullPolicy: Always
           args: ["bundle", "exec", "sidekiq"]

--- a/hokusai/sidekiq-legacy-staging.yml
+++ b/hokusai/sidekiq-legacy-staging.yml
@@ -21,6 +21,12 @@ spec:
     spec:
       containers:
         - name: convection-sidekiq
+          env:
+            - name: "REDIS_URL"
+              valueFrom:
+                configMapKeyRef:
+                  name: convection-environment
+                  key: LEGACY_REDIS_URL
           envFrom:
             - configMapRef:
                 name: convection-environment

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -194,12 +194,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: convection-environment
-          env:
-            - name: "REDIS_URL"
-              valueFrom:
-                configMapKeyRef:
-                  name: shared-redis-db-assignments
-                  key: convection
           image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/convection:staging
           imagePullPolicy: Always
           args: ["bundle", "exec", "sidekiq"]


### PR DESCRIPTION
Follow-up to https://github.com/artsy/convection/pull/381 upgrading to our new Redis v5 servers https://github.com/artsy/infrastructure/pull/179

## Migration

### Staging

1. Merge and deploy
2. Copy `REDIS_URL` to `LEGACY_REDIS_URL` with `hokusai staging env set "LEGACY_$(hokusai staging env get REDIS_URL)"`
3. Create legacy sidekiq deployment `hokusai staging create --filename=./hokusai/sidekiq-legacy-staging.yml`
4. Update to the new `REDIS_URL` with `hokusai staging env set`
5. Refresh `hokusai staging refresh`
6. Wait until the legacy-sidekiq pod [has no more messages to consume](https://github.com/artsy/infrastructure/pull/179#issuecomment-574284349)
7. Delete the legacy-sidekiq deployment `hokusai staging delete --filename=./hokusai/sidekiq-legacy-staging.yml`
8. Unset `LEGACY_REDIS_URL` `hokusai staging env unset LEGACY_REDIS_URL`

### Production
1. Release and deploy
2. Copy REDIS_URL to LEGACY_REDIS_URL with `hokusai production env set "LEGACY_$(hokusai production env get REDIS_URL)"`
3. Create legacy sidekiq deployment `hokusai production create --filename=./hokusai/sidekiq-legacy-production.yml`
4. Update to the new REDIS_URL with `hokusai production env set`
5. Refresh `hokusai production refresh`
6. Wait until the legacy-sidekiq pod [has no more messages to consume](https://github.com/artsy/infrastructure/pull/179#issuecomment-574284349)
7. Delete the legacy-sidekiq deployment `hokusai production delete --filename=./hokusai/sidekiq-legacy-production.yml`
8. Unset LEGACY_REDIS_URL `hokusai production env unset LEGACY_REDIS_URL`
