### PR TITLE
CSGN-4: Handle commas in dollar conversion

### DIFF
--- a/app/models/concerns/dollarize.rb
+++ b/app/models/concerns/dollarize.rb
@@ -16,12 +16,15 @@ module Dollarize
         end
 
         define_method "#{method_name.to_s.gsub(/_cents$/, '_dollars')}=" do |dollars|
-          if dollars.blank?
-            self[method_name] = nil
-          else
-            cents = dollars.to_f * 100
-            self[method_name] = cents
-          end
+          cents = if dollars.blank?
+                    nil
+                  elsif dollars.is_a?(String)
+                    dollars.gsub(',', '').to_f * 100
+                  else
+                    dollars.to_f * 100
+                  end
+
+          self[method_name] = cents
         end
 
         define_method method_name.to_s.gsub(/_cents$/, '_display') do

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -125,6 +125,11 @@ describe Offer do
       expect(offer.low_estimate_dollars).to eq 100
       expect(offer.low_estimate_display).to eq '$100'
     end
+
+    it 'ignores commas' do
+      offer = Offer.new(price_dollars: '7,000')
+      expect(offer.price_cents).to eq 7_000_00
+    end
   end
 
   describe 'Percentize' do


### PR DESCRIPTION
In order to allow admins to continue entering commas in the UI of convection, this PR removes them when we convert from dollars to cents. This is nice because we won't interrupt their workflow but we don't make any data problems for ourselves. This also will work for ALL dollar fields rather than going through all the INPUT fields in the HAML files.