### PR TITLE
CNMT-20: Rearrange submission detail page

### DIFF
--- a/app/views/admin/submissions/_submission_details.html.erb
+++ b/app/views/admin/submissions/_submission_details.html.erb
@@ -3,7 +3,7 @@
     Artist/Designer
   </div>
   <div class='overview-item-value'>
-    <%= @submission.artist_name %>
+    <%= @submission.artist_name.upcase %>
   </div>
 </div>
 
@@ -12,16 +12,16 @@
     Title
   </div>
   <div class='overview-item-value'>
-    <%= @submission.title %>
+    <em><%= @submission.title %></em>
   </div>
 </div>
 
 <div class='overview-item'>
   <div class='overview-item-title'>
-    Year
+    Signature
   </div>
   <div class='overview-item-value'>
-    <%= @submission.year %>
+    <%= @submission.signature %>
   </div>
 </div>
 
@@ -54,19 +54,10 @@
 
 <div class='overview-item'>
   <div class='overview-item-title'>
-    Location
+    Year
   </div>
   <div class='overview-item-value'>
-    <%= formatted_location(@submission) %>
-  </div>
-</div>
-
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Edition No./Size
-  </div>
-  <div class='overview-item-value'>
-    <%= formatted_editions(@submission) %>
+    <%= @submission.year %>
   </div>
 </div>
 
@@ -75,16 +66,7 @@
     Provenance
   </div>
   <div class='overview-item-value'>
-    <%= @submission.provenance %>
-  </div>
-</div>
-
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Signature
-  </div>
-  <div class='overview-item-value'>
-    <%= @submission.signature %>
+    <strong><%= @submission.provenance %></strong>
   </div>
 </div>
 
@@ -99,28 +81,10 @@
 
 <div class='overview-item'>
   <div class='overview-item-title'>
-    Created At
+    Location
   </div>
   <div class='overview-item-value'>
-    <%= @submission.created_at&.strftime('%b %-d @ %l:%M %p %Z') %>
-  </div>
-</div>
-
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Receipt Sent At
-  </div>
-  <div class='overview-item-value'>
-    <%= @submission.receipt_sent_at&.strftime('%b %-d @ %l:%M %p %Z') %>
-  </div>
-</div>
-
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Reminders Sent
-  </div>
-  <div class='overview-item-value'>
-    <%= @submission.reminders_sent_count %>
+    <%= formatted_location(@submission) %>
   </div>
 </div>
 
@@ -135,6 +99,15 @@
 
 <div class='overview-item'>
   <div class='overview-item-title'>
+    Auction Score
+  </div>
+  <div class='overview-item-value auction-score'>
+    <%= formatted_score(@submission.auction_score) %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
     Artist Score
   </div>
   <div class='overview-item-value artist-score'>
@@ -144,9 +117,9 @@
 
 <div class='overview-item'>
   <div class='overview-item-title'>
-    Auction Score
+    Created At
   </div>
-  <div class='overview-item-value auction-score'>
-    <%= formatted_score(@submission.auction_score) %>
+  <div class='overview-item-value'>
+    <%= @submission.created_at&.strftime('%b %-d @ %l:%M %p %Z') %>
   </div>
 </div>

--- a/spec/views/admin/submissions/edit.html.erb_spec.rb
+++ b/spec/views/admin/submissions/edit.html.erb_spec.rb
@@ -34,7 +34,7 @@ describe 'admin/submissions/edit.html.erb', type: :feature do
       fill_in('submission_title', with: 'my new artwork title')
       find_button('Save').click
       expect(@submission.reload.title).to eq('my new artwork title')
-      expect(page).to have_content('Gob Bluth')
+      expect(page).to have_content('Gob Bluth'.upcase)
       expect(page).to have_content('Add New')
     end
   end

--- a/spec/views/admin/submissions/new.html.erb_spec.rb
+++ b/spec/views/admin/submissions/new.html.erb_spec.rb
@@ -25,7 +25,7 @@ describe 'admin/submissions/new.html.erb', type: :feature do
       find_button('Create').click
       expect(page).to have_content('Submission #')
       expect(page).to have_content('my new artwork title')
-      expect(page).to have_content('Gob Bluth')
+      expect(page).to have_content('Gob Bluth'.upcase)
       expect(page).to have_content('Jon Jonson')
     end
   end

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -32,7 +32,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
 
     it 'displays the page title and content' do
       expect(page).to have_content("Submission ##{@submission.id}")
-      expect(page).to have_content('Gob Bluth')
+      expect(page).to have_content('Gob Bluth'.upcase)
       expect(page).to have_content('Jon Jonson')
       expect(page).to have_content('user@example.com')
       expect(page).to have_content('Painting')


### PR DESCRIPTION
This is just a rearranging of the fields in the details section of the submission detail page. Here's a before/after:

<img width="1241" alt="Screen Shot 2020-02-06 at 2 51 51 PM" src="https://user-images.githubusercontent.com/79799/73979888-b5f25880-48f4-11ea-977f-aa0e5bb1d262.png">
<img width="1241" alt="Screen Shot 2020-02-06 at 3 04 37 PM" src="https://user-images.githubusercontent.com/79799/73979896-b854b280-48f4-11ea-8619-1500413df062.png">

I ended up chatting with Noosh on this in Slack directly because it was easier/faster:

https://artsy.slack.com/archives/CS3H1K4BD/p1581022384044300