### PR TITLE
Add .env setup to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Convection is the application that powers our consignments workflow, enabling us
   $ bin/setup
   ```
 
+- Populate environment variables
+
+  `.env.example` contains the keys you'll need to add to your local `.env` file. Consider using [the `copy_env` utility](https://github.com/jonallured/copy_env) to populate the values directly from hokusai:
+
+  ```
+  $ copy_env hokusai
+  ```
+
 ## Tests
 
 Once setup, you can run the tests like this:


### PR DESCRIPTION
This PR updates the docs to include info about setting up a `.env` file.

It's possible that it could be automated to use `copy_env`, but I didn't want to put the time/effort into that.