### PR TITLE
[Toolchain] Run prettier over codebase

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
     - bin/**/*
     - Gemfile
 
-# prevent warnings from         
+# prevent warnings from
 #   expect { PartnerSubmissionService.daily_digest }.to change { ActionMailer::Base.deliveries.length }
 # see https://github.com/rubocop-hq/rubocop/issues/4222
 
@@ -29,7 +29,7 @@ Layout/LineLength:
   Exclude:
     - config/environments/*
     - config/initializers/*
-  Max: 165
+  Max: 80
   IgnoreCopDirectives: true
 
 Layout/ParameterAlignment:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,6 +9,10 @@
 # Offense count: 5
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: slashes, arguments
+
+inherit_gem:
+  rubocop-config-prettier: config/rubocop.yml
+
 Rails/FilePath:
   Exclude:
     - 'config/application.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,10 @@ gem 'sidekiq', '<6' # for sending emails in the background (<6 necessary for Red
 gem 'uglifier'
 
 group :development, :test do
+  gem 'prettier'
   gem 'pry-byebug'
   gem 'rspec-rails'
+  gem 'rubocop-config-prettier'
   gem 'rubocop-rails'
   gem 'webdrivers', '~> 4.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
     premailer-rails (1.10.3)
       actionmailer (>= 3)
       premailer (~> 1.7, >= 1.7.9)
+    prettier (0.17.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -314,6 +315,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-config-prettier (0.1.2)
     rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -424,6 +426,7 @@ DEPENDENCIES
   pg
   pg_search
   premailer-rails
+  prettier
   pry-byebug
   puma
   rack-cors
@@ -433,6 +436,7 @@ DEPENDENCIES
   rails_param
   redcarpet
   rspec-rails
+  rubocop-config-prettier
   rubocop-rails
   sass-rails
   selenium-webdriver

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class AssetsController < ApplicationController
     before_action :set_submission
-    before_action :set_asset, only: [:show, :destroy]
+    before_action :set_asset, only: %i[show destroy]
 
     def show
       @original_image = @asset.original_image
@@ -19,7 +19,9 @@ module Admin
 
       gemini_tokens = params[:gemini_tokens].split(' ')
       gemini_tokens.each do |token|
-        @submission.assets.create(asset_type: params[:asset_type], gemini_token: token)
+        @submission.assets.create(
+          asset_type: params[:asset_type], gemini_token: token
+        )
       end
       redirect_to admin_submission_path(@submission)
     end

--- a/app/controllers/admin/consignments_controller.rb
+++ b/app/controllers/admin/consignments_controller.rb
@@ -2,15 +2,15 @@ module Admin
   class ConsignmentsController < ApplicationController
     include GraphqlHelper
 
-    before_action :set_consignment, only: [:show, :edit, :update]
+    before_action :set_consignment, only: %i[show edit update]
 
-    expose(:consignment) do
-      PartnerSubmission.consigned.find(params[:id])
-    end
+    expose(:consignment) { PartnerSubmission.consigned.find(params[:id]) }
 
     expose(:consignments) do
       matching_consignments = PartnerSubmission.consigned
-      matching_consignments = matching_consignments.search(term) if term.present?
+      if term.present?
+        matching_consignments = matching_consignments.search(term)
+      end
 
       if params[:partner].present?
         partner = Partner.find(params[:partner])
@@ -19,20 +19,29 @@ module Admin
 
       if params[:user].present?
         user = User.find(params[:user])
-        matching_consignments = matching_consignments.where(submission: user.submissions)
+        matching_consignments =
+          matching_consignments.where(submission: user.submissions)
       end
 
-      matching_consignments = matching_consignments.where(state: params[:state]) if params[:state].present?
+      if params[:state].present?
+        matching_consignments =
+          matching_consignments.where(state: params[:state])
+      end
 
       sort = params[:sort].presence || 'id'
       direction = params[:direction].presence || 'desc'
-      matching_consignments = if sort.include?('partners')
-                                matching_consignments.includes(:partner).reorder("#{sort} #{direction}, partner_submissions.id desc")
-                              elsif sort.include?('offers')
-                                matching_consignments.joins(:accepted_offer).reorder("#{sort} #{direction}, partner_submissions.id desc")
-                              else
-                                matching_consignments.reorder("#{sort} #{direction}")
-                              end
+      matching_consignments =
+        if sort.include?('partners')
+          matching_consignments.includes(:partner).reorder(
+            "#{sort} #{direction}, partner_submissions.id desc"
+          )
+        elsif sort.include?('offers')
+          matching_consignments.joins(:accepted_offer).reorder(
+            "#{sort} #{direction}, partner_submissions.id desc"
+          )
+        else
+          matching_consignments.reorder("#{sort} #{direction}")
+        end
 
       matching_consignments.page(page).per(size)
     end
@@ -46,20 +55,20 @@ module Admin
     end
 
     expose(:filters) do
-      { state: params[:state], partner: params[:partner], user: params[:user], sort: params[:sort], direction: params[:direction] }
+      {
+        state: params[:state],
+        partner: params[:partner],
+        user: params[:user],
+        sort: params[:sort],
+        direction: params[:direction]
+      }
     end
 
-    expose(:counts) do
-      PartnerSubmission.consigned.group(:state).count
-    end
+    expose(:counts) { PartnerSubmission.consigned.group(:state).count }
 
-    expose(:consignments_count) do
-      PartnerSubmission.consigned.count
-    end
+    expose(:consignments_count) { PartnerSubmission.consigned.count }
 
-    expose(:term) do
-      params[:term]
-    end
+    expose(:term) { params[:term] }
 
     def show
       @artist_details = artists_query([@consignment.submission.artist_id])

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -6,29 +6,22 @@ module Admin
       Submission.not_deleted.submitted.order(id: :desc).take(4)
     end
 
-    expose(:offers) do
-      Offer.sent.order(id: :desc).take(4)
-    end
+    expose(:offers) { Offer.sent.order(id: :desc).take(4) }
 
     expose(:consignments) do
       PartnerSubmission.consigned.order(id: :desc).take(4)
     end
 
-    expose(:submissions_count) do
-      Submission.not_deleted.submitted.count
-    end
+    expose(:submissions_count) { Submission.not_deleted.submitted.count }
 
-    expose(:offers_count) do
-      Offer.sent.count
-    end
+    expose(:offers_count) { Offer.sent.count }
 
-    expose(:consignments_count) do
-      PartnerSubmission.consigned.count
-    end
+    expose(:consignments_count) { PartnerSubmission.consigned.count }
 
     expose(:artist_details) do
       submission_artists = artists_query(submissions.map(&:artist_id)) || {}
-      consignment_artists = artists_query(consignments.map(&:submission).map(&:artist_id)) || {}
+      consignment_artists =
+        artists_query(consignments.map(&:submission).map(&:artist_id)) || {}
       submission_artists.merge(consignment_artists)
     end
 

--- a/app/controllers/admin/offers_controller.rb
+++ b/app/controllers/admin/offers_controller.rb
@@ -2,13 +2,15 @@ module Admin
   class OffersController < ApplicationController
     include GraphqlHelper
 
-    before_action :set_offer, only: [:show, :edit, :update, :destroy]
+    before_action :set_offer, only: %i[show edit update destroy]
 
     expose :offer
 
     expose(:offers) do
       matching_offers = Offer.all
-      matching_offers = matching_offers.search(params[:term]) if params[:term].present?
+      if params[:term].present?
+        matching_offers = matching_offers.search(params[:term])
+      end
 
       if params[:partner].present?
         partner = Partner.find(params[:partner])
@@ -20,32 +22,38 @@ module Admin
         matching_offers = matching_offers.where(submission: user.submissions)
       end
 
-      matching_offers = matching_offers.where(state: params[:state]) if params[:state].present?
+      if params[:state].present?
+        matching_offers = matching_offers.where(state: params[:state])
+      end
 
       sort = params[:sort].presence || 'id'
       direction = params[:direction].presence || 'desc'
-      matching_offers = if sort.include?('partners')
-                          matching_offers.includes(:partner_submission).includes(:partner).reorder("#{sort} #{direction}")
-                        elsif sort.include?('submissions')
-                          matching_offers.includes(:submission).reorder("#{sort} #{direction}")
-                        else
-                          matching_offers.reorder("#{sort} #{direction}")
-                        end
+      matching_offers =
+        if sort.include?('partners')
+          matching_offers.includes(:partner_submission).includes(:partner)
+            .reorder("#{sort} #{direction}")
+        elsif sort.include?('submissions')
+          matching_offers.includes(:submission).reorder("#{sort} #{direction}")
+        else
+          matching_offers.reorder("#{sort} #{direction}")
+        end
 
       matching_offers.page(page).per(size)
     end
 
     expose(:filters) do
-      { state: params[:state], partner: params[:partner], user: params[:user], sort: params[:sort], direction: params[:direction] }
+      {
+        state: params[:state],
+        partner: params[:partner],
+        user: params[:user],
+        sort: params[:sort],
+        direction: params[:direction]
+      }
     end
 
-    expose(:counts) do
-      Offer.group(:state).count
-    end
+    expose(:counts) { Offer.group(:state).count }
 
-    expose(:offers_count) do
-      Offer.count
-    end
+    expose(:offers_count) { Offer.count }
 
     expose(:partner) do
       Partner.find(params[:partner_id]) if params[:partner_id].present?
@@ -55,9 +63,7 @@ module Admin
       Submission.find(params[:submission_id]) if params[:submission_id].present?
     end
 
-    expose(:term) do
-      params[:term]
-    end
+    expose(:term) { params[:term] }
 
     expose(:artist) do
       artists_query([offer.submission.artist_id])&.values&.first
@@ -65,13 +71,16 @@ module Admin
 
     def new_step_0
       @offer = Offer.new
-      @submission = Submission.find(params[:submission_id]) if params[:submission_id]
+      if params[:submission_id]
+        @submission = Submission.find(params[:submission_id])
+      end
     end
 
     def new_step_1
       @offer = Offer.new(offer_type: params[:offer_type])
 
-      if params[:submission_id].present? && params[:partner_id].present? && params[:offer_type].present?
+      if params[:submission_id].present? && params[:partner_id].present? &&
+           params[:offer_type].present?
         render 'new_step_1'
       else
         flash.now[:error] = 'Offer requires type, submission, and partner.'
@@ -80,7 +89,13 @@ module Admin
     end
 
     def create
-      @offer = OfferService.create_offer(params[:submission_id], params[:partner_id], offer_params, @current_user)
+      @offer =
+        OfferService.create_offer(
+          params[:submission_id],
+          params[:partner_id],
+          offer_params,
+          @current_user
+        )
       redirect_to admin_offer_path(@offer)
     rescue OfferService::OfferError => e
       flash.now[:error] = e.message

--- a/app/controllers/admin/partner_submissions_controller.rb
+++ b/app/controllers/admin/partner_submissions_controller.rb
@@ -9,9 +9,13 @@ module Admin
       @partner = Partner.find(params[:partner_id])
 
       partner_submissions = @partner.partner_submissions
-      partner_submissions = partner_submissions.where(notified_at: notified_at) if params[:notified_at]
+      if params[:notified_at]
+        partner_submissions =
+          partner_submissions.where(notified_at: notified_at)
+      end
       @partner_submissions = partner_submissions.page(page).per(size)
-      @artist_details = artists_query(@partner_submissions.map(&:submission).map(&:artist_id))
+      @artist_details =
+        artists_query(@partner_submissions.map(&:submission).map(&:artist_id))
     end
   end
 end

--- a/app/controllers/admin/partners_controller.rb
+++ b/app/controllers/admin/partners_controller.rb
@@ -4,13 +4,13 @@ module Admin
 
     expose(:partners) do
       matching_partners = Partner.all
-      matching_partners = matching_partners.search_by_name(params[:term]) if params[:term].present?
+      if params[:term].present?
+        matching_partners = matching_partners.search_by_name(params[:term])
+      end
       matching_partners.page(page).per(size)
     end
 
-    expose(:term) do
-      params[:term]
-    end
+    expose(:term) { params[:term] }
 
     def index
       respond_to do |format|
@@ -20,12 +20,20 @@ module Admin
     end
 
     def create
-      partner = Partner.new(gravity_partner_id: params[:gravity_partner_id], name: params[:name]) if params[:gravity_partner_id]
+      if params[:gravity_partner_id]
+        partner =
+          Partner.new(
+            gravity_partner_id: params[:gravity_partner_id], name: params[:name]
+          )
+      end
       if partner&.save
         flash[:notice] = 'Partner successfully created.'
         redirect_to admin_partners_path
       else
-        flash.now[:error] = "Error creating gravity partner. #{partner&.errors&.full_messages&.to_sentence}"
+        flash.now[:error] =
+          "Error creating gravity partner. #{
+            partner&.errors&.full_messages&.to_sentence
+          }"
         render 'index'
       end
     end
@@ -35,9 +43,7 @@ module Admin
         @term = params[:term]
         @partners = match_partners_query(@term)
       end
-      respond_to do |format|
-        format.json { render json: @partners || [] }
-      end
+      respond_to { |format| format.json { render json: @partners || [] } }
     end
   end
 end

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -2,38 +2,55 @@ module Admin
   class SubmissionsController < ApplicationController
     include GraphqlHelper
 
-    before_action :set_submission, only: [:show, :edit, :update, :undo_approval, :undo_rejection]
+    before_action :set_submission,
+                  only: %i[show edit update undo_approval undo_rejection]
 
     expose(:submissions) do
       matching_submissions = Submission.not_deleted
-      matching_submissions = matching_submissions.search(params[:term]) if params[:term].present?
-      matching_submissions = matching_submissions.where(state: params[:state]) if params[:state].present?
-      matching_submissions = matching_submissions.where(user_id: params[:user]) if params[:user].present?
+      if params[:term].present?
+        matching_submissions = matching_submissions.search(params[:term])
+      end
+      if params[:state].present?
+        matching_submissions = matching_submissions.where(state: params[:state])
+      end
+      if params[:user].present?
+        matching_submissions =
+          matching_submissions.where(user_id: params[:user])
+      end
 
       sort = params[:sort].presence || 'id'
       direction = params[:direction].presence || 'desc'
 
-      matching_submissions = if sort.include?('users')
-                               matching_submissions.includes(:user).reorder("#{sort} #{direction}, submissions.id desc")
-                             else
-                               matching_submissions.reorder("#{sort} #{direction}")
-                             end
+      matching_submissions =
+        if sort.include?('users')
+          matching_submissions.includes(:user).reorder(
+            "#{sort} #{direction}, submissions.id desc"
+          )
+        else
+          matching_submissions.reorder("#{sort} #{direction}")
+        end
       matching_submissions.page(page).per(size)
     end
 
-    expose(:artist_details) do
-      artists_query(submissions.map(&:artist_id))
-    end
+    expose(:artist_details) { artists_query(submissions.map(&:artist_id)) }
 
     expose(:filters) do
-      { state: params[:state], user: params[:user], sort: params[:sort], direction: params[:direction] }
+      {
+        state: params[:state],
+        user: params[:user],
+        sort: params[:sort],
+        direction: params[:direction]
+      }
     end
 
     def index
       respond_to do |format|
         format.html
         format.json do
-          submissions_with_thumbnails = submissions.map { |submission| submission.as_json.merge(thumbnail: submission.thumbnail) }
+          submissions_with_thumbnails =
+            submissions.map do |submission|
+              submission.as_json.merge(thumbnail: submission.thumbnail)
+            end
           render json: submissions_with_thumbnails || []
         end
       end
@@ -44,7 +61,11 @@ module Admin
     end
 
     def create
-      @submission = SubmissionService.create_submission(submission_params.merge(state: 'submitted'), params[:submission][:user_id])
+      @submission =
+        SubmissionService.create_submission(
+          submission_params.merge(state: 'submitted'),
+          params[:submission][:user_id]
+        )
       redirect_to admin_submission_path(@submission)
     rescue SubmissionService::SubmissionError => e
       @submission = Submission.new(submission_params)
@@ -53,15 +74,21 @@ module Admin
     end
 
     def show
-      notified_partner_submissions = @submission.partner_submissions.where.not(notified_at: nil)
-      @partner_submissions_count = notified_partner_submissions.group_by_day.count
+      notified_partner_submissions =
+        @submission.partner_submissions.where.not(notified_at: nil)
+      @partner_submissions_count =
+        notified_partner_submissions.group_by_day.count
       @offers = @submission.offers
     end
 
     def edit; end
 
     def update
-      if SubmissionService.update_submission(@submission, submission_params, @current_user)
+      if SubmissionService.update_submission(
+           @submission,
+           submission_params,
+           @current_user
+         )
         redirect_to admin_submission_path(@submission)
       else
         render 'edit'
@@ -86,9 +113,7 @@ module Admin
         term = params[:term]
         artists = Gravity.client.artists(term: term).artists
       end
-      respond_to do |format|
-        format.json { render json: artists || [] }
-      end
+      respond_to { |format| format.json { render json: artists || [] } }
     end
 
     def match_user
@@ -96,9 +121,7 @@ module Admin
         term = params[:term]
         users = Gravity.client.users(term: term).users
       end
-      respond_to do |format|
-        format.json { render json: users || [] }
-      end
+      respond_to { |format| format.json { render json: users || [] } }
     end
 
     private

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,18 +2,16 @@ module Admin
   class UsersController < ApplicationController
     expose(:users) do
       matching_users = User.all
-      matching_users = matching_users.search(params[:term]) if params[:term].present?
+      if params[:term].present?
+        matching_users = matching_users.search(params[:term])
+      end
       matching_users.page(page).per(size)
     end
 
-    expose(:term) do
-      params[:term]
-    end
+    expose(:term) { params[:term] }
 
     def index
-      respond_to do |format|
-        format.json { render json: users || [] }
-      end
+      respond_to { |format| format.json { render json: users || [] } }
     end
   end
 end

--- a/app/controllers/api/assets_controller.rb
+++ b/app/controllers/api/assets_controller.rb
@@ -1,8 +1,8 @@
 module Api
   class AssetsController < BaseController
     before_action :require_authentication
-    before_action :set_submission_and_asset, only: [:show]
-    before_action :set_submission, only: [:create, :index]
+    before_action :set_submission_and_asset, only: %i[show]
+    before_action :set_submission, only: %i[create index]
     before_action :require_authorized_submission
 
     def index
@@ -36,11 +36,7 @@ module Api
     end
 
     def asset_params
-      params.permit(
-        :asset_type,
-        :gemini_token,
-        :submission_id
-      )
+      params.permit(:asset_type, :gemini_token, :submission_id)
     end
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -26,15 +26,22 @@ module Api
     end
 
     def require_trusted_app
-      raise ApplicationController::NotAuthorized unless current_app.present? && current_user.blank? && current_user_roles.include?(:trusted)
+      unless current_app.present? && current_user.blank? &&
+               current_user_roles.include?(:trusted)
+        raise ApplicationController::NotAuthorized
+      end
     end
 
     def require_authentication
-      raise ApplicationController::NotAuthorized unless current_app && current_user
+      unless current_app && current_user
+        raise ApplicationController::NotAuthorized
+      end
     end
 
     def require_authorized_submission
-      raise ApplicationController::NotAuthorized unless current_user && current_user == @submission.user&.gravity_user_id
+      unless current_user && current_user == @submission.user&.gravity_user_id
+        raise ApplicationController::NotAuthorized
+      end
     end
 
     private
@@ -57,7 +64,8 @@ module Api
     end
 
     def current_user_roles
-      @current_user_roles ||= jwt_payload&.fetch('roles', nil)&.split(',')&.map(&:to_sym) || []
+      @current_user_roles ||=
+        jwt_payload&.fetch('roles', nil)&.split(',')&.map(&:to_sym) || []
     end
   end
 end

--- a/app/controllers/api/graphql_controller.rb
+++ b/app/controllers/api/graphql_controller.rb
@@ -1,15 +1,16 @@
 module Api
   class GraphqlController < BaseController
     def execute
-      result = RootSchema.execute(
-        params[:query],
-        variables: params[:variables],
-        context: {
-          current_application: current_app,
-          current_user: current_user,
-          current_user_roles: current_user_roles
-        }
-      )
+      result =
+        RootSchema.execute(
+          params[:query],
+          variables: params[:variables],
+          context: {
+            current_application: current_app,
+            current_user: current_user,
+            current_user_roles: current_user_roles
+          }
+        )
       render json: result, status: :ok
     end
   end

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -1,8 +1,8 @@
 module Api
   class SubmissionsController < BaseController
     before_action :require_authentication
-    before_action :set_submission, only: [:show, :update]
-    before_action :require_authorized_submission, only: [:show, :update]
+    before_action :set_submission, only: %i[show update]
+    before_action :require_authorized_submission, only: %i[show update]
 
     def show
       render json: @submission.to_json, status: :ok
@@ -10,7 +10,8 @@ module Api
 
     def create
       param! :artist_id, String, required: true
-      submission = SubmissionService.create_submission(submission_params, current_user)
+      submission =
+        SubmissionService.create_submission(submission_params, current_user)
       render json: submission.to_json, status: :created
     end
 
@@ -25,7 +26,8 @@ module Api
       user = User.where(gravity_user_id: current_user).first
       submissions = Submission.where(user: user)
       if params.include? :completed
-        submissions = params[:completed] ? submissions.completed : submissions.draft
+        submissions =
+          params[:completed] ? submissions.completed : submissions.draft
       end
 
       submissions = submissions.order(created_at: :desc).page(page).per(size)
@@ -59,7 +61,8 @@ module Api
         :title,
         :width,
         :year
-      ).merge(user_agent: request.user_agent)
+      )
+        .merge(user_agent: request.user_agent)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,13 +13,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery prepend: true, with: :exception
 
-  expose(:page) do
-    (params[:page] || 1).to_i
-  end
+  expose(:page) { (params[:page] || 1).to_i }
 
-  expose(:size) do
-    (params[:size] || 10).to_i
-  end
+  expose(:size) { (params[:size] || 10).to_i }
 
   # override application to decode token and allow only users with `admin` role
   def authorized_artsy_token?(token)

--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -1,42 +1,52 @@
 module GraphqlHelper
   extend ActiveSupport::Concern
 
-  ARTISTS_DETAILS_QUERY = %|
+  ARTISTS_DETAILS_QUERY =
+    '
   query artistsDetails($ids: [ID!]!){
     artists(ids: $ids){
       id
       name
     }
   }
-  |.freeze
+  '
+      .freeze
 
-  MATCH_PARTNERS_QUERY = %|
+  MATCH_PARTNERS_QUERY =
+    '
   query matchPartners($term: String!) {
     match_partners(term: $term){
       id
       given_name
     }
   }
-  |.freeze
+  '
+      .freeze
 
   def artists_query(artist_ids)
-    artist_details_response = Gravql::Schema.execute(
-      query: ARTISTS_DETAILS_QUERY,
-      variables: { ids: artist_ids.uniq }
-    )
-    flash.now[:error] = 'Error fetching artist details.' if artist_details_response[:errors].present?
+    artist_details_response =
+      Gravql::Schema.execute(
+        query: ARTISTS_DETAILS_QUERY, variables: { ids: artist_ids.uniq }
+      )
+    if artist_details_response[:errors].present?
+      flash.now[:error] = 'Error fetching artist details.'
+    end
     return if artist_details_response.try(:[], :data).try(:[], :artists).blank?
 
     artist_details_response[:data][:artists].map { |h| [h[:id], h[:name]] }.to_h
   end
 
   def match_partners_query(term)
-    match_partners_response = Gravql::Schema.execute(
-      query: MATCH_PARTNERS_QUERY,
-      variables: { term: term }
-    )
-    flash.now[:error] = 'Error fetching partner details.' if match_partners_response[:errors].present?
-    return if match_partners_response.try(:[], :data).try(:[], :match_partners).blank?
+    match_partners_response =
+      Gravql::Schema.execute(
+        query: MATCH_PARTNERS_QUERY, variables: { term: term }
+      )
+    if match_partners_response[:errors].present?
+      flash.now[:error] = 'Error fetching partner details.'
+    end
+    if match_partners_response.try(:[], :data).try(:[], :match_partners).blank?
+      return
+    end
 
     match_partners_response[:data][:match_partners]
   end

--- a/app/events/submission_event.rb
+++ b/app/events/submission_event.rb
@@ -6,10 +6,7 @@ class SubmissionEvent < Events::BaseEvent
   ].freeze
 
   def object
-    {
-      id: @object.id,
-      display: "#{@object.id} (#{@object.state})"
-    }
+    { id: @object.id, display: "#{@object.id} (#{@object.state})" }
   end
 
   def subject

--- a/app/graph/mutations/add_asset_to_consignment_submission.rb
+++ b/app/graph/mutations/add_asset_to_consignment_submission.rb
@@ -1,26 +1,32 @@
 module Mutations
   module AddAssetToConsignmentSubmission
-    Definition = GraphQL::Relay::Mutation.define do
-      name 'AddAssetToConsignmentSubmission'
+    Definition =
+      GraphQL::Relay::Mutation.define do
+        name 'AddAssetToConsignmentSubmission'
 
-      input_field :submission_id, !types.ID
-      input_field :gemini_token, !types.String
-      input_field :asset_type, types.String
+        input_field :submission_id, !types.ID
+        input_field :gemini_token, !types.String
+        input_field :asset_type, types.String
 
-      return_field :asset, Types::AssetType
-    end
+        return_field :asset, Types::AssetType
+      end
 
     def self.resolve(_obj, args, context)
       params = args.to_h['input'].except('clientMutationId')
       client_mutation_id = args.to_h['input']['clientMutationId']
 
       submission = Submission.find_by(id: params['submission_id'])
-      raise(GraphQL::ExecutionError, 'Submission from ID Not Found') unless submission
+      unless submission
+        raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
+      end
 
-      is_same_as_user = submission&.user&.gravity_user_id == context[:current_user]
+      is_same_as_user =
+        submission&.user&.gravity_user_id == context[:current_user]
       is_admin = context[:current_user_roles].include?(:admin)
 
-      raise(GraphQL::ExecutionError, 'Submission from ID Not Found') unless is_same_as_user || is_admin
+      unless is_same_as_user || is_admin
+        raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
+      end
 
       params['asset_type'] ||= 'image'
       asset = submission.assets.create!(params)

--- a/app/graph/mutations/create_consignment_submission.rb
+++ b/app/graph/mutations/create_consignment_submission.rb
@@ -1,39 +1,44 @@
 module Mutations
   module CreateConsignmentSubmission
-    Definition = GraphQL::Relay::Mutation.define do
-      name 'CreateConsignmentSubmission'
+    Definition =
+      GraphQL::Relay::Mutation.define do
+        name 'CreateConsignmentSubmission'
 
-      input_field :additional_info, types.String
-      input_field :artist_id, !types.String
-      input_field :authenticity_certificate, types.Boolean
-      input_field :category, Types::CategoryType
-      input_field :currency, types.String
-      input_field :depth, types.String
-      input_field :dimensions_metric, types.String
-      input_field :edition, types.Boolean
-      input_field :edition_number, types.String
-      input_field :edition_size, types.Int
-      input_field :height, types.String
-      input_field :location_city, types.String
-      input_field :location_country, types.String
-      input_field :location_state, types.String
-      input_field :medium, types.String
-      input_field :minimum_price_dollars, types.Int
-      input_field :provenance, types.String
-      input_field :signature, types.Boolean
-      input_field :state, Types::StateType
-      input_field :title, types.String
-      input_field :width, types.String
-      input_field :year, types.String
+        input_field :additional_info, types.String
+        input_field :artist_id, !types.String
+        input_field :authenticity_certificate, types.Boolean
+        input_field :category, Types::CategoryType
+        input_field :currency, types.String
+        input_field :depth, types.String
+        input_field :dimensions_metric, types.String
+        input_field :edition, types.Boolean
+        input_field :edition_number, types.String
+        input_field :edition_size, types.Int
+        input_field :height, types.String
+        input_field :location_city, types.String
+        input_field :location_country, types.String
+        input_field :location_state, types.String
+        input_field :medium, types.String
+        input_field :minimum_price_dollars, types.Int
+        input_field :provenance, types.String
+        input_field :signature, types.Boolean
+        input_field :state, Types::StateType
+        input_field :title, types.String
+        input_field :width, types.String
+        input_field :year, types.String
 
-      return_field :consignment_submission, Types::SubmissionType
-    end
+        return_field :consignment_submission, Types::SubmissionType
+      end
 
     def self.resolve(_obj, args, context)
       params = args.to_h['input'].except('clientMutationId')
       client_mutation_id = args.to_h['input']['clientMutationId']
-      submission = SubmissionService.create_submission(params, context[:current_user])
-      OpenStruct.new(consignment_submission: submission, client_mutation_id: client_mutation_id)
+      submission =
+        SubmissionService.create_submission(params, context[:current_user])
+      OpenStruct.new(
+        consignment_submission: submission,
+        client_mutation_id: client_mutation_id
+      )
     end
   end
 end

--- a/app/graph/mutations/update_consignment_submission.rb
+++ b/app/graph/mutations/update_consignment_submission.rb
@@ -1,48 +1,57 @@
 module Mutations
   module UpdateConsignmentSubmission
-    Definition = GraphQL::Relay::Mutation.define do
-      name 'UpdateConsignmentSubmission'
+    Definition =
+      GraphQL::Relay::Mutation.define do
+        name 'UpdateConsignmentSubmission'
 
-      input_field :id, !types.ID
-      input_field :additional_info, types.String
-      input_field :artist_id, types.String
-      input_field :authenticity_certificate, types.Boolean
-      input_field :category, Types::CategoryType
-      input_field :currency, types.String
-      input_field :depth, types.String
-      input_field :dimensions_metric, types.String
-      input_field :edition, types.Boolean
-      input_field :edition_number, types.String
-      input_field :edition_size, types.Int
-      input_field :height, types.String
-      input_field :location_city, types.String
-      input_field :location_country, types.String
-      input_field :location_state, types.String
-      input_field :medium, types.String
-      input_field :minimum_price_dollars, types.Int
-      input_field :provenance, types.String
-      input_field :signature, types.Boolean
-      input_field :state, Types::StateType
-      input_field :title, types.String
-      input_field :width, types.String
-      input_field :year, types.String
+        input_field :id, !types.ID
+        input_field :additional_info, types.String
+        input_field :artist_id, types.String
+        input_field :authenticity_certificate, types.Boolean
+        input_field :category, Types::CategoryType
+        input_field :currency, types.String
+        input_field :depth, types.String
+        input_field :dimensions_metric, types.String
+        input_field :edition, types.Boolean
+        input_field :edition_number, types.String
+        input_field :edition_size, types.Int
+        input_field :height, types.String
+        input_field :location_city, types.String
+        input_field :location_country, types.String
+        input_field :location_state, types.String
+        input_field :medium, types.String
+        input_field :minimum_price_dollars, types.Int
+        input_field :provenance, types.String
+        input_field :signature, types.Boolean
+        input_field :state, Types::StateType
+        input_field :title, types.String
+        input_field :width, types.String
+        input_field :year, types.String
 
-      return_field :consignment_submission, Types::SubmissionType
-    end
+        return_field :consignment_submission, Types::SubmissionType
+      end
 
     def self.resolve(_obj, args, context)
       params = args.to_h['input'].except('clientMutationId')
       client_mutation_id = args.to_h['input']['clientMutationId']
 
       submission = Submission.find_by(id: params['id'])
-      raise(GraphQL::ExecutionError, 'Submission from ID Not Found') unless submission
+      unless submission
+        raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
+      end
 
-      is_same_as_user = submission&.user&.gravity_user_id == context[:current_user]
+      is_same_as_user =
+        submission&.user&.gravity_user_id == context[:current_user]
       is_admin = context[:current_user_roles].include?(:admin)
-      raise(GraphQL::ExecutionError, 'Submission Not Found') unless is_same_as_user || is_admin
+      unless is_same_as_user || is_admin
+        raise(GraphQL::ExecutionError, 'Submission Not Found')
+      end
 
       SubmissionService.update_submission(submission, params.except('id'))
-      OpenStruct.new(consignment_submission: submission, client_mutation_id: client_mutation_id)
+      OpenStruct.new(
+        consignment_submission: submission,
+        client_mutation_id: client_mutation_id
+      )
     end
   end
 end

--- a/app/graph/root_schema.rb
+++ b/app/graph/root_schema.rb
@@ -1,10 +1,15 @@
-GraphQL::Field.accepts_definitions(permit: GraphQL::Define.assign_metadata_key(:permit))
-GraphQL::Argument.accepts_definitions(permit: GraphQL::Define.assign_metadata_key(:permit))
+GraphQL::Field.accepts_definitions(
+  permit: GraphQL::Define.assign_metadata_key(:permit)
+)
+GraphQL::Argument.accepts_definitions(
+  permit: GraphQL::Define.assign_metadata_key(:permit)
+)
 
-RootSchema = GraphQL::Schema.define do
-  query Types::QueryType
-  mutation Types::MutationType
+RootSchema =
+  GraphQL::Schema.define do
+    query Types::QueryType
+    mutation Types::MutationType
 
-  instrument(:field, Util::AuthorizationInstrumentation.new)
-  max_depth 5
-end
+    instrument(:field, Util::AuthorizationInstrumentation.new)
+    max_depth 5
+  end

--- a/app/graph/types/asset_type.rb
+++ b/app/graph/types/asset_type.rb
@@ -1,11 +1,12 @@
 module Types
-  AssetType = GraphQL::ObjectType.define do
-    name 'Asset'
-    description 'Submission Asset'
+  AssetType =
+    GraphQL::ObjectType.define do
+      name 'Asset'
+      description 'Submission Asset'
 
-    field :id, !types.ID, 'Uniq ID for this asset'
-    field :asset_type, !types.String, 'type of this Asset'
-    field :gemini_token, types.String, 'gemini token for asset'
-    field :submission_id, !types.ID
-  end
+      field :id, !types.ID, 'Uniq ID for this asset'
+      field :asset_type, !types.String, 'type of this Asset'
+      field :gemini_token, types.String, 'gemini token for asset'
+      field :submission_id, !types.ID
+    end
 end

--- a/app/graph/types/category_type.rb
+++ b/app/graph/types/category_type.rb
@@ -1,20 +1,29 @@
 module Types
-  CategoryType = GraphQL::EnumType.define do
-    name 'Category'
-    value('PAINTING', nil, value: 'Painting')
-    value('SCULPTURE', nil, value: 'Sculpture')
-    value('PHOTOGRAPHY', nil, value: 'Photography')
-    value('PRINT', nil, value: 'Print')
-    value('DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER', nil, value: 'Drawing, Collage or other Work on Paper')
-    value('MIXED_MEDIA', nil, value: 'Mixed Media')
-    value('PERFORMANCE_ART', nil, value: 'Performance Art')
-    value('INSTALLATION', nil, value: 'Installation')
-    value('VIDEO_FILM_ANIMATION', nil, value: 'Video/Film/Animation')
-    value('ARCHITECTURE', nil, value: 'Architecture')
-    value('FASHION_DESIGN_AND_WEARABLE_ART', nil, value: 'Fashion Design and Wearable Art')
-    value('JEWELRY', nil, value: 'Jewelry')
-    value('DESIGN_DECORATIVE_ART', nil, value: 'Design/Decorative Art')
-    value('TEXTILE_ARTS', nil, value: 'Textile Arts')
-    value('OTHER', nil, value: 'Other')
-  end
+  CategoryType =
+    GraphQL::EnumType.define do
+      name 'Category'
+      value('PAINTING', nil, value: 'Painting')
+      value('SCULPTURE', nil, value: 'Sculpture')
+      value('PHOTOGRAPHY', nil, value: 'Photography')
+      value('PRINT', nil, value: 'Print')
+      value(
+        'DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER',
+        nil,
+        value: 'Drawing, Collage or other Work on Paper'
+      )
+      value('MIXED_MEDIA', nil, value: 'Mixed Media')
+      value('PERFORMANCE_ART', nil, value: 'Performance Art')
+      value('INSTALLATION', nil, value: 'Installation')
+      value('VIDEO_FILM_ANIMATION', nil, value: 'Video/Film/Animation')
+      value('ARCHITECTURE', nil, value: 'Architecture')
+      value(
+        'FASHION_DESIGN_AND_WEARABLE_ART',
+        nil,
+        value: 'Fashion Design and Wearable Art'
+      )
+      value('JEWELRY', nil, value: 'Jewelry')
+      value('DESIGN_DECORATIVE_ART', nil, value: 'Design/Decorative Art')
+      value('TEXTILE_ARTS', nil, value: 'Textile Arts')
+      value('OTHER', nil, value: 'Other')
+    end
 end

--- a/app/graph/types/date_type.rb
+++ b/app/graph/types/date_type.rb
@@ -1,9 +1,10 @@
 module Types
-  DateType = GraphQL::ScalarType.define do
-    name 'Date'
-    description 'Date type'
+  DateType =
+    GraphQL::ScalarType.define do
+      name 'Date'
+      description 'Date type'
 
-    coerce_input ->(value, _ctx) { Date.new(value) }
-    coerce_result ->(value, _ctx) { value.to_f }
-  end
+      coerce_input ->(value, _ctx) { Date.new(value) }
+      coerce_result ->(value, _ctx) { value.to_f }
+    end
 end

--- a/app/graph/types/json_type.rb
+++ b/app/graph/types/json_type.rb
@@ -1,7 +1,8 @@
 module Types
-  JsonType = GraphQL::ScalarType.define do
-    name 'JSON'
-    coerce_input ->(x, _ctx) { JSON.parse(x) }
-    coerce_result ->(x, _ctx) { JSON.dump(x) }
-  end
+  JsonType =
+    GraphQL::ScalarType.define do
+      name 'JSON'
+      coerce_input ->(x, _ctx) { JSON.parse(x) }
+      coerce_result ->(x, _ctx) { JSON.dump(x) }
+    end
 end

--- a/app/graph/types/mutation_type.rb
+++ b/app/graph/types/mutation_type.rb
@@ -1,33 +1,54 @@
 module Types
-  MutationType = GraphQL::ObjectType.define do
-    name 'Mutation'
-    description 'Mutation root for this schema'
+  MutationType =
+    GraphQL::ObjectType.define do
+      name 'Mutation'
+      description 'Mutation root for this schema'
 
-    field :createConsignmentSubmission, Mutations::CreateConsignmentSubmission::Definition.return_type do
-      permit :user
-      argument :input, Mutations::CreateConsignmentSubmission::Definition.input_type
+      field :createConsignmentSubmission,
+            Mutations::CreateConsignmentSubmission::Definition.return_type do
+        permit :user
+        argument :input,
+                 Mutations::CreateConsignmentSubmission::Definition.input_type
 
-      resolve ->(obj, args, context) {
-        Mutations::CreateConsignmentSubmission.resolve(obj, args, context)
-      }
+        resolve lambda { |obj, args, context|
+                  Mutations::CreateConsignmentSubmission.resolve(
+                    obj,
+                    args,
+                    context
+                  )
+                }
+      end
+
+      field :updateConsignmentSubmission,
+            Mutations::UpdateConsignmentSubmission::Definition.return_type do
+        permit :user
+        argument :input,
+                 Mutations::UpdateConsignmentSubmission::Definition.input_type
+
+        resolve lambda { |obj, args, context|
+                  Mutations::UpdateConsignmentSubmission.resolve(
+                    obj,
+                    args,
+                    context
+                  )
+                }
+      end
+
+      field :addAssetToConsignmentSubmission,
+            Mutations::AddAssetToConsignmentSubmission::Definition
+              .return_type do
+        description 'Create an asset'
+        argument :input,
+                 Mutations::AddAssetToConsignmentSubmission::Definition
+                   .input_type
+
+        resolve lambda { |obj, args, context|
+                  Mutations::AddAssetToConsignmentSubmission.resolve(
+                    obj,
+                    args,
+                    context
+                  )
+                }
+      end
     end
-
-    field :updateConsignmentSubmission, Mutations::UpdateConsignmentSubmission::Definition.return_type do
-      permit :user
-      argument :input, Mutations::UpdateConsignmentSubmission::Definition.input_type
-
-      resolve ->(obj, args, context) {
-        Mutations::UpdateConsignmentSubmission.resolve(obj, args, context)
-      }
-    end
-
-    field :addAssetToConsignmentSubmission, Mutations::AddAssetToConsignmentSubmission::Definition.return_type do
-      description 'Create an asset'
-      argument :input, Mutations::AddAssetToConsignmentSubmission::Definition.input_type
-
-      resolve ->(obj, args, context) {
-        Mutations::AddAssetToConsignmentSubmission.resolve(obj, args, context)
-      }
-    end
-  end
 end

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -1,46 +1,73 @@
 module Types
-  QueryType = GraphQL::ObjectType.define do
-    name 'Query'
-    description 'Query root for this schema'
-    field :submission, Types::SubmissionType do
-      description 'Get a Submission'
-      argument :id, types.ID
-      permit :admin
+  QueryType =
+    GraphQL::ObjectType.define do
+      name 'Query'
+      description 'Query root for this schema'
+      field :submission, Types::SubmissionType do
+        description 'Get a Submission'
+        argument :id, types.ID
+        permit :admin
 
-      resolve ->(_object, args, _context) { Submission.find(args[:id]) }
-    end
-
-    connection :submissions, Types::SubmissionType.define_connection do
-      description 'Filter all submission'
-
-      argument :ids, types[types.ID], 'Get all submissions with these IDs', permit: :admin
-      argument :user_id, types[types.ID], 'Only get submission by this user_id', prepare: ->(obj, context) do
-        is_same_as_user = obj == context[:current_user]
-        GraphQL::ExecutionError.new('Only Admins can use the user_id for another user.') if !is_same_as_user && !context[:current_user_roles].include?(:admin)
-        obj
+        resolve ->(_object, args, _context) { Submission.find(args[:id]) }
       end
 
-      argument :completed, types.Boolean, 'If present return either completed or not completed submissions'
+      connection :submissions, Types::SubmissionType.define_connection do
+        description 'Filter all submission'
 
-      resolve ->(_object, args, context) do
-        get_all_submissions = !args[:ids] && !args[:user_id]
-        return GraphQL::ExecutionError.new('Only Admins can look at all submissions.') if !get_all_submissions && !context[:current_user_roles].include?(:admin)
+        argument :ids,
+                 types[types.ID],
+                 'Get all submissions with these IDs',
+                 permit: :admin
+        argument :user_id,
+                 types[types.ID],
+                 'Only get submission by this user_id',
+                 prepare: lambda { |obj, context|
+                   is_same_as_user = obj == context[:current_user]
+                   if !is_same_as_user &&
+                        !context[:current_user_roles].include?(:admin)
+                     GraphQL::ExecutionError.new(
+                       'Only Admins can use the user_id for another user.'
+                     )
+                   end
+                   obj
+                 }
 
-        submissions = Submission.order(id: :desc)
-        submissions = if args[:ids]
-                        submissions.where(id: args[:ids])
-                      elsif args[:user_id]
-                        submissions.where(user_id: args[:user_id])
+        argument :completed,
+                 types.Boolean,
+                 'If present return either completed or not completed submissions'
+
+        resolve lambda { |_object, args, context|
+                  get_all_submissions = !args[:ids] && !args[:user_id]
+                  if !get_all_submissions &&
+                       !context[:current_user_roles].include?(:admin)
+                    return(
+                      GraphQL::ExecutionError.new(
+                        'Only Admins can look at all submissions.'
+                      )
+                    )
+                  end
+
+                  submissions = Submission.order(id: :desc)
+                  submissions =
+                    if args[:ids]
+                      submissions.where(id: args[:ids])
+                    elsif args[:user_id]
+                      submissions.where(user_id: args[:user_id])
+                    else
+                      submissions
+                    end
+
+                  if args.key?('completed')
+                    submissions =
+                      if args[:completed]
+                        submissions.completed
                       else
-                        submissions
+                        submissions.draft
                       end
+                  end
 
-        if args.key?('completed')
-          submissions = args[:completed] ? submissions.completed : submissions.draft
-        end
-
-        submissions
+                  submissions
+                }
       end
     end
-  end
 end

--- a/app/graph/types/state_type.rb
+++ b/app/graph/types/state_type.rb
@@ -1,9 +1,10 @@
 module Types
-  StateType = GraphQL::EnumType.define do
-    name 'State'
-    value('DRAFT', nil, value: 'draft')
-    value('SUBMITTED', nil, value: 'submitted')
-    value('APPROVED', nil, value: 'approved')
-    value('REJECTED', nil, value: 'rejected')
-  end
+  StateType =
+    GraphQL::EnumType.define do
+      name 'State'
+      value('DRAFT', nil, value: 'draft')
+      value('SUBMITTED', nil, value: 'submitted')
+      value('APPROVED', nil, value: 'approved')
+      value('REJECTED', nil, value: 'rejected')
+    end
 end

--- a/app/graph/types/submission_type.rb
+++ b/app/graph/types/submission_type.rb
@@ -1,33 +1,34 @@
 module Types
-  SubmissionType = GraphQL::ObjectType.define do
-    name 'Submission'
-    description 'Consignment Submission'
+  SubmissionType =
+    GraphQL::ObjectType.define do
+      name 'Submission'
+      description 'Consignment Submission'
 
-    field :id, !types.ID, 'Uniq ID for this submission'
-    field :additional_info, types.String
-    field :user_id, !types.String
-    field :artist_id, !types.String
-    field :authenticity_certificate, types.Boolean
-    field :category, Types::CategoryType
-    field :currency, types.String
-    field :depth, types.String
-    field :dimensions_metric, types.String
-    field :edition, types.String
-    field :edition_number, types.String
-    field :edition_size, types.Int
-    field :height, types.String
-    field :location_city, types.String
-    field :location_country, types.String
-    field :location_state, types.String
-    field :medium, types.String
-    field :minimum_price_dollars, types.Int
-    field :provenance, types.String
-    field :signature, types.Boolean
-    field :state, Types::StateType
-    field :title, types.String
-    field :width, types.String
-    field :year, types.String
+      field :id, !types.ID, 'Uniq ID for this submission'
+      field :additional_info, types.String
+      field :user_id, !types.String
+      field :artist_id, !types.String
+      field :authenticity_certificate, types.Boolean
+      field :category, Types::CategoryType
+      field :currency, types.String
+      field :depth, types.String
+      field :dimensions_metric, types.String
+      field :edition, types.String
+      field :edition_number, types.String
+      field :edition_size, types.Int
+      field :height, types.String
+      field :location_city, types.String
+      field :location_country, types.String
+      field :location_state, types.String
+      field :medium, types.String
+      field :minimum_price_dollars, types.Int
+      field :provenance, types.String
+      field :signature, types.Boolean
+      field :state, Types::StateType
+      field :title, types.String
+      field :width, types.String
+      field :year, types.String
 
-    field :assets, types[Types::AssetType]
-  end
+      field :assets, types[Types::AssetType]
+    end
 end

--- a/app/helpers/offers_helper.rb
+++ b/app/helpers/offers_helper.rb
@@ -3,9 +3,14 @@ module OffersHelper
   def reviewed_byline(offer)
     if offer.rejected?
       [
-        "Rejected by #{offer.rejected_by_user.try(:name)}. #{offer.rejection_reason}",
+        "Rejected by #{offer.rejected_by_user.try(:name)}. #{
+          offer.rejection_reason
+        }",
         offer.rejection_note
-      ].compact.reject(&:blank?).join(': ').strip
+      ].compact
+        .reject(&:blank?)
+        .join(': ')
+        .strip
     elsif offer.lapsed?
       'Offer lapsed.'
     end
@@ -42,37 +47,40 @@ module OffersHelper
   def offer_type_description(offer)
     case offer.offer_type
     when Offer::AUCTION_CONSIGNMENT
-      'This work will be offered in an auction. The work will sell if bidding meets the '\
-      'minimum selling price that you and the auction house have agreed to. Please note '\
-      'that the minimum selling price generally cannot be higher than the suggested low '\
-      'estimate. You are responsible for shipping the work to the auction house unless '\
-      'otherwise stated in the notes.'
+      'This work will be offered in an auction. The work will sell if bidding meets the ' \
+        'minimum selling price that you and the auction house have agreed to. Please note ' \
+        'that the minimum selling price generally cannot be higher than the suggested low ' \
+        'estimate. You are responsible for shipping the work to the auction house unless ' \
+        'otherwise stated in the notes.'
     when Offer::PURCHASE
       'The work will be purchased directly from you by the partner for the specified price.'
     when Offer::RETAIL
-      'This work will be offered privately to a small group of collectors that the partner has '\
-      'relationships with. The work will sell if a collector agrees to your price.'
+      'This work will be offered privately to a small group of collectors that the partner has ' \
+        'relationships with. The work will sell if a collector agrees to your price.'
     when Offer::NET_PRICE
-      'This work will be offered privately to a small group of collectors that the partner has '\
-      'relationships with. The work will sell if a collector agrees to your price.'
+      'This work will be offered privately to a small group of collectors that the partner has ' \
+        'relationships with. The work will sell if a collector agrees to your price.'
     end
   end
 
   def estimate_display(offer)
     currency = Money::Currency.new(offer.currency)
-    estimate = [
-      offer.low_estimate_cents,
-      offer.high_estimate_cents
-    ].compact.map { |amt| (amt / currency.subunit_to_unit).round }.join(' - ')
+    estimate =
+      [offer.low_estimate_cents, offer.high_estimate_cents].compact
+        .map { |amt| (amt / currency.subunit_to_unit).round }.join(' - ')
     "#{offer.currency} #{currency.symbol}#{estimate}" if estimate.present?
   end
 
   def sale_period_display(offer)
-    return unless offer.sale_period_start.present? || offer.sale_period_end.present?
+    unless offer.sale_period_start.present? || offer.sale_period_end.present?
+      return
+    end
 
     if offer.sale_period_start.present?
       if offer.sale_period_end.present?
-        "#{formatted_date_offer(offer.sale_period_start)} - #{formatted_date_offer(offer.sale_period_end)}"
+        "#{formatted_date_offer(offer.sale_period_start)} - #{
+          formatted_date_offer(offer.sale_period_end)
+        }"
       else
         "Starts #{formatted_date_offer(offer.sale_period_start)}"
       end
@@ -96,30 +104,42 @@ module OffersHelper
   def shipping_display(offer)
     return if offer.shipping_cents.blank?
 
-    "#{offer.currency} #{Money.new(offer.shipping_cents, offer.currency).format}"
+    "#{offer.currency} #{
+      Money.new(offer.shipping_cents, offer.currency).format
+    }"
   end
 
   def photography_display(offer)
     return if offer.photography_cents.blank?
 
-    "#{offer.currency} #{Money.new(offer.photography_cents, offer.currency).format}"
+    "#{offer.currency} #{
+      Money.new(offer.photography_cents, offer.currency).format
+    }"
   end
 
   def insurance_display(offer)
-    return unless offer.insurance_cents.present? || offer.insurance_percent.present?
+    unless offer.insurance_cents.present? || offer.insurance_percent.present?
+      return
+    end
 
     if offer.insurance_cents.present?
-      "#{offer.currency} #{Money.new(offer.insurance_cents, offer.currency).format}"
+      "#{offer.currency} #{
+        Money.new(offer.insurance_cents, offer.currency).format
+      }"
     else
       "#{offer.insurance_percent * 100}%"
     end
   end
 
   def other_fees_display(offer)
-    return unless offer.other_fees_cents.present? || offer.other_fees_percent.present?
+    unless offer.other_fees_cents.present? || offer.other_fees_percent.present?
+      return
+    end
 
     if offer.other_fees_cents.present?
-      "#{offer.currency} #{Money.new(offer.other_fees_cents, offer.currency).format}"
+      "#{offer.currency} #{
+        Money.new(offer.other_fees_cents, offer.currency).format
+      }"
     else
       "#{offer.other_fees_percent * 100}%"
     end

--- a/app/helpers/partner_submissions_helper.rb
+++ b/app/helpers/partner_submissions_helper.rb
@@ -1,9 +1,5 @@
 module PartnerSubmissionsHelper
   def new_time_field_value(current_value)
-    if current_value.present?
-      nil
-    else
-      Time.now.utc
-    end
+    current_value.present? ? nil : Time.now.utc
   end
 end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -4,11 +4,17 @@ module SubmissionsHelper
   end
 
   def formatted_location(submission)
-    [submission.location_city, submission.location_state, submission.location_country].select(&:present?).join(', ')
+    [
+      submission.location_city,
+      submission.location_state,
+      submission.location_country
+    ].select(&:present?)
+      .join(', ')
   end
 
   def formatted_dimensions(submission)
-    values = [submission.height, submission.width, submission.depth].select(&:present?)
+    values =
+      [submission.height, submission.width, submission.depth].select(&:present?)
     return if values.empty?
 
     "#{values.join('x')}#{submission.dimensions_metric.try(:downcase)}"
@@ -19,16 +25,26 @@ module SubmissionsHelper
   end
 
   def formatted_editions(submission)
-    submission.edition_number.present? ? "#{submission.edition_number}/#{submission.edition_size}" : nil
+    if submission.edition_number.present?
+      "#{submission.edition_number}/#{submission.edition_size}"
+    else
+      nil
+    end
   end
 
   def formatted_medium_metadata(submission)
-    edition_text = formatted_editions(submission).present? ? "Edition #{formatted_editions(submission)}" : nil
+    edition_text =
+      if formatted_editions(submission).present?
+        "Edition #{formatted_editions(submission)}"
+      else
+        nil
+      end
     [
       submission.medium.try(:truncate, 100),
       formatted_dimensions(submission),
       edition_text
-    ].compact.join(', ')
+    ].compact
+      .join(', ')
   end
 
   def reviewer_byline(submission)
@@ -44,11 +60,19 @@ module SubmissionsHelper
   end
 
   def preferred_image(submission)
-    (submission.primary_image.presence || submission.processed_images.min_by(&:id)).image_urls['square']
+    (
+      submission.primary_image.presence ||
+        submission.processed_images.min_by(&:id)
+    )
+      .image_urls[
+      'square'
+    ]
   end
 
   def formatted_current_time
-    Time.now.in_time_zone('Eastern Time (US & Canada)').strftime('%l:%M %Z %B %-d, %Y')
+    Time.now.in_time_zone('Eastern Time (US & Canada)').strftime(
+      '%l:%M %Z %B %-d, %Y'
+    )
   end
 
   def formatted_minimum_price(submission)

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,6 +1,11 @@
 module UrlHelper
   def upload_photo_url(submission_id, utm_params = {})
-    utm_url("#{Convection.config.artsy_url}/consign/submission/#{submission_id}/upload", utm_params)
+    utm_url(
+      "#{Convection.config.artsy_url}/consign/submission/#{
+        submission_id
+      }/upload",
+      utm_params
+    )
   end
 
   def artsy_formatted_url(path, utm_params)
@@ -9,11 +14,18 @@ module UrlHelper
   end
 
   def offer_form_url(submission_id: '')
-    Convection.config.auction_offer_form_url.gsub('SUBMISSION_NUMBER', submission_id.to_s)
+    Convection.config.auction_offer_form_url.gsub(
+      'SUBMISSION_NUMBER',
+      submission_id.to_s
+    )
   end
 
   def offer_response_form_url(submission_id: '', partner_name: '')
-    url = Convection.config.offer_response_form_url.gsub('SUBMISSION_NUMBER', submission_id.to_s)
+    url =
+      Convection.config.offer_response_form_url.gsub(
+        'SUBMISSION_NUMBER',
+        submission_id.to_s
+      )
     url.gsub('PARTNER_NAME', partner_name)
   end
 

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -7,11 +7,11 @@ class AdminMailer < ApplicationMailer
     @user_detail = user_detail
     @artist = artist
 
-    smtpapi category: ['submission'], unique_args: {
-      submission_id: submission.id
-    }
-    mail(to: Convection.config.admin_email_address, subject: "Submission ##{@submission.id}") do |format|
-      format.html { render layout: 'mailer_no_footer' }
-    end
+    smtpapi category: %w[submission],
+            unique_args: { submission_id: submission.id }
+    mail(
+      to: Convection.config.admin_email_address,
+      subject: "Submission ##{@submission.id}"
+    ) { |format| format.html { render layout: 'mailer_no_footer' } }
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -10,10 +10,6 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def utm_params(source:, campaign:)
-    {
-      utm_campaign: campaign,
-      utm_medium: 'email',
-      utm_source: source
-    }
+    { utm_campaign: campaign, utm_medium: 'email', utm_source: source }
   end
 end

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -1,47 +1,56 @@
 class PartnerMailer < ApplicationMailer
   helper :url, :submissions, :offers, :application
 
-  def submission_digest(users_to_submissions:, partner_name:, partner_type:, email:, submissions_count:)
+  def submission_digest(
+    users_to_submissions:,
+    partner_name:,
+    partner_type:,
+    email:,
+    submissions_count:
+  )
     @users_to_submissions = users_to_submissions
     @partner_type = partner_type
-    @utm_params = utm_params(source: 'consignment-partner-digest', campaign: 'consignment-complete')
-    smtpapi category: ['submission_digest'], unique_args: {
-      partner_name: partner_name
-    }
+    @utm_params =
+      utm_params(
+        source: 'consignment-partner-digest', campaign: 'consignment-complete'
+      )
+    smtpapi category: %w[submission_digest],
+            unique_args: { partner_name: partner_name }
 
     current_date = Time.now.utc.strftime('%B %-d')
     mail(
       to: email,
       from: Convection.config.admin_email_address,
-      subject: "New Artsy Consignments #{current_date}: #{submissions_count} works"
-    ) do |format|
-      format.html { render layout: 'mailer_no_footer' }
-    end
+      subject:
+        "New Artsy Consignments #{current_date}: #{submissions_count} works"
+    ) { |format| format.html { render layout: 'mailer_no_footer' } }
   end
 
   def offer_introduction(offer:, artist:, email:)
     @offer = offer
     @submission = offer.submission
     @artist = artist
-    @utm_params = utm_params(source: 'consignment-offer-introduction', campaign: 'consignment-offer')
+    @utm_params =
+      utm_params(
+        source: 'consignment-offer-introduction', campaign: 'consignment-offer'
+      )
 
-    smtpapi category: ['offer'], unique_args: {
-      offer_id: offer.id
-    }
-    mail(to: email,
-         subject: 'The consignor has expressed interest in your offer')
+    smtpapi category: %w[offer], unique_args: { offer_id: offer.id }
+    mail(
+      to: email, subject: 'The consignor has expressed interest in your offer'
+    )
   end
 
   def offer_rejection(offer:, artist:, email:)
     @offer = offer
     @submission = offer.submission
     @artist = artist
-    @utm_params = utm_params(source: 'consignment-offer-rejected', campaign: 'consignment-offer')
+    @utm_params =
+      utm_params(
+        source: 'consignment-offer-rejected', campaign: 'consignment-offer'
+      )
 
-    smtpapi category: ['offer'], unique_args: {
-      offer_id: offer.id
-    }
-    mail(to: email,
-         subject: 'A response to your consignment offer')
+    smtpapi category: %w[offer], unique_args: { offer_id: offer.id }
+    mail(to: email, subject: 'A response to your consignment offer')
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,25 +6,35 @@ class UserMailer < ApplicationMailer
     @user = user
     @user_detail = user_detail
     @artist = artist
-    @utm_params = utm_params(source: 'consignment-receipt', campaign: 'consignment-complete')
+    @utm_params =
+      utm_params(
+        source: 'consignment-receipt', campaign: 'consignment-complete'
+      )
 
-    smtpapi category: ['submission_receipt'], unique_args: {
-      submission_id: submission.id
-    }
-    mail(to: user_detail.email,
-         subject: "Consignment Submission Confirmation ##{@submission.id}",
-         bcc: [Convection.config.admin_email_address, Convection.config.bcc_email_address])
+    smtpapi category: %w[submission_receipt],
+            unique_args: { submission_id: submission.id }
+    mail(
+      to: user_detail.email,
+      subject: "Consignment Submission Confirmation ##{@submission.id}",
+      bcc: [
+        Convection.config.admin_email_address,
+        Convection.config.bcc_email_address
+      ]
+    )
   end
 
   def first_upload_reminder(submission:, user:, user_detail:)
     @submission = submission
     @user = user
     @user_detail = user_detail
-    @utm_params = utm_params(source: 'drip-consignment-reminder-e01', campaign: 'consignment-complete')
+    @utm_params =
+      utm_params(
+        source: 'drip-consignment-reminder-e01',
+        campaign: 'consignment-complete'
+      )
 
-    smtpapi category: ['first_upload_reminder'], unique_args: {
-      submission_id: submission.id
-    }
+    smtpapi category: %w[first_upload_reminder],
+            unique_args: { submission_id: submission.id }
     mail to: user_detail.email, subject: "You're Almost Done"
   end
 
@@ -32,11 +42,14 @@ class UserMailer < ApplicationMailer
     @submission = submission
     @user = user
     @user_detail = user_detail
-    @utm_params = utm_params(source: 'drip-consignment-reminder-e02', campaign: 'consignment-complete')
+    @utm_params =
+      utm_params(
+        source: 'drip-consignment-reminder-e02',
+        campaign: 'consignment-complete'
+      )
 
-    smtpapi category: ['second_upload_reminder'], unique_args: {
-      submission_id: submission.id
-    }
+    smtpapi category: %w[second_upload_reminder],
+            unique_args: { submission_id: submission.id }
     mail to: user_detail.email, subject: "You're Almost Done"
   end
 
@@ -44,12 +57,16 @@ class UserMailer < ApplicationMailer
     @submission = submission
     @user = user
     @user_detail = user_detail
-    @utm_params = utm_params(source: 'drip-consignment-reminder-e03', campaign: 'consignment-complete')
+    @utm_params =
+      utm_params(
+        source: 'drip-consignment-reminder-e03',
+        campaign: 'consignment-complete'
+      )
 
-    smtpapi category: ['third_upload_reminder'], unique_args: {
-      submission_id: submission.id
-    }
-    mail to: user_detail.email, subject: 'Last chance to complete your consignment'
+    smtpapi category: %w[third_upload_reminder],
+            unique_args: { submission_id: submission.id }
+    mail to: user_detail.email,
+         subject: 'Last chance to complete your consignment'
   end
 
   def submission_approved(submission:, user:, user_detail:, artist:)
@@ -57,13 +74,14 @@ class UserMailer < ApplicationMailer
     @user = user
     @user_detail = user_detail
     @artist = artist
-    @utm_params = utm_params(source: 'consignment-approved', campaign: 'consignment-complete')
+    @utm_params =
+      utm_params(
+        source: 'consignment-approved', campaign: 'consignment-complete'
+      )
 
-    smtpapi category: ['submission_approved'], unique_args: {
-      submission_id: submission.id
-    }
-    mail(to: user_detail.email,
-         subject: 'Your consignment has been approved')
+    smtpapi category: %w[submission_approved],
+            unique_args: { submission_id: submission.id }
+    mail(to: user_detail.email, subject: 'Your consignment has been approved')
   end
 
   def submission_rejected(submission:, user:, user_detail:, artist:)
@@ -71,13 +89,17 @@ class UserMailer < ApplicationMailer
     @user = user
     @user_detail = user_detail
     @artist = artist
-    @utm_params = utm_params(source: 'consignment-rejected', campaign: 'consignment-complete')
+    @utm_params =
+      utm_params(
+        source: 'consignment-rejected', campaign: 'consignment-complete'
+      )
 
-    smtpapi category: ['submission_rejected'], unique_args: {
-      submission_id: submission.id
-    }
-    mail(to: user_detail.email,
-         subject: 'An important update about your consignment submission')
+    smtpapi category: %w[submission_rejected],
+            unique_args: { submission_id: submission.id }
+    mail(
+      to: user_detail.email,
+      subject: 'An important update about your consignment submission'
+    )
   end
 
   def offer(offer:, artist:, user:, user_detail:)
@@ -86,12 +108,12 @@ class UserMailer < ApplicationMailer
     @artist = artist
     @user = user
     @user_detail = user_detail
-    @utm_params = utm_params(source: 'consignment-offer', campaign: 'consignment-offer')
+    @utm_params =
+      utm_params(source: 'consignment-offer', campaign: 'consignment-offer')
 
-    smtpapi category: ['offer'], unique_args: {
-      offer_id: offer.id
-    }
-    mail(to: user_detail.email,
-         subject: 'An offer for your consignment submission')
+    smtpapi category: %w[offer], unique_args: { offer_id: offer.id }
+    mail(
+      to: user_detail.email, subject: 'An offer for your consignment submission'
+    )
   end
 end

--- a/app/models/artist_standing_score.rb
+++ b/app/models/artist_standing_score.rb
@@ -1,2 +1,1 @@
-class ArtistStandingScore < ApplicationRecord
-end
+class ArtistStandingScore < ApplicationRecord; end

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -2,7 +2,7 @@ require 'net/http'
 class Asset < ApplicationRecord
   GeminiHttpException = Class.new(StandardError)
 
-  TYPES = ['image'].freeze
+  TYPES = %w[image].freeze
   belongs_to :submission
 
   validates :asset_type, inclusion: { in: TYPES }
@@ -14,19 +14,30 @@ class Asset < ApplicationRecord
     url = params[:image_url].values.first
     return self unless version && url
 
-    Asset.where(id: id).update_all(['image_urls = jsonb_set(image_urls, ?, ?)', "{#{version}}", "\"#{url}\""])
+    Asset.where(id: id).update_all(
+      ['image_urls = jsonb_set(image_urls, ?, ?)', "{#{version}}", "\"#{url}\""]
+    )
   end
 
   def original_image
     return unless gemini_token
 
-    uri = URI.parse("#{Convection.config.gemini_app}/original.json?token=#{gemini_token}")
+    uri =
+      URI.parse(
+        "#{Convection.config.gemini_app}/original.json?token=#{gemini_token}"
+      )
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
-    req = Net::HTTP::Get.new("#{uri.path}?#{uri.query}", 'Content-Type' => 'application/json')
+    req =
+      Net::HTTP::Get.new(
+        "#{uri.path}?#{uri.query}",
+        'Content-Type' => 'application/json'
+      )
     req.basic_auth Convection.config.gemini_account_key, nil
     response = http.request(req)
-    raise GeminiHttpException, "#{response.code}: #{response.body}" unless response.code == '302'
+    unless response.code == '302'
+      raise GeminiHttpException, "#{response.code}: #{response.body}"
+    end
 
     response['location']
   end

--- a/app/models/concerns/currency.rb
+++ b/app/models/concerns/currency.rb
@@ -1,13 +1,7 @@
 module Currency
   extend ActiveSupport::Concern
 
-  SUPPORTED = %w[
-    USD
-    EUR
-    GBP
-    CAD
-    HKD
-  ].freeze
+  SUPPORTED = %w[USD EUR GBP CAD HKD].freeze
 
   included do
     validates :currency, inclusion: { in: SUPPORTED }, allow_nil: true

--- a/app/models/concerns/dollarize.rb
+++ b/app/models/concerns/dollarize.rb
@@ -15,14 +15,17 @@ module Dollarize
           self[method_name] / 100
         end
 
-        define_method "#{method_name.to_s.gsub(/_cents$/, '_dollars')}=" do |dollars|
-          cents = if dollars.blank?
-                    nil
-                  elsif dollars.is_a?(String)
-                    dollars.gsub(',', '').to_f * 100
-                  else
-                    dollars.to_f * 100
-                  end
+        define_method "#{
+                        method_name.to_s.gsub(/_cents$/, '_dollars')
+                      }=" do |dollars|
+          cents =
+            if dollars.blank?
+              nil
+            elsif dollars.is_a?(String)
+              dollars.gsub(',', '').to_f * 100
+            else
+              dollars.to_f * 100
+            end
 
           self[method_name] = cents
         end

--- a/app/models/concerns/reference_id.rb
+++ b/app/models/concerns/reference_id.rb
@@ -1,9 +1,7 @@
 module ReferenceId
   extend ActiveSupport::Concern
 
-  included do
-    before_create :create_reference_id
-  end
+  included { before_create :create_reference_id }
 
   def create_reference_id
     loop do

--- a/app/models/demand_calculator.rb
+++ b/app/models/demand_calculator.rb
@@ -10,9 +10,7 @@ end
 
 class DemandCalculator
   CATEGORY_MODIFIERS = {
-    'Default' => 0.5,
-    'Painting' => 1,
-    'Print' => 0.75
+    'Default' => 0.5, 'Painting' => 1, 'Print' => 0.75
   }.freeze
 
   def self.score(artist_id, category)
@@ -22,14 +20,15 @@ class DemandCalculator
   def initialize(artist_id, category)
     @artist_id = artist_id
     @category = category
-    @artist_standing_score = ArtistStandingScore.where(artist_id: artist_id).order(created_at: :asc).limit(1).first || NullArtistStandingScore.new
+    @artist_standing_score =
+      ArtistStandingScore.where(artist_id: artist_id).order(created_at: :asc)
+        .limit(1)
+        .first ||
+        NullArtistStandingScore.new
   end
 
   def score
-    {
-      artist_score: artist_score,
-      auction_score: auction_score
-    }
+    { artist_score: artist_score, auction_score: auction_score }
   end
 
   private
@@ -45,7 +44,8 @@ class DemandCalculator
   def calculate_demand_score(base_score)
     return 0 unless base_score.positive?
 
-    modifier = CATEGORY_MODIFIERS.fetch(@category, CATEGORY_MODIFIERS['Default'])
+    modifier =
+      CATEGORY_MODIFIERS.fetch(@category, CATEGORY_MODIFIERS['Default'])
     base_score * modifier
   end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -6,13 +6,9 @@ class Offer < ApplicationRecord
   include Percentize
 
   pg_search_scope :search,
-                  against: [:id, :reference_id],
-                  associated_against: {
-                    partner: [:name]
-                  },
-                  using: {
-                    tsearch: { prefix: true }
-                  }
+                  against: %i[id reference_id],
+                  associated_against: { partner: %i[name] },
+                  using: { tsearch: { prefix: true } }
 
   OFFER_TYPES = [
     AUCTION_CONSIGNMENT = 'auction consignment'.freeze,
@@ -22,15 +18,7 @@ class Offer < ApplicationRecord
   ].freeze
 
   # FIXME: deprecate 'accepted' state
-  STATES = %w[
-    draft
-    sent
-    accepted
-    rejected
-    lapsed
-    review
-    consigned
-  ].freeze
+  STATES = %w[draft sent accepted rejected lapsed review consigned].freeze
 
   REJECTION_REASONS = [
     'Low estimate',
@@ -48,7 +36,8 @@ class Offer < ApplicationRecord
 
   validates :state, inclusion: { in: STATES }
   validates :offer_type, inclusion: { in: OFFER_TYPES }, allow_nil: true
-  validates :rejection_reason, inclusion: { in: REJECTION_REASONS }, allow_nil: true
+  validates :rejection_reason,
+            inclusion: { in: REJECTION_REASONS }, allow_nil: true
 
   before_validation :set_state, on: :create
   before_create :set_submission
@@ -81,7 +70,8 @@ class Offer < ApplicationRecord
   end
 
   def locked?
-    submission.consigned_partner_submission_id.present? && submission.consigned_partner_submission.accepted_offer_id != id
+    submission.consigned_partner_submission_id.present? &&
+      submission.consigned_partner_submission.accepted_offer_id != id
   end
 
   def rejected_by_user

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -3,10 +3,7 @@ class Partner < ApplicationRecord
 
   default_scope { order('name ASC') }
   pg_search_scope :search_by_name,
-                  against: :name,
-                  using: {
-                    tsearch: { prefix: true }
-                  }
+                  against: :name, using: { tsearch: { prefix: true } }
 
   has_many :partner_submissions, dependent: :destroy
   has_many :offers, through: :partner_submissions

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -6,25 +6,16 @@ class PartnerSubmission < ApplicationRecord
   include Percentize
 
   pg_search_scope :search,
-                  against: [:id, :reference_id],
-                  associated_against: {
-                    partner: [:name]
-                  },
-                  using: {
-                    tsearch: { prefix: true }
-                  }
+                  against: %i[id reference_id],
+                  associated_against: { partner: %i[name] },
+                  using: { tsearch: { prefix: true } }
 
   belongs_to :partner
   belongs_to :submission
   has_many :offers, dependent: :destroy
   belongs_to :accepted_offer, class_name: 'Offer'
 
-  STATES = [
-    'open',
-    'sold',
-    'bought in',
-    'canceled'
-  ].freeze
+  STATES = ['open', 'sold', 'bought in', 'canceled'].freeze
 
   scope :group_by_day, -> { group("date_trunc('day', notified_at) ") }
   scope :consigned, -> { where.not(accepted_offer_id: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,7 @@ class User < ApplicationRecord
 
   has_many :submissions, dependent: :nullify
 
-  pg_search_scope :search,
-                  against: :email,
-                  using: {
-                    tsearch: { prefix: true }
-                  }
+  pg_search_scope :search, against: :email, using: { tsearch: { prefix: true } }
 
   def gravity_user
     Gravity.client.user(id: gravity_user_id)._get

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -1,10 +1,11 @@
 class NotificationService
   class << self
     def post_submission_event(submission_id, action)
-      submission = Submission.find(submission_id)
-      # post notification
+      submission = Submission.find(submission_id) # post notification
       event = SubmissionEvent.new(action: action, model: submission)
-      Artsy::EventService.post_event(topic: SubmissionEvent::TOPIC, event: event)
+      Artsy::EventService.post_event(
+        topic: SubmissionEvent::TOPIC, event: event
+      )
     end
   end
 end

--- a/app/services/partner_service.rb
+++ b/app/services/partner_service.rb
@@ -2,15 +2,18 @@ module PartnerService
   class << self
     def fetch_partner_contacts!(partner)
       gravity_partner_id = partner.gravity_partner_id
-      partner_communication = Gravity.client.partner_communications(
-        name: Convection.config.consignment_communication_name
-      ).first
+      partner_communication =
+        Gravity.client.partner_communications(
+          name: Convection.config.consignment_communication_name
+        )
+          .first
 
-      partner_contacts = Gravity.fetch_all(
-        partner_communication,
-        :partner_contacts,
-        partner_id: gravity_partner_id
-      )
+      partner_contacts =
+        Gravity.fetch_all(
+          partner_communication,
+          :partner_contacts,
+          partner_id: gravity_partner_id
+        )
 
       raise "No contacts for #{partner.id}" unless partner_contacts.any?
 

--- a/app/services/partner_submission_service.rb
+++ b/app/services/partner_submission_service.rb
@@ -3,9 +3,7 @@ class PartnerSubmissionService
 
   class << self
     def daily_digest
-      Partner.all.each do |partner|
-        delay.deliver_digest(partner.id)
-      end
+      Partner.all.each { |partner| delay.deliver_digest(partner.id) }
     end
 
     def deliver_digest(partner_id)
@@ -19,34 +17,48 @@ class PartnerSubmissionService
 
       gravity_partner_id = partner.gravity_partner_id
       gravity_partner = Gravity.client.partner(id: gravity_partner_id)._get
-      partner_communication = Gravity.client.partner_communications(
-        name: Convection.config.consignment_communication_name
-      ).first
-      partner_contacts = Gravity.fetch_all(
-        partner_communication,
-        :partner_contacts,
-        partner_id: gravity_partner_id
-      )
+      partner_communication =
+        Gravity.client.partner_communications(
+          name: Convection.config.consignment_communication_name
+        )
+          .first
+      partner_contacts =
+        Gravity.fetch_all(
+          partner_communication,
+          :partner_contacts,
+          partner_id: gravity_partner_id
+        )
 
       unless partner_contacts.any?
-        Rails.logger.info "Skipping digest for #{partner_id}... no partner contacts."
+        Rails.logger.info "Skipping digest for #{
+                            partner_id
+                          }... no partner contacts."
         return
       end
 
       Rails.logger.info(
-        "Sending digest of #{submissions.count} submissions to partner #{partner_id} (#{partner.gravity_partner_id})."
+        "Sending digest of #{submissions.count} submissions to partner #{
+          partner_id
+        } (#{partner.gravity_partner_id})."
       )
 
       submission_ids = submissions.pluck(:id)
       partner_contacts.map(&:email).each do |email|
-        delay.deliver_partner_contact_email(submission_ids, partner.name, gravity_partner.type, email)
+        delay.deliver_partner_contact_email(
+          submission_ids,
+          partner.name,
+          gravity_partner.type,
+          email
+        )
       end
 
       notified_at = Time.now.utc
       partner_submissions.each { |ps| ps.update!(notified_at: notified_at) }
     end
 
-    def deliver_partner_contact_email(submission_ids, partner_name, partner_type, email)
+    def deliver_partner_contact_email(
+      submission_ids, partner_name, partner_type, email
+    )
       submissions = Submission.find(submission_ids)
       return if submissions.empty?
 
@@ -57,7 +69,8 @@ class PartnerSubmissionService
         partner_type: partner_type,
         email: email,
         submissions_count: submissions.count
-      ).deliver_now
+      )
+        .deliver_now
     end
 
     def generate_for_all_partners(submission_id)
@@ -69,7 +82,9 @@ class PartnerSubmissionService
 
     def generate_for_new_partner(partner)
       Submission.where(state: 'approved').each do |submission|
-        partner.partner_submissions.find_or_create_by!(submission_id: submission.id)
+        partner.partner_submissions.find_or_create_by!(
+          submission_id: submission.id
+        )
       end
     end
   end

--- a/app/services/partner_update_service.rb
+++ b/app/services/partner_update_service.rb
@@ -1,9 +1,7 @@
 module PartnerUpdateService
   class << self
     def update_partners_from_gravity
-      Partner.all.each do |partner|
-        delay.update_partner!(partner.id)
-      end
+      Partner.all.each { |partner| delay.update_partner!(partner.id) }
     end
 
     def update_partner!(partner_id)
@@ -15,7 +13,9 @@ module PartnerUpdateService
 
       gravity_partner = Gravity.client.partner(id: partner.gravity_partner_id)
       new_partner_name = gravity_partner.name
-      partner.update!(name: new_partner_name) unless partner.name == new_partner_name
+      unless partner.name == new_partner_name
+        partner.update!(name: new_partner_name)
+      end
     end
   end
 end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -15,20 +15,28 @@ class SubmissionService
 
     def update_submission(submission, params, current_user = nil)
       submission.assign_attributes(params)
-      update_submission_state(submission, current_user) if submission.state_changed?
+      if submission.state_changed?
+        update_submission_state(submission, current_user)
+      end
       submission.save!
     end
 
     def update_submission_state(submission, current_user)
       case submission.state
-      when 'submitted' then submit!(submission)
-      when 'approved' then approve!(submission, current_user)
-      when 'rejected' then reject!(submission, current_user)
+      when 'submitted'
+        submit!(submission)
+      when 'approved'
+        approve!(submission, current_user)
+      when 'rejected'
+        reject!(submission, current_user)
       end
     end
 
     def undo_approval(submission)
-      raise SubmissionError, 'Undoing approval of a submission with offers is not allowed!' if submission.offers.count.positive?
+      if submission.offers.count.positive?
+        raise SubmissionError,
+              'Undoing approval of a submission with offers is not allowed!'
+      end
 
       return_to_submitted_state(submission)
       submission.partner_submissions.each(&:destroy)
@@ -39,24 +47,37 @@ class SubmissionService
     end
 
     def return_to_submitted_state(submission)
-      submission.update!(state: 'submitted', approved_at: nil, approved_by: nil, rejected_at: nil, rejected_by: nil)
+      submission.update!(
+        state: 'submitted',
+        approved_at: nil,
+        approved_by: nil,
+        rejected_at: nil,
+        rejected_by: nil
+      )
     end
 
     def submit!(submission)
-      raise ParamError, 'Missing fields for submission.' unless submission.can_submit?
+      unless submission.can_submit?
+        raise ParamError, 'Missing fields for submission.'
+      end
 
       notify_admin(submission.id)
       notify_user(submission.id)
       return if submission.images.count.positive?
 
-      delay_until(Convection.config.second_reminder_days_after.days.from_now).notify_user(submission.id)
-      delay_until(Convection.config.third_reminder_days_after.days.from_now).notify_user(submission.id)
+      delay_until(Convection.config.second_reminder_days_after.days.from_now)
+        .notify_user(submission.id)
+      delay_until(Convection.config.third_reminder_days_after.days.from_now)
+        .notify_user(submission.id)
     end
 
     def approve!(submission, current_user)
       submission.update!(approved_by: current_user, approved_at: Time.now.utc)
       delay.deliver_approval_notification(submission.id)
-      NotificationService.delay.post_submission_event(submission.id, SubmissionEvent::APPROVED)
+      NotificationService.delay.post_submission_event(
+        submission.id,
+        SubmissionEvent::APPROVED
+      )
       PartnerSubmissionService.delay.generate_for_all_partners(submission.id)
     end
 
@@ -70,7 +91,10 @@ class SubmissionService
       return if submission.admin_receipt_sent_at
 
       delay.deliver_submission_notification(submission.id)
-      NotificationService.delay.post_submission_event(submission_id, SubmissionEvent::SUBMITTED)
+      NotificationService.delay.post_submission_event(
+        submission_id,
+        SubmissionEvent::SUBMITTED
+      )
       submission.update!(admin_receipt_sent_at: Time.now.utc)
     end
 
@@ -97,9 +121,7 @@ class SubmissionService
       raise 'User lacks email.' if user_detail.email.blank?
 
       email_args = {
-        submission: submission,
-        user: user,
-        user_detail: user_detail
+        submission: submission, user: user, user_detail: user_detail
       }
 
       if submission.reminders_sent_count == 1
@@ -127,7 +149,8 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      ).deliver_now
+      )
+        .deliver_now
     end
 
     def deliver_submission_notification(submission_id)
@@ -143,7 +166,8 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      ).deliver_now
+      )
+        .deliver_now
     end
 
     def deliver_approval_notification(submission_id)
@@ -157,7 +181,8 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      ).deliver_now
+      )
+        .deliver_now
     end
 
     def deliver_rejection_notification(submission_id)
@@ -171,7 +196,8 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      ).deliver_now
+      )
+        .deliver_now
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,20 +10,18 @@ require_relative '../lib/middleware/jwt_middleware'
 Bundler.require(*Rails.groups)
 
 module Convection
-  class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+  class Application < Rails::Application # -- all .rb files in that directory are automatically loaded. # Application configuration should go into files in config/initializers # Settings in config/environments/* take precedence over those specified here.
     config.paths.add 'app', glob: '**/*.rb'
 
-    config.eager_load_paths += %W[
-      #{config.root}/lib
-      #{Rails.root.join('app', 'events')}
-      #{Rails.root.join('app', 'services')}
-      #{Rails.root.join('app', 'graph')}
-      #{Rails.root.join('app', 'controllers', 'concerns')}
-      #{Rails.root.join('app', 'models', 'concerns')}
-    ]
+    config.eager_load_paths +=
+      %W[
+        #{config.root}/lib
+        #{Rails.root.join('app', 'events')}
+        #{Rails.root.join('app', 'services')}
+        #{Rails.root.join('app', 'graph')}
+        #{Rails.root.join('app', 'controllers', 'concerns')}
+        #{Rails.root.join('app', 'models', 'concerns')}
+      ]
 
     # include JWT middleware
     config.middleware.use ::JwtMiddleware
@@ -31,7 +29,7 @@ module Convection
     config.middleware.insert_before 0, Rack::Cors do
       allow do
         origins '*'
-        resource '*', headers: :any, methods: [:get, :post, :put, :options]
+        resource '*', headers: :any, methods: %i[get post put options]
       end
     end
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
@@ -27,8 +27,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
-  # config.assets.css_compressor = :sass
+  config.assets.js_compressor = Uglifier.new(harmony: true) # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
@@ -81,8 +80,8 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,10 +16,12 @@ Rails.application.configure do
 
   # Configure static file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
-  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=3600'
+  }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -2,39 +2,46 @@ module Convection
   mattr_accessor :config
 end
 
-Convection.config = OpenStruct.new(
-  access_token: ENV['ACCESS_TOKEN'] || 'replace-me',
-  admin_email_address: ENV['ADMIN_EMAIL_ADDRESS'] || 'consign@artsy.net',
-  artsy_url: ENV['ARTSY_URL'] || 'https://staging.artsy.net',
-  auction_offer_form_url: ENV['AUCTION_OFFER_FORM_URL'] || 'https://foo.com',
-  offer_response_form_url: ENV['OFFER_RESPONSE_FORM_URL'] || 'https://foo.com',
-  bcc_email_address: ENV['BCC_EMAIL_ADDRESS'] || 'consignments-archive@artsymail.com',
-  cloudfront_url: ENV['CLOUDFRONT_URL'],
-  consignment_communication_name: ENV['CONSIGNMENT_COMMUNICATION_NAME'] || 'Consignment Submissions',
-  contact_email_address: ENV['CONTACT_EMAIL'] || 'specialist@artsy.net',
-  contact_phone_number: ENV['CONTACT_PHONE_NUMBER'] || '+1 (646) 712-8154',
-  convection_url: ENV['CONVECTION_URL'] || 'https://convection-staging.artsy.net',
-  datadog_trace_agent_hostname: ENV['DATADOG_TRACE_AGENT_HOSTNAME'],
-  datadog_debug: ENV['DATADOG_DEBUG'] == 'true',
-  debug_email_address: ENV['DEBUG_EMAIL_ADDRESS'] || 'sarah@artsymail.com',
-  gemini_account_key: ENV['GEMINI_ACCOUNT_KEY'] || 'convection-staging',
-  gemini_app: ENV['GEMINI_APP'] || 'https://media.artsy.net',
-  gravity_api_url: "#{ENV['GRAVITY_URL'] || 'https://stagingapi.artsy.net'}/api",
-  gravity_app_id: ENV['GRAVITY_APP_ID'] || 'replace-me',
-  gravity_app_secret: ENV['GRAVITY_APP_SECRET'] || 'replace-me',
-  gravity_xapp_token: ENV['GRAVITY_XAPP_TOKEN'] || 'replace-me',
-  gravity_url: ENV['GRAVITY_URL'] || 'https://stagingapi.artsy.net',
-  jwt_secret: ENV['JWT_SECRET'] || 'replace-me',
-  processing_grace_seconds: (ENV['PROCESSING_GRACE_SECONDS'] || 600).to_i,
-  second_reminder_days_after: (ENV['SECOND_REMINDER_DAYS_AFTER'] || 1).to_i,
-  sentry_dsn: ENV['SENTRY_DSN'],
-  sidekiq_username: ENV['SIDEKIQ_USERNAME'] || 'admin',
-  sidekiq_password: ENV['SIDEKIQ_PASSWORD'] || 'replace-me',
-  smtp_address: ENV['SMTP_ADDRESS'],
-  smtp_domain: 'artsy.net',
-  smtp_password: ENV['SMTP_PASSWORD'],
-  smtp_port: ENV['SMTP_PORT'],
-  smtp_user: ENV['SMTP_USER'],
-  third_reminder_days_after: (ENV['THIRD_REMINDER_DAYS_AFTER'] || 7).to_i,
-  vibrations_url: ENV['VIBRATIONS_URL'] || 'https://admin-partners-staging.artsy.net'
-)
+Convection.config =
+  OpenStruct.new(
+    access_token: ENV['ACCESS_TOKEN'] || 'replace-me',
+    admin_email_address: ENV['ADMIN_EMAIL_ADDRESS'] || 'consign@artsy.net',
+    artsy_url: ENV['ARTSY_URL'] || 'https://staging.artsy.net',
+    auction_offer_form_url: ENV['AUCTION_OFFER_FORM_URL'] || 'https://foo.com',
+    offer_response_form_url:
+      ENV['OFFER_RESPONSE_FORM_URL'] || 'https://foo.com',
+    bcc_email_address:
+      ENV['BCC_EMAIL_ADDRESS'] || 'consignments-archive@artsymail.com',
+    cloudfront_url: ENV['CLOUDFRONT_URL'],
+    consignment_communication_name:
+      ENV['CONSIGNMENT_COMMUNICATION_NAME'] || 'Consignment Submissions',
+    contact_email_address: ENV['CONTACT_EMAIL'] || 'specialist@artsy.net',
+    contact_phone_number: ENV['CONTACT_PHONE_NUMBER'] || '+1 (646) 712-8154',
+    convection_url:
+      ENV['CONVECTION_URL'] || 'https://convection-staging.artsy.net',
+    datadog_trace_agent_hostname: ENV['DATADOG_TRACE_AGENT_HOSTNAME'],
+    datadog_debug: ENV['DATADOG_DEBUG'] == 'true',
+    debug_email_address: ENV['DEBUG_EMAIL_ADDRESS'] || 'sarah@artsymail.com',
+    gemini_account_key: ENV['GEMINI_ACCOUNT_KEY'] || 'convection-staging',
+    gemini_app: ENV['GEMINI_APP'] || 'https://media.artsy.net',
+    gravity_api_url:
+      "#{ENV['GRAVITY_URL'] || 'https://stagingapi.artsy.net'}/api",
+    gravity_app_id: ENV['GRAVITY_APP_ID'] || 'replace-me',
+    gravity_app_secret: ENV['GRAVITY_APP_SECRET'] || 'replace-me',
+    gravity_xapp_token: ENV['GRAVITY_XAPP_TOKEN'] || 'replace-me',
+    gravity_url: ENV['GRAVITY_URL'] || 'https://stagingapi.artsy.net',
+    jwt_secret: ENV['JWT_SECRET'] || 'replace-me',
+    processing_grace_seconds: (ENV['PROCESSING_GRACE_SECONDS'] || 600).to_i,
+    second_reminder_days_after: (ENV['SECOND_REMINDER_DAYS_AFTER'] || 1).to_i,
+    sentry_dsn: ENV['SENTRY_DSN'],
+    sidekiq_username: ENV['SIDEKIQ_USERNAME'] || 'admin',
+    sidekiq_password: ENV['SIDEKIQ_PASSWORD'] || 'replace-me',
+    smtp_address: ENV['SMTP_ADDRESS'],
+    smtp_domain: 'artsy.net',
+    smtp_password: ENV['SMTP_PASSWORD'],
+    smtp_port: ENV['SMTP_PORT'],
+    smtp_user: ENV['SMTP_USER'],
+    third_reminder_days_after: (ENV['THIRD_REMINDER_DAYS_AFTER'] || 7).to_i,
+    vibrations_url:
+      ENV['VIBRATIONS_URL'] || 'https://admin-partners-staging.artsy.net'
+  )

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -7,7 +7,10 @@ Datadog.configure do |c|
     distributed_tracing: true,
     debug: Convection.config[:datadog_debug]
   )
-  c.use :rails, service_name: 'convection', controller_service: 'convection.controller', cache_service: 'convection.cache'
+  c.use :rails,
+        service_name: 'convection',
+        controller_service: 'convection.controller',
+        cache_service: 'convection.cache'
   c.use :redis, service_name: 'convection.redis'
   c.use :http, service_name: 'convection.http', distributed_tracing: true
 end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[password]

--- a/config/initializers/graphiql.rb
+++ b/config/initializers/graphiql.rb
@@ -1,1 +1,3 @@
-GraphiQL::Rails.config.headers['Authorization'] = ->(context) { "Bearer #{context.session[:access_token]}" }
+GraphiQL::Rails.config.headers['Authorization'] = lambda do |context|
+  "Bearer #{context.session[:access_token]}"
+end

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -7,7 +7,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json] if respond_to?(:wrap_parameters)
+  wrap_parameters format: %i[json] if respond_to?(:wrap_parameters)
 end
 
 # To enable root element in JSON for ActiveRecord objects.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,8 +8,8 @@ threads threads_count, threads_count
 
 preload_app!
 
-rackup      DefaultRackup
-port        ENV['PORT']     || 3000
+rackup DefaultRackup
+port ENV['PORT'] || 3_000
 environment ENV['RACK_ENV'] || 'development'
 
 on_worker_boot do

--- a/db/migrate/20170503151447_change_image_urls_type.rb
+++ b/db/migrate/20170503151447_change_image_urls_type.rb
@@ -1,6 +1,9 @@
 class ChangeImageUrlsType < ActiveRecord::Migration[5.0]
   def self.up
-    change_column :assets, :image_urls, 'jsonb USING CAST(image_urls AS jsonb)', default: {}
+    change_column :assets,
+                  :image_urls,
+                  'jsonb USING CAST(image_urls AS jsonb)',
+                  default: {}
   end
 
   def self.down

--- a/db/migrate/20170814141232_create_partners.rb
+++ b/db/migrate/20170814141232_create_partners.rb
@@ -5,6 +5,6 @@ class CreatePartners < ActiveRecord::Migration[5.0]
 
       t.timestamps
     end
-    add_index :partners, [:external_partner_id], unique: true
+    add_index :partners, %i[external_partner_id], unique: true
   end
 end

--- a/db/migrate/20171101190725_update_primary_image.rb
+++ b/db/migrate/20171101190725_update_primary_image.rb
@@ -1,6 +1,8 @@
 class UpdatePrimaryImage < ActiveRecord::Migration[5.0]
   def change
     remove_foreign_key :submissions, column: :primary_image_id
-    add_foreign_key :submissions, :assets, column: :primary_image_id, on_delete: :nullify
+    add_foreign_key :submissions,
+                    :assets,
+                    column: :primary_image_id, on_delete: :nullify
   end
 end

--- a/db/migrate/20180105162256_add_consignment_info.rb
+++ b/db/migrate/20180105162256_add_consignment_info.rb
@@ -1,9 +1,15 @@
 class AddConsignmentInfo < ActiveRecord::Migration[5.0]
   def change
-    add_reference :submissions, :consigned_partner_submission, references: :partner_submissions, index: true
-    add_foreign_key :submissions, :partner_submissions, column: :consigned_partner_submission_id
+    add_reference :submissions,
+                  :consigned_partner_submission,
+                  references: :partner_submissions, index: true
+    add_foreign_key :submissions,
+                    :partner_submissions,
+                    column: :consigned_partner_submission_id
 
-    add_reference :partner_submissions, :accepted_offer, references: :offers, index: true
+    add_reference :partner_submissions,
+                  :accepted_offer,
+                  references: :offers, index: true
     add_foreign_key :partner_submissions, :offers, column: :accepted_offer_id
 
     add_column :partner_submissions, :partner_commission_percent, :float

--- a/db/migrate/20180126212637_denormalize_collector_email.rb
+++ b/db/migrate/20180126212637_denormalize_collector_email.rb
@@ -1,6 +1,6 @@
 class DenormalizeCollectorEmail < ActiveRecord::Migration[5.1]
   def change
     add_column :submissions, :user_email, :string
-    execute "create extension if not exists pg_trgm;"
+    execute 'create extension if not exists pg_trgm;'
   end
 end

--- a/db/migrate/20180131172252_add_users_table.rb
+++ b/db/migrate/20180131172252_add_users_table.rb
@@ -7,6 +7,6 @@ class AddUsersTable < ActiveRecord::Migration[5.1]
       t.timestamps
     end
 
-    add_index :users, [:gravity_user_id], unique: true
+    add_index :users, %i[gravity_user_id], unique: true
   end
 end

--- a/db/migrate/20190820201521_update_foreign_keys.rb
+++ b/db/migrate/20190820201521_update_foreign_keys.rb
@@ -1,52 +1,57 @@
-# Recreate some of our FK constraints to add ON DELETE clauses, because we 
+# Recreate some of our FK constraints to add ON DELETE clauses, because we
 # were unable to delete a test offer in the production database when requested.
 
 # The original SQL:
 #
-#   ALTER TABLE offers 
-#     DROP CONSTRAINT fk_rails_80eb82ccbf, 
+#   ALTER TABLE offers
+#     DROP CONSTRAINT fk_rails_80eb82ccbf,
 #     ADD CONSTRAINT fk_rails_80eb82ccbf FOREIGN KEY (partner_submission_id) REFERENCES partner_submissions(id) ON DELETE CASCADE;
 
-#   ALTER TABLE offers 
-#     DROP CONSTRAINT fk_rails_bb4a8a64be, 
+#   ALTER TABLE offers
+#     DROP CONSTRAINT fk_rails_bb4a8a64be,
 #     ADD CONSTRAINT fk_rails_bb4a8a64be FOREIGN KEY (submission_id) REFERENCES submissions(id) ON DELETE CASCADE;
 
-#   ALTER TABLE partner_submissions 
-#     DROP CONSTRAINT fk_rails_7d3e140ff6, 
+#   ALTER TABLE partner_submissions
+#     DROP CONSTRAINT fk_rails_7d3e140ff6,
 #     ADD CONSTRAINT fk_rails_7d3e140ff6 FOREIGN KEY (accepted_offer_id) REFERENCES offers(id) ON DELETE CASCADE;
 
-#   ALTER TABLE submissions 
-#     DROP CONSTRAINT fk_rails_750bb63f9c, 
+#   ALTER TABLE submissions
+#     DROP CONSTRAINT fk_rails_750bb63f9c,
 #     ADD CONSTRAINT fk_rails_750bb63f9c FOREIGN KEY (consigned_partner_submission_id) REFERENCES partner_submissions(id) ON DELETE SET NULL;
-
-
 
 class UpdateForeignKeys < ActiveRecord::Migration[5.2]
   def up
-    remove_foreign_key "offers", "partner_submissions"
-    add_foreign_key "offers", "partner_submissions", on_delete: :cascade
+    remove_foreign_key 'offers', 'partner_submissions'
+    add_foreign_key 'offers', 'partner_submissions', on_delete: :cascade
 
-    remove_foreign_key "offers", "submissions"
-    add_foreign_key "offers", "submissions", on_delete: :cascade
+    remove_foreign_key 'offers', 'submissions'
+    add_foreign_key 'offers', 'submissions', on_delete: :cascade
 
-    remove_foreign_key "partner_submissions", column: "accepted_offer_id"
-    add_foreign_key "partner_submissions", "offers", column: "accepted_offer_id", on_delete: :nullify
+    remove_foreign_key 'partner_submissions', column: 'accepted_offer_id'
+    add_foreign_key 'partner_submissions',
+                    'offers',
+                    column: 'accepted_offer_id', on_delete: :nullify
 
-    remove_foreign_key "submissions", column: "consigned_partner_submission_id"
-    add_foreign_key "submissions", "partner_submissions", column: "consigned_partner_submission_id", on_delete: :nullify
+    remove_foreign_key 'submissions', column: 'consigned_partner_submission_id'
+    add_foreign_key 'submissions',
+                    'partner_submissions',
+                    column: 'consigned_partner_submission_id',
+                    on_delete: :nullify
   end
 
   def down
-    remove_foreign_key "offers", "partner_submissions"
-    add_foreign_key "offers", "partner_submissions"
+    remove_foreign_key 'offers', 'partner_submissions'
+    add_foreign_key 'offers', 'partner_submissions'
 
-    remove_foreign_key "offers", "submissions"
-    add_foreign_key "offers", "submissions"
+    remove_foreign_key 'offers', 'submissions'
+    add_foreign_key 'offers', 'submissions'
 
-    remove_foreign_key "partner_submissions", column: "accepted_offer_id"
-    add_foreign_key "partner_submissions", "offers", column: "accepted_offer_id"
+    remove_foreign_key 'partner_submissions', column: 'accepted_offer_id'
+    add_foreign_key 'partner_submissions', 'offers', column: 'accepted_offer_id'
 
-    remove_foreign_key "submissions", column: "consigned_partner_submission_id"
-    add_foreign_key "submissions", "partner_submissions", column: "consigned_partner_submission_id"
+    remove_foreign_key 'submissions', column: 'consigned_partner_submission_id'
+    add_foreign_key 'submissions',
+                    'partner_submissions',
+                    column: 'consigned_partner_submission_id'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,167 +11,178 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2020_01_08_220043) do
-
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_trgm"
-  enable_extension "plpgsql"
+  enable_extension 'pg_trgm'
+  enable_extension 'plpgsql'
 
-  create_table "artist_standing_scores", force: :cascade do |t|
-    t.string "artist_id"
-    t.float "artist_score"
-    t.float "auction_score"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'artist_standing_scores', force: :cascade do |t|
+    t.string 'artist_id'
+    t.float 'artist_score'
+    t.float 'auction_score'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "assets", id: :serial, force: :cascade do |t|
-    t.string "asset_type"
-    t.string "gemini_token"
-    t.jsonb "image_urls", default: {}
-    t.integer "submission_id"
-    t.index ["submission_id"], name: "index_assets_on_submission_id"
+  create_table 'assets', id: :serial, force: :cascade do |t|
+    t.string 'asset_type'
+    t.string 'gemini_token'
+    t.jsonb 'image_urls', default: {}
+    t.integer 'submission_id'
+    t.index %w[submission_id], name: 'index_assets_on_submission_id'
   end
 
-  create_table "offers", id: :serial, force: :cascade do |t|
-    t.integer "partner_submission_id"
-    t.string "offer_type"
-    t.datetime "sale_period_start"
-    t.datetime "sale_period_end"
-    t.datetime "sale_date"
-    t.string "sale_name"
-    t.bigint "low_estimate_cents"
-    t.bigint "high_estimate_cents"
-    t.string "currency"
-    t.text "notes"
-    t.float "commission_percent"
-    t.bigint "price_cents"
-    t.integer "shipping_cents"
-    t.integer "photography_cents"
-    t.integer "other_fees_cents"
-    t.float "other_fees_percent"
-    t.float "insurance_percent"
-    t.integer "insurance_cents"
-    t.string "state"
-    t.string "created_by_id"
-    t.string "reference_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "submission_id"
-    t.datetime "sent_at"
-    t.string "sent_by"
-    t.string "rejection_reason"
-    t.text "rejection_note"
-    t.string "rejected_by"
-    t.datetime "rejected_at"
-    t.string "accepted_by"
-    t.datetime "accepted_at"
-    t.datetime "review_started_at"
-    t.datetime "consigned_at"
-    t.string "override_email"
-    t.index ["partner_submission_id"], name: "index_offers_on_partner_submission_id"
-    t.index ["reference_id"], name: "index_offers_on_reference_id"
-    t.index ["submission_id"], name: "index_offers_on_submission_id"
+  create_table 'offers', id: :serial, force: :cascade do |t|
+    t.integer 'partner_submission_id'
+    t.string 'offer_type'
+    t.datetime 'sale_period_start'
+    t.datetime 'sale_period_end'
+    t.datetime 'sale_date'
+    t.string 'sale_name'
+    t.bigint 'low_estimate_cents'
+    t.bigint 'high_estimate_cents'
+    t.string 'currency'
+    t.text 'notes'
+    t.float 'commission_percent'
+    t.bigint 'price_cents'
+    t.integer 'shipping_cents'
+    t.integer 'photography_cents'
+    t.integer 'other_fees_cents'
+    t.float 'other_fees_percent'
+    t.float 'insurance_percent'
+    t.integer 'insurance_cents'
+    t.string 'state'
+    t.string 'created_by_id'
+    t.string 'reference_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'submission_id'
+    t.datetime 'sent_at'
+    t.string 'sent_by'
+    t.string 'rejection_reason'
+    t.text 'rejection_note'
+    t.string 'rejected_by'
+    t.datetime 'rejected_at'
+    t.string 'accepted_by'
+    t.datetime 'accepted_at'
+    t.datetime 'review_started_at'
+    t.datetime 'consigned_at'
+    t.string 'override_email'
+    t.index %w[partner_submission_id],
+            name: 'index_offers_on_partner_submission_id'
+    t.index %w[reference_id], name: 'index_offers_on_reference_id'
+    t.index %w[submission_id], name: 'index_offers_on_submission_id'
   end
 
-  create_table "partner_submissions", id: :serial, force: :cascade do |t|
-    t.integer "submission_id"
-    t.integer "partner_id"
-    t.datetime "notified_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "accepted_offer_id"
-    t.float "partner_commission_percent"
-    t.float "artsy_commission_percent"
-    t.string "sale_name"
-    t.string "sale_location"
-    t.string "sale_lot_number"
-    t.datetime "sale_date"
-    t.bigint "sale_price_cents"
-    t.string "currency"
-    t.datetime "partner_invoiced_at"
-    t.datetime "partner_paid_at"
-    t.text "notes"
-    t.string "state"
-    t.string "reference_id"
-    t.text "canceled_reason"
-    t.index ["accepted_offer_id"], name: "index_partner_submissions_on_accepted_offer_id"
-    t.index ["partner_id"], name: "index_partner_submissions_on_partner_id"
-    t.index ["submission_id"], name: "index_partner_submissions_on_submission_id"
+  create_table 'partner_submissions', id: :serial, force: :cascade do |t|
+    t.integer 'submission_id'
+    t.integer 'partner_id'
+    t.datetime 'notified_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'accepted_offer_id'
+    t.float 'partner_commission_percent'
+    t.float 'artsy_commission_percent'
+    t.string 'sale_name'
+    t.string 'sale_location'
+    t.string 'sale_lot_number'
+    t.datetime 'sale_date'
+    t.bigint 'sale_price_cents'
+    t.string 'currency'
+    t.datetime 'partner_invoiced_at'
+    t.datetime 'partner_paid_at'
+    t.text 'notes'
+    t.string 'state'
+    t.string 'reference_id'
+    t.text 'canceled_reason'
+    t.index %w[accepted_offer_id],
+            name: 'index_partner_submissions_on_accepted_offer_id'
+    t.index %w[partner_id], name: 'index_partner_submissions_on_partner_id'
+    t.index %w[submission_id],
+            name: 'index_partner_submissions_on_submission_id'
   end
 
-  create_table "partners", id: :serial, force: :cascade do |t|
-    t.string "gravity_partner_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "name"
-    t.index ["gravity_partner_id"], name: "index_partners_on_gravity_partner_id", unique: true
+  create_table 'partners', id: :serial, force: :cascade do |t|
+    t.string 'gravity_partner_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'name'
+    t.index %w[gravity_partner_id],
+            name: 'index_partners_on_gravity_partner_id', unique: true
   end
 
-  create_table "submissions", id: :serial, force: :cascade do |t|
-    t.string "ext_user_id"
-    t.boolean "qualified"
-    t.string "artist_id"
-    t.string "title"
-    t.string "medium"
-    t.string "year"
-    t.string "category"
-    t.string "height"
-    t.string "width"
-    t.string "depth"
-    t.string "dimensions_metric"
-    t.boolean "signature"
-    t.boolean "authenticity_certificate"
-    t.text "provenance"
-    t.string "location_city"
-    t.string "location_state"
-    t.string "location_country"
-    t.date "deadline_to_sell"
-    t.text "additional_info"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean "edition"
-    t.string "state"
-    t.datetime "receipt_sent_at"
-    t.string "edition_number"
-    t.integer "edition_size"
-    t.integer "reminders_sent_count", default: 0
-    t.datetime "admin_receipt_sent_at"
-    t.string "approved_by"
-    t.datetime "approved_at"
-    t.string "rejected_by"
-    t.datetime "rejected_at"
-    t.integer "primary_image_id"
-    t.integer "consigned_partner_submission_id"
-    t.string "user_email"
-    t.integer "user_id"
-    t.integer "offers_count", default: 0
-    t.bigint "minimum_price_cents"
-    t.string "currency"
-    t.string "user_agent"
-    t.datetime "deleted_at"
-    t.float "artist_score"
-    t.float "auction_score"
-    t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
-    t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
-    t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"
-    t.index ["user_id"], name: "index_submissions_on_user_id"
+  create_table 'submissions', id: :serial, force: :cascade do |t|
+    t.string 'ext_user_id'
+    t.boolean 'qualified'
+    t.string 'artist_id'
+    t.string 'title'
+    t.string 'medium'
+    t.string 'year'
+    t.string 'category'
+    t.string 'height'
+    t.string 'width'
+    t.string 'depth'
+    t.string 'dimensions_metric'
+    t.boolean 'signature'
+    t.boolean 'authenticity_certificate'
+    t.text 'provenance'
+    t.string 'location_city'
+    t.string 'location_state'
+    t.string 'location_country'
+    t.date 'deadline_to_sell'
+    t.text 'additional_info'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.boolean 'edition'
+    t.string 'state'
+    t.datetime 'receipt_sent_at'
+    t.string 'edition_number'
+    t.integer 'edition_size'
+    t.integer 'reminders_sent_count', default: 0
+    t.datetime 'admin_receipt_sent_at'
+    t.string 'approved_by'
+    t.datetime 'approved_at'
+    t.string 'rejected_by'
+    t.datetime 'rejected_at'
+    t.integer 'primary_image_id'
+    t.integer 'consigned_partner_submission_id'
+    t.string 'user_email'
+    t.integer 'user_id'
+    t.integer 'offers_count', default: 0
+    t.bigint 'minimum_price_cents'
+    t.string 'currency'
+    t.string 'user_agent'
+    t.datetime 'deleted_at'
+    t.float 'artist_score'
+    t.float 'auction_score'
+    t.index %w[consigned_partner_submission_id],
+            name: 'index_submissions_on_consigned_partner_submission_id'
+    t.index %w[ext_user_id], name: 'index_submissions_on_ext_user_id'
+    t.index %w[primary_image_id], name: 'index_submissions_on_primary_image_id'
+    t.index %w[user_id], name: 'index_submissions_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "gravity_user_id", null: false
-    t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["gravity_user_id"], name: "index_users_on_gravity_user_id", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'gravity_user_id', null: false
+    t.string 'email'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index %w[gravity_user_id],
+            name: 'index_users_on_gravity_user_id', unique: true
   end
 
-  add_foreign_key "assets", "submissions"
-  add_foreign_key "offers", "partner_submissions", on_delete: :cascade
-  add_foreign_key "offers", "submissions", on_delete: :cascade
-  add_foreign_key "partner_submissions", "offers", column: "accepted_offer_id", on_delete: :nullify
-  add_foreign_key "partner_submissions", "partners"
-  add_foreign_key "partner_submissions", "submissions"
-  add_foreign_key "submissions", "assets", column: "primary_image_id", on_delete: :nullify
-  add_foreign_key "submissions", "partner_submissions", column: "consigned_partner_submission_id", on_delete: :nullify
-  add_foreign_key "submissions", "users"
+  add_foreign_key 'assets', 'submissions'
+  add_foreign_key 'offers', 'partner_submissions', on_delete: :cascade
+  add_foreign_key 'offers', 'submissions', on_delete: :cascade
+  add_foreign_key 'partner_submissions',
+                  'offers',
+                  column: 'accepted_offer_id', on_delete: :nullify
+  add_foreign_key 'partner_submissions', 'partners'
+  add_foreign_key 'partner_submissions', 'submissions'
+  add_foreign_key 'submissions',
+                  'assets',
+                  column: 'primary_image_id', on_delete: :nullify
+  add_foreign_key 'submissions',
+                  'partner_submissions',
+                  column: 'consigned_partner_submission_id', on_delete: :nullify
+  add_foreign_key 'submissions', 'users'
 end

--- a/lib/gravity.rb
+++ b/lib/gravity.rb
@@ -1,10 +1,11 @@
 class Gravity
   class << self
     def client
-      @client ||= Hyperclient.new(Convection.config.gravity_api_url) do |client|
-        client.headers['X-XAPP-TOKEN'] = Convection.config.gravity_xapp_token
-        client.headers['ACCEPT'] = 'application/vnd.artsy-v2+format'
-      end
+      @client ||=
+        Hyperclient.new(Convection.config.gravity_api_url) do |client|
+          client.headers['X-XAPP-TOKEN'] = Convection.config.gravity_xapp_token
+          client.headers['ACCEPT'] = 'application/vnd.artsy-v2+format'
+        end
     end
 
     def fetch_all(object, link_sym, params = {})

--- a/lib/gravql.rb
+++ b/lib/gravql.rb
@@ -4,12 +4,13 @@ require 'uri'
 class Gravql
   module Schema
     def self.execute(query:, variables: {})
-      response = Net::HTTP.post(
-        URI("#{Convection.config.gravity_api_url}/graphql"),
-        { query: query, variables: variables }.to_json,
-        'X-XAPP-TOKEN' => Convection.config.gravity_xapp_token,
-        'Content-Type' => 'application/json'
-      )
+      response =
+        Net::HTTP.post(
+          URI("#{Convection.config.gravity_api_url}/graphql"),
+          { query: query, variables: variables }.to_json,
+          'X-XAPP-TOKEN' => Convection.config.gravity_xapp_token,
+          'Content-Type' => 'application/json'
+        )
 
       JSON.parse(response.body, symbolize_names: true)
     end

--- a/lib/middleware/jwt_middleware.rb
+++ b/lib/middleware/jwt_middleware.rb
@@ -8,7 +8,8 @@ class JwtMiddleware
       token = parse_header env['HTTP_AUTHORIZATION']
 
       begin
-        env['JWT_PAYLOAD'], _headers = JWT.decode(token, Convection.config.jwt_secret, 'HS256')
+        env['JWT_PAYLOAD'], _headers =
+          JWT.decode(token, Convection.config.jwt_secret, 'HS256')
       rescue JWT::DecodeError
         Rails.logger.info "Unable to verify JWT: #{token}"
       end

--- a/spec/controllers/admin/assets_controller_spec.rb
+++ b/spec/controllers/admin/assets_controller_spec.rb
@@ -4,40 +4,40 @@ require 'support/gravity_helper'
 describe Admin::AssetsController, type: :controller do
   context 'with a submission' do
     before do
-      allow_any_instance_of(Admin::AssetsController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::AssetsController).to receive(
+        :require_artsy_authentication
+      )
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail
       stub_gravity_artist
-      @submission = Fabricate(:submission, artist_id: 'artistid', user: Fabricate(:user, gravity_user_id: 'userid'))
+      @submission =
+        Fabricate(
+          :submission,
+          artist_id: 'artistid',
+          user: Fabricate(:user, gravity_user_id: 'userid')
+        )
     end
 
     context 'fetching an asset' do
       it 'renders the show page if the asset exists' do
         asset = Fabricate(:image, submission: @submission, gemini_token: nil)
-        get :show, params: {
-          submission_id: @submission.id,
-          id: asset.id
-        }
+        get :show, params: { submission_id: @submission.id, id: asset.id }
         expect(response).to render_template(:show)
       end
 
       it 'returns a 404 if the asset does not exist' do
-        expect do
-          get :show, params: {
-            submission_id: @submission.id,
-            id: 'foo'
-          }
-        end.to raise_error(ActiveRecord::RecordNotFound)
+        expect {
+          get :show, params: { submission_id: @submission.id, id: 'foo' }
+        }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
       it 'renders a flash error if the original image cannot be found' do
         asset = Fabricate(:image, submission: @submission)
-        expect_any_instance_of(Asset).to receive(:original_image).and_raise(Asset::GeminiHttpException)
-        get :show, params: {
-          submission_id: @submission.id,
-          id: asset.id
-        }
+        expect_any_instance_of(Asset).to receive(:original_image).and_raise(
+          Asset::GeminiHttpException
+        )
+        get :show, params: { submission_id: @submission.id, id: asset.id }
         expect(response).to render_template(:show)
         expect(assigns(:asset)['original_image']).to be_nil
       end
@@ -47,40 +47,45 @@ describe Admin::AssetsController, type: :controller do
       it 'removes an existing asset' do
         asset = Fabricate(:image, submission: @submission)
 
-        expect do
-          delete :destroy, params: {
-            submission_id: @submission.id,
-            id: asset.id
-          }
-        end.to change(@submission.assets, :count).by(-1)
+        expect {
+          delete :destroy,
+                 params: { submission_id: @submission.id, id: asset.id }
+        }.to change(@submission.assets, :count).by(-1)
       end
     end
 
     context 'creating assets for a submission' do
       it 'correctly adds the assets for a single token' do
-        expect do
-          post :multiple, params: {
-            gemini_tokens: 'token1',
-            submission_id: @submission.id,
-            asset_type: 'image'
-          }
-        end.to change(@submission.assets, :count).by(1)
+        expect {
+          post :multiple,
+               params: {
+                 gemini_tokens: 'token1',
+                 submission_id: @submission.id,
+                 asset_type: 'image'
+               }
+        }.to change(@submission.assets, :count).by(1)
       end
 
       it 'correctly adds the assets for multiple tokens' do
-        expect do
-          post :multiple, params: {
-            gemini_tokens: 'token1 token2 token3 token4',
-            submission_id: @submission.id,
-            asset_type: 'image'
-          }
-        end.to change(@submission.assets, :count).by(4)
+        expect {
+          post :multiple,
+               params: {
+                 gemini_tokens: 'token1 token2 token3 token4',
+                 submission_id: @submission.id,
+                 asset_type: 'image'
+               }
+        }.to change(@submission.assets, :count).by(4)
       end
 
       it 'creates no assets for a single token' do
-        expect do
-          post :multiple, params: { gemini_tokens: '', submission_id: @submission.id, asset_type: 'image' }
-        end.to_not change(@submission.assets, :count)
+        expect {
+          post :multiple,
+               params: {
+                 gemini_tokens: '',
+                 submission_id: @submission.id,
+                 asset_type: 'image'
+               }
+        }.to_not change(@submission.assets, :count)
       end
     end
   end

--- a/spec/controllers/admin/consignments_controller_spec.rb
+++ b/spec/controllers/admin/consignments_controller_spec.rb
@@ -2,50 +2,98 @@ require 'rails_helper'
 
 describe Admin::ConsignmentsController, type: :controller do
   before do
-    allow_any_instance_of(Admin::ConsignmentsController).to receive(:require_artsy_authentication)
+    allow_any_instance_of(Admin::ConsignmentsController).to receive(
+      :require_artsy_authentication
+    )
   end
 
   describe '#index' do
     before do
       @partner1 = Fabricate(:partner, name: 'Gagosian Gallery')
       partner2 = Fabricate(:partner, name: 'Heritage Auctions')
-      @consignment1 = Fabricate(:partner_submission,
-                                state: 'open',
-                                submission: Fabricate(:submission, state: 'approved'),
-                                partner: @partner1,
-                                sale_price_cents: 100_000)
-      @consignment2 = Fabricate(:partner_submission,
-                                state: 'open',
-                                submission: Fabricate(:submission, state: 'approved'),
-                                partner: @partner1,
-                                sale_price_cents: 200_000)
-      @consignment3 = Fabricate(:partner_submission,
-                                state: 'bought in',
-                                submission: Fabricate(:submission, state: 'approved'),
-                                partner: @partner1,
-                                sale_price_cents: 300_000)
-      @consignment4 = Fabricate(:partner_submission,
-                                state: 'open',
-                                submission: Fabricate(:submission, state: 'approved'),
-                                partner: partner2)
-      @consignment5 = Fabricate(:partner_submission,
-                                state: 'open', submission: Fabricate(:submission, state: 'approved'),
-                                partner: partner2)
+      @consignment1 =
+        Fabricate(
+          :partner_submission,
+          state: 'open',
+          submission: Fabricate(:submission, state: 'approved'),
+          partner: @partner1,
+          sale_price_cents: 100_000
+        )
+      @consignment2 =
+        Fabricate(
+          :partner_submission,
+          state: 'open',
+          submission: Fabricate(:submission, state: 'approved'),
+          partner: @partner1,
+          sale_price_cents: 200_000
+        )
+      @consignment3 =
+        Fabricate(
+          :partner_submission,
+          state: 'bought in',
+          submission: Fabricate(:submission, state: 'approved'),
+          partner: @partner1,
+          sale_price_cents: 300_000
+        )
+      @consignment4 =
+        Fabricate(
+          :partner_submission,
+          state: 'open',
+          submission: Fabricate(:submission, state: 'approved'),
+          partner: partner2
+        )
+      @consignment5 =
+        Fabricate(
+          :partner_submission,
+          state: 'open',
+          submission: Fabricate(:submission, state: 'approved'),
+          partner: partner2
+        )
 
       @consignment1.update!(
-        accepted_offer: Fabricate(:offer, state: 'sent', partner_submission: @consignment1, offer_type: 'purchase')
+        accepted_offer:
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission: @consignment1,
+            offer_type: 'purchase'
+          )
       )
       @consignment2.update!(
-        accepted_offer: Fabricate(:offer, state: 'sent', partner_submission: @consignment1, offer_type: 'purchase')
+        accepted_offer:
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission: @consignment1,
+            offer_type: 'purchase'
+          )
       )
       @consignment3.update!(
-        accepted_offer: Fabricate(:offer, state: 'sent', partner_submission: @consignment1, offer_type: 'net price')
+        accepted_offer:
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission: @consignment1,
+            offer_type: 'net price'
+          )
       )
       @consignment4.update!(
-        accepted_offer: Fabricate(:offer, state: 'sent', partner_submission: @consignment1, offer_type: 'auction consignment')
+        accepted_offer:
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission: @consignment1,
+            offer_type: 'auction consignment'
+          )
       )
       @consignment5.update!(
-        accepted_offer: Fabricate(:offer, state: 'sent', partner_submission: @consignment1, offer_type: 'retail')
+        accepted_offer:
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission: @consignment1,
+            offer_type: 'retail'
+          )
       )
     end
 
@@ -62,7 +110,12 @@ describe Admin::ConsignmentsController, type: :controller do
     describe '#sorting and filtering' do
       it 'allows you to filter by state = open' do
         get :index, params: { state: 'open' }
-        expect(controller.consignments.pluck(:id)).to eq [@consignment5.id, @consignment4.id, @consignment2.id, @consignment1.id]
+        expect(controller.consignments.pluck(:id)).to eq [
+             @consignment5.id,
+             @consignment4.id,
+             @consignment2.id,
+             @consignment1.id
+           ]
       end
 
       it 'allows you to filter by state = bought in' do
@@ -73,32 +126,65 @@ describe Admin::ConsignmentsController, type: :controller do
       it 'allows you to sort by offer type' do
         get :index, params: { sort: 'offers.offer_type', direction: 'asc' }
         expect(controller.consignments.pluck(:id)).to eq(
-          [@consignment4.id, @consignment3.id, @consignment2.id, @consignment1.id, @consignment5.id]
+          [
+            @consignment4.id,
+            @consignment3.id,
+            @consignment2.id,
+            @consignment1.id,
+            @consignment5.id
+          ]
         )
       end
 
       it 'allows you to sort by partner name' do
         get :index, params: { sort: 'partners.name', direction: 'desc' }
         expect(controller.consignments.pluck(:id)).to eq(
-          [@consignment5.id, @consignment4.id, @consignment3.id, @consignment2.id, @consignment1.id]
+          [
+            @consignment5.id,
+            @consignment4.id,
+            @consignment3.id,
+            @consignment2.id,
+            @consignment1.id
+          ]
         )
       end
 
       it 'allows you to sort by sale_price_cents' do
         get :index, params: { sort: 'sale_price_cents', direction: 'desc' }
         expect(controller.consignments.pluck(:id)).to eq(
-          [@consignment4.id, @consignment5.id, @consignment3.id, @consignment2.id, @consignment1.id]
+          [
+            @consignment4.id,
+            @consignment5.id,
+            @consignment3.id,
+            @consignment2.id,
+            @consignment1.id
+          ]
         )
       end
 
       it 'allows you to filter by state and sort by sale_price_cents' do
-        get :index, params: { sort: 'sale_price_cents', direction: 'desc', state: 'open' }
-        expect(controller.consignments.pluck(:id)).to eq [@consignment4.id, @consignment5.id, @consignment2.id, @consignment1.id]
+        get :index,
+            params: {
+              sort: 'sale_price_cents', direction: 'desc', state: 'open'
+            }
+        expect(controller.consignments.pluck(:id)).to eq [
+             @consignment4.id,
+             @consignment5.id,
+             @consignment2.id,
+             @consignment1.id
+           ]
       end
 
       it 'allows you to search for partner and sort by sale_price_cents' do
-        get :index, params: { sort: 'sale_price_cents', direction: 'desc', partner: @partner1.id }
-        expect(controller.consignments.pluck(:id)).to eq [@consignment3.id, @consignment2.id, @consignment1.id]
+        get :index,
+            params: {
+              sort: 'sale_price_cents', direction: 'desc', partner: @partner1.id
+            }
+        expect(controller.consignments.pluck(:id)).to eq [
+             @consignment3.id,
+             @consignment2.id,
+             @consignment1.id
+           ]
       end
     end
   end

--- a/spec/controllers/admin/offers_controller_spec.rb
+++ b/spec/controllers/admin/offers_controller_spec.rb
@@ -6,23 +6,35 @@ describe Admin::OffersController, type: :controller do
     let(:partner) { Fabricate(:partner, name: 'Gagosian Gallery') }
 
     before do
-      allow_any_instance_of(Admin::OffersController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::OffersController).to receive(
+        :require_artsy_authentication
+      )
     end
 
     describe '#create' do
       it 'redirects to the edit view on success' do
-        expect do
-          post :create, params: { partner_id: partner.id, submission_id: submission.id, offer: { offer_type: 'purchase' } }
+        expect {
+          post :create,
+               params: {
+                 partner_id: partner.id,
+                 submission_id: submission.id,
+                 offer: { offer_type: 'purchase' }
+               }
           expect(response).to redirect_to(admin_offer_url(Offer.last))
-        end.to change(Offer, :count).by(1)
+        }.to change(Offer, :count).by(1)
       end
 
       it 'remains on the new view and shows an error on failure' do
-        expect do
-          post :create, params: { partner_id: partner.id, offer: { offer_type: 'purchase' } }
-          expect(controller.flash[:error]).to include("Couldn't find Submission without an ID")
+        expect {
+          post :create,
+               params: {
+                 partner_id: partner.id, offer: { offer_type: 'purchase' }
+               }
+          expect(controller.flash[:error]).to include(
+            "Couldn't find Submission without an ID"
+          )
           expect(response).to render_template(:new_step_1)
-        end.to_not change(Offer, :count)
+        }.to_not change(Offer, :count)
       end
     end
 
@@ -30,41 +42,76 @@ describe Admin::OffersController, type: :controller do
       before do
         @partner1 = Fabricate(:partner, name: 'Gagosian Gallery')
         partner2 = Fabricate(:partner, name: 'Heritage Auctions')
-        @offer1 = Fabricate(:offer,
-                            state: 'sent',
-                            partner_submission: Fabricate(:partner_submission,
-                                                          partner: @partner1,
-                                                          submission: Fabricate(:submission, user_email: 'michael@bluth.com')),
-                            offer_type: 'purchase',
-                            price_cents: 100_00)
-        @offer2 = Fabricate(:offer,
-                            state: 'sent',
-                            partner_submission: Fabricate(:partner_submission,
-                                                          partner: @partner1,
-                                                          submission: Fabricate(:submission, user_email: 'michael@bluth.com')),
-                            offer_type: 'purchase',
-                            price_cents: 200_00)
-        @offer3 = Fabricate(:offer,
-                            state: 'sent',
-                            partner_submission: Fabricate(:partner_submission,
-                                                          partner: @partner1,
-                                                          submission: Fabricate(:submission, user_email: 'lucille@bluth.com')),
-                            offer_type: 'purchase',
-                            price_cents: 300_00)
-        @offer4 = Fabricate(:offer,
-                            state: 'sent',
-                            partner_submission: Fabricate(:partner_submission,
-                                                          partner: partner2,
-                                                          submission: Fabricate(:submission, user_email: 'lucille@bluth.com')),
-                            offer_type: 'auction consignment',
-                            high_estimate_cents: 400_00)
-        @offer5 = Fabricate(:offer,
-                            state: 'rejected',
-                            partner_submission: Fabricate(:partner_submission,
-                                                          partner: partner2,
-                                                          submission: Fabricate(:submission, user_email: 'lucille@bluth.com')),
-                            offer_type: 'purchase',
-                            price_cents: 500_00)
+        @offer1 =
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission:
+              Fabricate(
+                :partner_submission,
+                partner: @partner1,
+                submission:
+                  Fabricate(:submission, user_email: 'michael@bluth.com')
+              ),
+            offer_type: 'purchase',
+            price_cents: 100_00
+          )
+        @offer2 =
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission:
+              Fabricate(
+                :partner_submission,
+                partner: @partner1,
+                submission:
+                  Fabricate(:submission, user_email: 'michael@bluth.com')
+              ),
+            offer_type: 'purchase',
+            price_cents: 200_00
+          )
+        @offer3 =
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission:
+              Fabricate(
+                :partner_submission,
+                partner: @partner1,
+                submission:
+                  Fabricate(:submission, user_email: 'lucille@bluth.com')
+              ),
+            offer_type: 'purchase',
+            price_cents: 300_00
+          )
+        @offer4 =
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission:
+              Fabricate(
+                :partner_submission,
+                partner: partner2,
+                submission:
+                  Fabricate(:submission, user_email: 'lucille@bluth.com')
+              ),
+            offer_type: 'auction consignment',
+            high_estimate_cents: 400_00
+          )
+        @offer5 =
+          Fabricate(
+            :offer,
+            state: 'rejected',
+            partner_submission:
+              Fabricate(
+                :partner_submission,
+                partner: partner2,
+                submission:
+                  Fabricate(:submission, user_email: 'lucille@bluth.com')
+              ),
+            offer_type: 'purchase',
+            price_cents: 500_00
+          )
       end
 
       it 'returns the first two offers on the first page' do
@@ -80,7 +127,12 @@ describe Admin::OffersController, type: :controller do
       describe '#sorting and filtering' do
         it 'allows you to filter by state = sent' do
           get :index, params: { state: 'sent' }
-          expect(controller.offers.pluck(:id)).to eq [@offer4.id, @offer3.id, @offer2.id, @offer1.id]
+          expect(controller.offers.pluck(:id)).to eq [
+               @offer4.id,
+               @offer3.id,
+               @offer2.id,
+               @offer1.id
+             ]
         end
 
         it 'allows you to filter by state = rejected' do
@@ -89,43 +141,91 @@ describe Admin::OffersController, type: :controller do
         end
 
         it 'allows you to sort by user email' do
-          get :index, params: { sort: 'submissions.user_email', direction: 'asc' }
-          expect(controller.offers.pluck(:id)).to eq [@offer3.id, @offer4.id, @offer5.id, @offer1.id, @offer2.id]
+          get :index,
+              params: { sort: 'submissions.user_email', direction: 'asc' }
+          expect(controller.offers.pluck(:id)).to eq [
+               @offer3.id,
+               @offer4.id,
+               @offer5.id,
+               @offer1.id,
+               @offer2.id
+             ]
         end
 
         it 'allows you to sort by price_cents' do
           get :index, params: { sort: 'price_cents', direction: 'desc' }
-          expect(controller.offers.pluck(:id)).to eq [@offer4.id, @offer5.id, @offer3.id, @offer2.id, @offer1.id]
+          expect(controller.offers.pluck(:id)).to eq [
+               @offer4.id,
+               @offer5.id,
+               @offer3.id,
+               @offer2.id,
+               @offer1.id
+             ]
         end
 
         it 'allows you to filter by state and sort by price_cents' do
-          get :index, params: { sort: 'price_cents', direction: 'desc', state: 'sent' }
-          expect(controller.offers.pluck(:id)).to eq [@offer4.id, @offer3.id, @offer2.id, @offer1.id]
+          get :index,
+              params: { sort: 'price_cents', direction: 'desc', state: 'sent' }
+          expect(controller.offers.pluck(:id)).to eq [
+               @offer4.id,
+               @offer3.id,
+               @offer2.id,
+               @offer1.id
+             ]
         end
 
         it 'allows you to filter by state, search for partner, and sort by price_cents' do
-          get :index, params: { sort: 'price_cents', direction: 'desc', state: 'sent', partner: @partner1.id }
-          expect(controller.offers.pluck(:id)).to eq [@offer3.id, @offer2.id, @offer1.id]
+          get :index,
+              params: {
+                sort: 'price_cents',
+                direction: 'desc',
+                state: 'sent',
+                partner: @partner1.id
+              }
+          expect(controller.offers.pluck(:id)).to eq [
+               @offer3.id,
+               @offer2.id,
+               @offer1.id
+             ]
         end
 
         it 'allows you to filter by state, search for partner, and sort by date' do
-          get :index, params: { sort: 'offers.created_at', direction: 'desc', state: 'sent', partner: @partner1.id }
-          expect(controller.offers.pluck(:id)).to eq [@offer3.id, @offer2.id, @offer1.id]
+          get :index,
+              params: {
+                sort: 'offers.created_at',
+                direction: 'desc',
+                state: 'sent',
+                partner: @partner1.id
+              }
+          expect(controller.offers.pluck(:id)).to eq [
+               @offer3.id,
+               @offer2.id,
+               @offer1.id
+             ]
         end
       end
     end
 
     describe '#update' do
       let(:offer) do
-        Fabricate(:offer,
-                  offer_type: 'auction consignment',
-                  low_estimate_cents: 10_000,
-                  high_estimate_cents: 20_000,
-                  sale_name: 'Fun sale!')
+        Fabricate(
+          :offer,
+          offer_type: 'auction consignment',
+          low_estimate_cents: 10_000,
+          high_estimate_cents: 20_000,
+          sale_name: 'Fun sale!'
+        )
       end
 
       it 'redirects to the show view on success' do
-        put :update, params: { id: offer.id, offer: { high_estimate_dollars: 300, notes: 'Adding some notes to the offer.' } }
+        put :update,
+            params: {
+              id: offer.id,
+              offer: {
+                high_estimate_dollars: 300,
+                notes: 'Adding some notes to the offer.'
+              }
+            }
         expect(response).to redirect_to(admin_offer_url(offer))
         expect(offer.reload.high_estimate_cents).to eq 30_000
         expect(offer.notes).to eq 'Adding some notes to the offer.'
@@ -138,7 +238,7 @@ describe Admin::OffersController, type: :controller do
           high_estimate_dollars: 50_000,
           commission_percent_whole: 10.0,
           sale_name: 'Fun sale',
-          sale_date: Date.new(2017, 10, 1),
+          sale_date: Date.new(2_017, 10, 1),
           currency: 'GBP',
           photography_dollars: 10_000,
           shipping_dollars: 20_000,
@@ -148,10 +248,7 @@ describe Admin::OffersController, type: :controller do
           other_fees_percent_whole: 11.0,
           notes: 'New notes.'
         }
-        put :update, params: {
-          id: auction_offer.id,
-          offer: new_params
-        }
+        put :update, params: { id: auction_offer.id, offer: new_params }
         expect(auction_offer.reload).to have_attributes(new_params)
       end
 
@@ -169,10 +266,7 @@ describe Admin::OffersController, type: :controller do
           other_fees_percent_whole: 11.0,
           notes: 'New notes.'
         }
-        put :update, params: {
-          id: purchase_offer.id,
-          offer: new_params
-        }
+        put :update, params: { id: purchase_offer.id, offer: new_params }
         expect(purchase_offer.reload).to have_attributes(new_params)
       end
 
@@ -181,8 +275,8 @@ describe Admin::OffersController, type: :controller do
         new_params = {
           price_dollars: 10_000,
           commission_percent_whole: 10.0,
-          sale_period_start: Date.new(2017, 1, 1),
-          sale_period_end: Date.new(2017, 10, 1),
+          sale_period_start: Date.new(2_017, 1, 1),
+          sale_period_end: Date.new(2_017, 10, 1),
           currency: 'GBP',
           photography_dollars: 10_000,
           shipping_dollars: 20_000,
@@ -192,35 +286,42 @@ describe Admin::OffersController, type: :controller do
           other_fees_percent_whole: 11.0,
           notes: 'New notes.'
         }
-        put :update, params: {
-          id: retail_offer.id,
-          offer: new_params
-        }
+        put :update, params: { id: retail_offer.id, offer: new_params }
         expect(retail_offer.reload).to have_attributes(new_params)
       end
 
       it 'allows you to un-set fields' do
-        retail_offer = Fabricate(:offer, offer_type: 'retail', insurance_dollars: 10, insurance_percent_whole: 12)
-        put :update, params: {
-          id: retail_offer.id,
-          offer: { insurance_dollars: nil, insurance_percent_whole: nil }
-        }
+        retail_offer =
+          Fabricate(
+            :offer,
+            offer_type: 'retail',
+            insurance_dollars: 10,
+            insurance_percent_whole: 12
+          )
+        put :update,
+            params: {
+              id: retail_offer.id,
+              offer: { insurance_dollars: nil, insurance_percent_whole: nil }
+            }
         expect(retail_offer.reload.insurance_cents).to eq nil
         expect(retail_offer.reload.insurance_percent_whole).to eq nil
       end
 
       it 'remains on the edit view and shows an error on failure' do
-        put :update, params: { id: offer.id, offer: { offer_type: 'bogus type' } }
+        put :update,
+            params: { id: offer.id, offer: { offer_type: 'bogus type' } }
         expect(response).to render_template(:edit)
-        expect(controller.flash[:error]).to include('Validation failed: Offer type is not included in the list')
+        expect(controller.flash[:error]).to include(
+          'Validation failed: Offer type is not included in the list'
+        )
       end
 
       it 'allows you to update every param for a net price offer' do
         net_price_offer = Fabricate(:offer, offer_type: 'net price')
         new_params = {
           price_dollars: 10_000,
-          sale_period_start: Date.new(2017, 1, 1),
-          sale_period_end: Date.new(2017, 10, 1),
+          sale_period_start: Date.new(2_017, 1, 1),
+          sale_period_end: Date.new(2_017, 10, 1),
           currency: 'GBP',
           photography_dollars: 10_000,
           shipping_dollars: 20_000,
@@ -230,17 +331,17 @@ describe Admin::OffersController, type: :controller do
           other_fees_percent_whole: 11.0,
           notes: 'New notes.'
         }
-        put :update, params: {
-          id: net_price_offer.id,
-          offer: new_params
-        }
+        put :update, params: { id: net_price_offer.id, offer: new_params }
         expect(net_price_offer.reload).to have_attributes(new_params)
       end
 
       it 'remains on the edit view and shows an error on failure' do
-        put :update, params: { id: offer.id, offer: { offer_type: 'bogus type' } }
+        put :update,
+            params: { id: offer.id, offer: { offer_type: 'bogus type' } }
         expect(response).to render_template(:edit)
-        expect(controller.flash[:error]).to include('Validation failed: Offer type is not included in the list')
+        expect(controller.flash[:error]).to include(
+          'Validation failed: Offer type is not included in the list'
+        )
       end
     end
   end

--- a/spec/controllers/admin/partners_controller_spec.rb
+++ b/spec/controllers/admin/partners_controller_spec.rb
@@ -9,7 +9,9 @@ describe Admin::PartnersController, type: :controller do
     let!(:partner5) { Fabricate(:partner, name: 'gagosian') }
 
     before do
-      allow_any_instance_of(Admin::PartnersController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::PartnersController).to receive(
+        :require_artsy_authentication
+      )
     end
 
     describe '#index' do
@@ -25,41 +27,51 @@ describe Admin::PartnersController, type: :controller do
         it 'orders the partners correctly' do
           get :index, params: { page: 1 }
           expect(controller.partners.count).to eq 5
-          expect(controller.partners.map(&:name)).to eq(['abracadabra', 'animal prints', 'bubbles', 'gagosian', 'zz top'])
+          expect(controller.partners.map(&:name)).to eq(
+            ['abracadabra', 'animal prints', 'bubbles', 'gagosian', 'zz top']
+          )
         end
       end
     end
 
     describe '#create' do
       it 'does nothing if there is no gravity_partner_id' do
-        expect do
-          post :create, params: {}
-        end.to_not change(Partner, :count)
+        expect { post :create, params: {} }.to_not change(Partner, :count)
       end
 
       it 'redirects to the index view on success' do
-        expect do
-          post :create, params: { gravity_partner_id: '123', name: 'New Gallery' }
+        expect {
+          post :create,
+               params: { gravity_partner_id: '123', name: 'New Gallery' }
           expect(Partner.reorder(id: :desc).first.name).to eq 'New Gallery'
           expect(response).to redirect_to(:admin_partners)
-        end.to change(Partner, :count).by(1)
+        }.to change(Partner, :count).by(1)
       end
 
       it 'renders the index view with an error on failure' do
         allow_any_instance_of(Partner).to receive(:save).and_return(false)
-        expect do
-          post :create, params: { gravity_partner_id: '123', name: 'New Gallery' }
-          expect(controller.flash[:error]).to include('Error creating gravity partner.')
+        expect {
+          post :create,
+               params: { gravity_partner_id: '123', name: 'New Gallery' }
+          expect(controller.flash[:error]).to include(
+            'Error creating gravity partner.'
+          )
           expect(response).to render_template(:index)
-        end.to_not change(Partner, :count)
+        }.to_not change(Partner, :count)
       end
 
       it 'does not allow you to create a partner with a duplicate gravity_partner_id' do
-        expect do
-          post :create, params: { gravity_partner_id: partner1.gravity_partner_id, name: 'New Gallery' }
-          expect(controller.flash[:error]).to eq('Error creating gravity partner. Gravity partner has already been taken')
+        expect {
+          post :create,
+               params: {
+                 gravity_partner_id: partner1.gravity_partner_id,
+                 name: 'New Gallery'
+               }
+          expect(controller.flash[:error]).to eq(
+            'Error creating gravity partner. Gravity partner has already been taken'
+          )
           expect(response).to render_template(:index)
-        end.to_not change(Partner, :count)
+        }.to_not change(Partner, :count)
       end
     end
   end

--- a/spec/controllers/admin/submissions_controller_spec.rb
+++ b/spec/controllers/admin/submissions_controller_spec.rb
@@ -3,8 +3,12 @@ require 'rails_helper'
 describe Admin::SubmissionsController, type: :controller do
   describe 'with some submisisons' do
     before do
-      allow_any_instance_of(Admin::SubmissionsController).to receive(:require_artsy_authentication)
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow_any_instance_of(Admin::SubmissionsController).to receive(
+        :require_artsy_authentication
+      )
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_artists_response = {
         data: {
           artists: [
@@ -16,23 +20,43 @@ describe Admin::SubmissionsController, type: :controller do
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_artists_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
     end
 
     context 'with many submissions' do
       before do
         @user1 = Fabricate(:user, email: 'sarah@artsymail.com')
         @user2 = Fabricate(:user, email: 'lucille@bluth.com')
-        @submission1 = Fabricate(:submission, state: 'submitted', title: 'hi hi', user: @user1)
-        @submission2 = Fabricate(:submission, state: 'submitted', title: 'my artwork', user: @user1)
-        @submission3 = Fabricate(:submission, state: 'submitted', title: 'another artwork', user: @user2)
-        @submission4 = Fabricate(:submission, state: 'approved', title: 'zzz', user: @user2)
-        @submission5 = Fabricate(:submission, state: 'approved', title: 'aaa', user: @user2)
-        @deleted_submission = Fabricate(:submission, state: 'submitted', title: 'deleted submission', user: @user2, deleted_at: Time.now.utc)
+        @submission1 =
+          Fabricate(
+            :submission,
+            state: 'submitted', title: 'hi hi', user: @user1
+          )
+        @submission2 =
+          Fabricate(
+            :submission,
+            state: 'submitted', title: 'my artwork', user: @user1
+          )
+        @submission3 =
+          Fabricate(
+            :submission,
+            state: 'submitted', title: 'another artwork', user: @user2
+          )
+        @submission4 =
+          Fabricate(:submission, state: 'approved', title: 'zzz', user: @user2)
+        @submission5 =
+          Fabricate(:submission, state: 'approved', title: 'aaa', user: @user2)
+        @deleted_submission =
+          Fabricate(
+            :submission,
+            state: 'submitted',
+            title: 'deleted submission',
+            user: @user2,
+            deleted_at: Time.now.utc
+          )
       end
 
       it 'does not return deleted submissions' do
@@ -52,47 +76,95 @@ describe Admin::SubmissionsController, type: :controller do
         end
         it 'sets the artist details correctly' do
           get :index
-          expect(controller.artist_details).to eq('artist1' => 'Andy Warhol',
-                                                  'artist2' => 'Kara Walker')
+          expect(controller.artist_details).to eq(
+            'artist1' => 'Andy Warhol', 'artist2' => 'Kara Walker'
+          )
         end
       end
 
       describe '#sorting and filtering' do
         it 'allows you to filter by state = approved' do
           get :index, params: { state: 'approved' }
-          expect(controller.submissions.pluck(:id)).to eq [@submission5.id, @submission4.id]
+          expect(controller.submissions.pluck(:id)).to eq [
+               @submission5.id,
+               @submission4.id
+             ]
         end
 
         it 'allows you to filter by state = submitted' do
           get :index, params: { state: 'submitted' }
-          expect(controller.submissions.pluck(:id)).to eq [@submission3.id, @submission2.id, @submission1.id]
+          expect(controller.submissions.pluck(:id)).to eq [
+               @submission3.id,
+               @submission2.id,
+               @submission1.id
+             ]
         end
 
         it 'allows you to sort by user email' do
           get :index, params: { sort: 'users.email', direction: 'asc' }
           expect(controller.submissions.pluck(:id)).to eq(
-            [@submission5.id, @submission4.id, @submission3.id, @submission2.id, @submission1.id]
+            [
+              @submission5.id,
+              @submission4.id,
+              @submission3.id,
+              @submission2.id,
+              @submission1.id
+            ]
           )
         end
 
         it 'allows you to sort by offers_count' do
-          Fabricate(:offer, partner_submission: Fabricate(:partner_submission, submission: @submission2))
-          Fabricate(:offer, partner_submission: Fabricate(:partner_submission, submission: @submission2))
-          Fabricate(:offer, partner_submission: Fabricate(:partner_submission, submission: @submission3))
+          Fabricate(
+            :offer,
+            partner_submission:
+              Fabricate(:partner_submission, submission: @submission2)
+          )
+          Fabricate(
+            :offer,
+            partner_submission:
+              Fabricate(:partner_submission, submission: @submission2)
+          )
+          Fabricate(
+            :offer,
+            partner_submission:
+              Fabricate(:partner_submission, submission: @submission3)
+          )
           get :index, params: { sort: 'offers_count', direction: 'desc' }
           expect(controller.submissions.pluck(:id)).to eq(
-            [@submission2.id, @submission3.id, @submission1.id, @submission4.id, @submission5.id]
+            [
+              @submission2.id,
+              @submission3.id,
+              @submission1.id,
+              @submission4.id,
+              @submission5.id
+            ]
           )
         end
 
         it 'allows you to filter by state and sort by user email' do
-          get :index, params: { sort: 'users.email', direction: 'desc', state: 'submitted' }
-          expect(controller.submissions.pluck(:id)).to eq [@submission2.id, @submission1.id, @submission3.id]
+          get :index,
+              params: {
+                sort: 'users.email', direction: 'desc', state: 'submitted'
+              }
+          expect(controller.submissions.pluck(:id)).to eq [
+               @submission2.id,
+               @submission1.id,
+               @submission3.id
+             ]
         end
 
         it 'allows you to filter by state, search for user, and sort by ID' do
-          get :index, params: { sort: 'id', direction: 'desc', state: 'submitted', user: @user1.id }
-          expect(controller.submissions.pluck(:id)).to eq [@submission2.id, @submission1.id]
+          get :index,
+              params: {
+                sort: 'id',
+                direction: 'desc',
+                state: 'submitted',
+                user: @user1.id
+              }
+          expect(controller.submissions.pluck(:id)).to eq [
+               @submission2.id,
+               @submission1.id
+             ]
         end
       end
 
@@ -109,13 +181,20 @@ describe Admin::SubmissionsController, type: :controller do
           get :index, format: 'json', params: { term: 'art' }
           submissions = JSON.parse(response.body)
           expect(submissions.length).to eq 2
-          expect(submissions.map { |sub| sub['id'] }).to eq [@submission3.id, @submission2.id]
+          expect(submissions.map { |sub| sub['id'] }).to eq [
+               @submission3.id,
+               @submission2.id
+             ]
         end
 
         it 'merges in the thumbnail url' do
-          Fabricate(:image,
-                    submission: @submission1,
-                    image_urls: { square: 'https://square.jpg', thumbnail: 'https://thumbnail-1.jpg' })
+          Fabricate(
+            :image,
+            submission: @submission1,
+            image_urls: {
+              square: 'https://square.jpg', thumbnail: 'https://thumbnail-1.jpg'
+            }
+          )
 
           get :index, format: 'json', params: { term: 'hi' }
           submissions = JSON.parse(response.body)

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 describe Admin::UsersController, type: :controller do
   describe 'with some users' do
     before do
-      allow_any_instance_of(Admin::UsersController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::UsersController).to receive(
+        :require_artsy_authentication
+      )
     end
 
     describe '#index' do
@@ -28,7 +30,10 @@ describe Admin::UsersController, type: :controller do
       it 'matches on the user email' do
         get :index, params: { term: 'sarah', format: 'json' }
         expect(controller.users.count).to eq 2
-        expect(controller.users.pluck(:email)).to include('sarah@test.com', 'sarah@sarah.com')
+        expect(controller.users.pluck(:email)).to include(
+          'sarah@test.com',
+          'sarah@sarah.com'
+        )
       end
     end
   end

--- a/spec/events/submission_event_spec.rb
+++ b/spec/events/submission_event_spec.rb
@@ -2,60 +2,70 @@ require 'rails_helper'
 
 describe SubmissionEvent do
   let(:submission) do
-    Fabricate(:submission,
-              artist_id: 'artistid',
-              user: Fabricate(:user, gravity_user_id: 'userid'),
-              title: 'My Artwork',
-              state: 'submitted',
-              medium: 'painting',
-              year: '1992',
-              height: '12',
-              width: '14',
-              depth: '2',
-              dimensions_metric: 'in',
-              location_city: 'New York',
-              location_state: 'NY',
-              location_country: 'US',
-              category: 'Painting',
-              signature: true,
-              authenticity_certificate: true,
-              provenance: 'This is the provenance')
+    Fabricate(
+      :submission,
+      artist_id: 'artistid',
+      user: Fabricate(:user, gravity_user_id: 'userid'),
+      title: 'My Artwork',
+      state: 'submitted',
+      medium: 'painting',
+      year: '1992',
+      height: '12',
+      width: '14',
+      depth: '2',
+      dimensions_metric: 'in',
+      location_city: 'New York',
+      location_state: 'NY',
+      location_country: 'US',
+      category: 'Painting',
+      signature: true,
+      authenticity_certificate: true,
+      provenance: 'This is the provenance'
+    )
   end
 
   let!(:image1) do
-    Fabricate(:image,
-              submission: submission,
-              image_urls: {
-                'square' => 'http://square1.jpg',
-                'large' => 'http://foo1.jpg',
-                'thumbnail' => 'http://thumb1.jpg'
-              })
+    Fabricate(
+      :image,
+      submission: submission,
+      image_urls: {
+        'square' => 'http://square1.jpg',
+        'large' => 'http://foo1.jpg',
+        'thumbnail' => 'http://thumb1.jpg'
+      }
+    )
   end
 
   let!(:image2) do
-    Fabricate(:image,
-              submission: submission,
-              image_urls: {
-                'square' => 'http://square2.jpg',
-                'large' => 'http://foo2.jpg',
-                'thumbnail' => 'http://thumb2.jpg'
-              })
+    Fabricate(
+      :image,
+      submission: submission,
+      image_urls: {
+        'square' => 'http://square2.jpg',
+        'large' => 'http://foo2.jpg',
+        'thumbnail' => 'http://thumb2.jpg'
+      }
+    )
   end
 
   let!(:image3) do
-    Fabricate(:image,
-              submission: submission,
-              image_urls: {
-                'square' => 'http://square3.jpg',
-                'large' => 'http://foo3.jpg',
-                'thumbnail' => 'http://thumb3.jpg'
-              })
+    Fabricate(
+      :image,
+      submission: submission,
+      image_urls: {
+        'square' => 'http://square3.jpg',
+        'large' => 'http://foo3.jpg',
+        'thumbnail' => 'http://thumb3.jpg'
+      }
+    )
   end
 
   let(:event) { SubmissionEvent.new(model: submission, action: 'submitted') }
 
   before do
-    allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction')
+    allow(Convection.config).to receive(:auction_offer_form_url).and_return(
+      'https://google.com/auction'
+    )
     submission.update!(primary_image: image2)
   end
 
@@ -92,13 +102,25 @@ describe SubmissionEvent do
       expect(event.properties[:signature]).to eq true
       expect(event.properties[:authenticity_certificate]).to eq true
       expect(event.properties[:thumbnail]).to eq 'http://thumb2.jpg'
-      expect(event.properties[:image_urls]).to match_array ['http://foo1.jpg', 'http://foo2.jpg', 'http://foo3.jpg']
+      expect(event.properties[:image_urls]).to match_array %w[
+                    http://foo1.jpg
+                    http://foo2.jpg
+                    http://foo3.jpg
+                  ]
       expect(event.properties[:offer_link]).to eq 'https://google.com/auction'
     end
 
     it 'returns proper properties for a submission with no processed images and few properties' do
-      minimal_submission = Fabricate(:submission, title: 'My Artwork', artist_id: 'artistid', year: '1992', state: 'approved')
-      minimal_event = SubmissionEvent.new(model: minimal_submission, action: 'approved')
+      minimal_submission =
+        Fabricate(
+          :submission,
+          title: 'My Artwork',
+          artist_id: 'artistid',
+          year: '1992',
+          state: 'approved'
+        )
+      minimal_event =
+        SubmissionEvent.new(model: minimal_submission, action: 'approved')
 
       expect(minimal_event.properties[:title]).to eq 'My Artwork'
       expect(minimal_event.properties[:artist_id]).to eq 'artistid'
@@ -110,7 +132,9 @@ describe SubmissionEvent do
       expect(minimal_event.properties[:authenticity_certificate]).to eq false
       expect(minimal_event.properties[:thumbnail]).to eq nil
       expect(minimal_event.properties[:image_urls]).to eq []
-      expect(minimal_event.properties[:offer_link]).to eq 'https://google.com/auction'
+      expect(
+        minimal_event.properties[:offer_link]
+      ).to eq 'https://google.com/auction'
     end
   end
 end

--- a/spec/fabricators/asset_fabricator.rb
+++ b/spec/fabricators/asset_fabricator.rb
@@ -1,5 +1,4 @@
-Fabricator(:asset) do
-end
+Fabricator(:asset) {}
 
 Fabricator(:image, from: :asset) do
   asset_type 'image'

--- a/spec/fabricators/partner_fabricator.rb
+++ b/spec/fabricators/partner_fabricator.rb
@@ -1,4 +1,6 @@
 Fabricator(:partner) do
-  gravity_partner_id { Fabricate.sequence(:gravity_partner_id) { |i| "partner-id-#{i}" } }
+  gravity_partner_id do
+    Fabricate.sequence(:gravity_partner_id) { |i| "partner-id-#{i}" }
+  end
   name { Fabricate.sequence(:name) { |i| "Gallery #{i}" } }
 end

--- a/spec/fabricators/submission_fabricator.rb
+++ b/spec/fabricators/submission_fabricator.rb
@@ -2,7 +2,7 @@ Fabricator(:submission) do
   user { Fabricate(:user) }
   artist_id { Fabricate.sequence(:artist_id) }
   title { Fabricate.sequence(:title) { |i| "The Last Supper #{i}" } }
-  year 2010
+  year 2_010
   medium 'oil on paper'
   category { Submission::CATEGORIES.first }
   height 10

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,4 +1,6 @@
 Fabricator(:user) do
-  gravity_user_id { Fabricate.sequence(:gravity_user_id) { |i| "user-id-#{i}" } }
+  gravity_user_id do
+    Fabricate.sequence(:gravity_user_id) { |i| "user-id-#{i}" }
+  end
   email { Fabricate.sequence(:email) { |i| "jon-jonson#{i}@test.com" } }
 end

--- a/spec/helpers/offers_helper_spec.rb
+++ b/spec/helpers/offers_helper_spec.rb
@@ -14,17 +14,30 @@ describe OffersHelper, type: :helper do
     end
 
     it 'shows the correct label for a rejected offer with a rejection_reason' do
-      offer = Fabricate(:offer, state: 'rejected', rejected_by: 'userid', rejection_reason: 'Low estimate')
-      expect(helper.reviewed_byline(offer)).to eq 'Rejected by Jon Jonson. Low estimate'
+      offer =
+        Fabricate(
+          :offer,
+          state: 'rejected',
+          rejected_by: 'userid',
+          rejection_reason: 'Low estimate'
+        )
+      expect(
+        helper.reviewed_byline(offer)
+      ).to eq 'Rejected by Jon Jonson. Low estimate'
     end
 
     it 'shows the correct label for a rejected offer with a rejection_reason and rejection_note' do
-      offer = Fabricate(:offer,
-                        state: 'rejected',
-                        rejected_by: 'userid',
-                        rejection_reason: 'Other',
-                        rejection_note: 'User not a fan of this partner.')
-      expect(helper.reviewed_byline(offer)).to eq 'Rejected by Jon Jonson. Other: User not a fan of this partner.'
+      offer =
+        Fabricate(
+          :offer,
+          state: 'rejected',
+          rejected_by: 'userid',
+          rejection_reason: 'Other',
+          rejection_note: 'User not a fan of this partner.'
+        )
+      expect(
+        helper.reviewed_byline(offer)
+      ).to eq 'Rejected by Jon Jonson. Other: User not a fan of this partner.'
     end
 
     it 'shows the correct label for a rejected offer with no user' do
@@ -35,19 +48,28 @@ describe OffersHelper, type: :helper do
 
   context 'display_fields' do
     it 'returns an array containing only the fields that are present, with minimal fields present' do
-      offer = Fabricate(:offer, offer_type: 'auction consignment', price_cents: nil, commission_percent: 0.1)
+      offer =
+        Fabricate(
+          :offer,
+          offer_type: 'auction consignment',
+          price_cents: nil,
+          commission_percent: 0.1
+        )
       expect(helper.display_fields(offer)).to eq('Commission' => '10.0%')
     end
 
     it 'does not include empty values' do
-      offer = Fabricate(:offer,
-                        offer_type: 'auction consignment',
-                        price_cents: nil,
-                        sale_name: '',
-                        commission_percent: 0.1,
-                        low_estimate_cents: 10_000,
-                        high_estimate_cents: 40_000,
-                        sale_date: Date.new(2018, 10, 30))
+      offer =
+        Fabricate(
+          :offer,
+          offer_type: 'auction consignment',
+          price_cents: nil,
+          sale_name: '',
+          commission_percent: 0.1,
+          low_estimate_cents: 10_000,
+          high_estimate_cents: 40_000,
+          sale_date: Date.new(2_018, 10, 30)
+        )
       expect(helper.display_fields(offer)).to eq(
         'Estimate' => 'USD $100 - 400',
         'Sale Date' => 'Oct 30, 2018',
@@ -56,13 +78,16 @@ describe OffersHelper, type: :helper do
     end
 
     it 'returns an array containing only the present fields with many fields present' do
-      offer = Fabricate(:offer,
-                        offer_type: 'auction consignment',
-                        price_cents: nil,
-                        commission_percent: 0.1,
-                        low_estimate_cents: 10_000,
-                        high_estimate_cents: 40_000,
-                        sale_date: Date.new(2018, 10, 30))
+      offer =
+        Fabricate(
+          :offer,
+          offer_type: 'auction consignment',
+          price_cents: nil,
+          commission_percent: 0.1,
+          low_estimate_cents: 10_000,
+          high_estimate_cents: 40_000,
+          sale_date: Date.new(2_018, 10, 30)
+        )
       expect(helper.display_fields(offer)).to eq(
         'Estimate' => 'USD $100 - 400',
         'Sale Date' => 'Oct 30, 2018',
@@ -79,7 +104,9 @@ describe OffersHelper, type: :helper do
 
     it 'returns the correct string for a retail offer' do
       offer = double('offer', offer_type: 'retail')
-      expect(helper.formatted_offer_type(offer)).to eq 'Private Sale: Retail Price'
+      expect(
+        helper.formatted_offer_type(offer)
+      ).to eq 'Private Sale: Retail Price'
     end
 
     it 'returns the correct string for a net price offer' do
@@ -96,49 +123,81 @@ describe OffersHelper, type: :helper do
   context 'offer_type_description' do
     it 'returns the correct string for an auction consignment offer' do
       offer = double('offer', offer_type: 'auction consignment')
-      expect(helper.offer_type_description(offer)).to include 'This work will be offered in an auction.'
+      expect(
+        helper.offer_type_description(offer)
+      ).to include 'This work will be offered in an auction.'
     end
 
     it 'returns the correct string for a retail offer' do
       offer = double('offer', offer_type: 'retail')
-      expect(helper.offer_type_description(offer)).to include 'This work will be offered privately'
+      expect(
+        helper.offer_type_description(offer)
+      ).to include 'This work will be offered privately'
     end
 
     it 'returns the correct string for a net price offer' do
       offer = double('offer', offer_type: 'net price')
-      expect(helper.offer_type_description(offer)).to include 'This work will be offered privately'
+      expect(
+        helper.offer_type_description(offer)
+      ).to include 'This work will be offered privately'
     end
 
     it 'returns the correct string for a direct purchase offer' do
       offer = double('offer', offer_type: 'purchase')
-      expect(helper.offer_type_description(offer)).to include 'The work will be purchased directly from you by the '\
-      'partner for the specified price.'
+      expect(
+        helper.offer_type_description(offer)
+      ).to include 'The work will be purchased directly from you by the ' \
+                'partner for the specified price.'
     end
   end
 
   context 'estimate_display' do
     it 'works for an offer in USD' do
-      offer = double('offer', low_estimate_cents: 10_000, high_estimate_cents: 30_000, currency: 'USD')
+      offer =
+        double(
+          'offer',
+          low_estimate_cents: 10_000,
+          high_estimate_cents: 30_000,
+          currency: 'USD'
+        )
       expect(helper.estimate_display(offer)).to eq 'USD $100 - 300'
     end
 
     it 'works for EUR' do
-      offer = double('offer', low_estimate_cents: 10_000, high_estimate_cents: 30_000, currency: 'EUR')
+      offer =
+        double(
+          'offer',
+          low_estimate_cents: 10_000,
+          high_estimate_cents: 30_000,
+          currency: 'EUR'
+        )
       expect(helper.estimate_display(offer)).to eq 'EUR €100 - 300'
     end
 
     it 'works when there is only a low estimate' do
-      offer = double('offer', low_estimate_cents: 10_000, high_estimate_cents: nil, currency: 'EUR')
+      offer =
+        double(
+          'offer',
+          low_estimate_cents: 10_000, high_estimate_cents: nil, currency: 'EUR'
+        )
       expect(helper.estimate_display(offer)).to eq 'EUR €100'
     end
 
     it 'works when there is only a high estimate' do
-      offer = double('offer', low_estimate_cents: nil, high_estimate_cents: 30_000, currency: 'EUR')
+      offer =
+        double(
+          'offer',
+          low_estimate_cents: nil, high_estimate_cents: 30_000, currency: 'EUR'
+        )
       expect(helper.estimate_display(offer)).to eq 'EUR €300'
     end
 
     it 'returns nil if both values are nil' do
-      offer = double('offer', low_estimate_cents: nil, high_estimate_cents: nil, currency: 'EUR')
+      offer =
+        double(
+          'offer',
+          low_estimate_cents: nil, high_estimate_cents: nil, currency: 'EUR'
+        )
       expect(helper.estimate_display(offer)).to eq nil
     end
   end
@@ -146,12 +205,16 @@ describe OffersHelper, type: :helper do
   context 'price_display' do
     it 'works for a price in USD' do
       offer = double('offer', price_cents: 10_000, currency: 'USD')
-      expect(helper.price_display(offer.currency, offer.price_cents)).to eq 'USD $100'
+      expect(
+        helper.price_display(offer.currency, offer.price_cents)
+      ).to eq 'USD $100'
     end
 
     it 'works for a price in CAD' do
       offer = double('offer', price_cents: 10_000, currency: 'CAD')
-      expect(helper.price_display(offer.currency, offer.price_cents)).to eq 'CAD $100'
+      expect(
+        helper.price_display(offer.currency, offer.price_cents)
+      ).to eq 'CAD $100'
     end
 
     it 'returns nil if there is no price_cents' do
@@ -162,17 +225,32 @@ describe OffersHelper, type: :helper do
 
   context 'sale_period_display' do
     it 'works for an offer with a sale period' do
-      offer = double('offer', sale_period_start: Date.new(2017, 1, 10), sale_period_end: Date.new(2017, 3, 10))
-      expect(helper.sale_period_display(offer)).to eq 'Jan 10, 2017 - Mar 10, 2017'
+      offer =
+        double(
+          'offer',
+          sale_period_start: Date.new(2_017, 1, 10),
+          sale_period_end: Date.new(2_017, 3, 10)
+        )
+      expect(
+        helper.sale_period_display(offer)
+      ).to eq 'Jan 10, 2017 - Mar 10, 2017'
     end
 
     it 'works for an offer with only a sale_period_start' do
-      offer = double('offer', sale_period_start: Date.new(2017, 1, 10), sale_period_end: nil)
+      offer =
+        double(
+          'offer',
+          sale_period_start: Date.new(2_017, 1, 10), sale_period_end: nil
+        )
       expect(helper.sale_period_display(offer)).to eq 'Starts Jan 10, 2017'
     end
 
     it 'works for an offer with only a sale_period_end' do
-      offer = double('offer', sale_period_start: nil, sale_period_end: Date.new(2017, 3, 10))
+      offer =
+        double(
+          'offer',
+          sale_period_start: nil, sale_period_end: Date.new(2_017, 3, 10)
+        )
       expect(helper.sale_period_display(offer)).to eq 'Ends Mar 10, 2017'
     end
 
@@ -184,7 +262,7 @@ describe OffersHelper, type: :helper do
 
   context 'sale_date_display' do
     it 'works for an offer with a sale_date' do
-      offer = double('offer', sale_date: Date.new(2017, 1, 10))
+      offer = double('offer', sale_date: Date.new(2_017, 1, 10))
       expect(helper.sale_date_display(offer)).to eq 'Jan 10, 2017'
     end
 
@@ -242,17 +320,29 @@ describe OffersHelper, type: :helper do
 
   context 'insurance_display' do
     it 'works if the offer has an insurance_cents' do
-      offer = double('offer', insurance_cents: 12_000, insurance_percent: nil, currency: 'USD')
+      offer =
+        double(
+          'offer',
+          insurance_cents: 12_000, insurance_percent: nil, currency: 'USD'
+        )
       expect(helper.insurance_display(offer)).to eq 'USD $120.00'
     end
 
     it 'works if the offer has an insurance_percent' do
-      offer = double('offer', insurance_cents: nil, insurance_percent: 0.12, currency: 'USD')
+      offer =
+        double(
+          'offer',
+          insurance_cents: nil, insurance_percent: 0.12, currency: 'USD'
+        )
       expect(helper.insurance_display(offer)).to eq '12.0%'
     end
 
     it 'returns nil if the offer has no insurance' do
-      offer = double('offer', insurance_percent: nil, insurance_cents: nil, currency: 'USD')
+      offer =
+        double(
+          'offer',
+          insurance_percent: nil, insurance_cents: nil, currency: 'USD'
+        )
       expect(helper.insurance_display(offer)).to eq nil
     end
   end
@@ -264,12 +354,20 @@ describe OffersHelper, type: :helper do
     end
 
     it 'works if the offer has an other_fees_percent' do
-      offer = double('offer', other_fees_cents: nil, other_fees_percent: 0.12, currency: 'USD')
+      offer =
+        double(
+          'offer',
+          other_fees_cents: nil, other_fees_percent: 0.12, currency: 'USD'
+        )
       expect(helper.other_fees_display(offer)).to eq '12.0%'
     end
 
     it 'returns nil if the offer has no other fees' do
-      offer = double('offer', other_fees_percent: nil, other_fees_cents: nil, currency: 'USD')
+      offer =
+        double(
+          'offer',
+          other_fees_percent: nil, other_fees_cents: nil, currency: 'USD'
+        )
       expect(helper.other_fees_display(offer)).to eq nil
     end
   end

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -4,37 +4,44 @@ require 'support/gravity_helper'
 describe SubmissionsHelper, type: :helper do
   context 'formatted_location' do
     it 'correctly formats location fields' do
-      submission = Fabricate(:submission,
-                             location_city: 'Brooklyn',
-                             location_state: 'New York',
-                             location_country: 'USA')
-      expect(helper.formatted_location(submission)).to eq 'Brooklyn, New York, USA'
+      submission =
+        Fabricate(
+          :submission,
+          location_city: 'Brooklyn',
+          location_state: 'New York',
+          location_country: 'USA'
+        )
+      expect(
+        helper.formatted_location(submission)
+      ).to eq 'Brooklyn, New York, USA'
     end
 
     it 'returns empty string when location values are nil' do
-      submission = Fabricate(:submission,
-                             location_city: '',
-                             location_state: '',
-                             location_country: '')
+      submission =
+        Fabricate(
+          :submission,
+          location_city: '', location_state: '', location_country: ''
+        )
       expect(helper.formatted_location(submission)).to be_blank
     end
 
     it 'works if the location has no city' do
-      submission = Fabricate(:submission,
-                             location_city: '',
-                             location_state: 'Tokyo',
-                             location_country: 'Japan')
+      submission =
+        Fabricate(
+          :submission,
+          location_city: '', location_state: 'Tokyo', location_country: 'Japan'
+        )
       expect(helper.formatted_location(submission)).to eq('Tokyo, Japan')
     end
   end
 
   context 'formatted_dimensions' do
     it 'correctly formats dimension fields' do
-      submission = Fabricate(:submission,
-                             width: '10',
-                             height: '12',
-                             depth: '1.75',
-                             dimensions_metric: 'in')
+      submission =
+        Fabricate(
+          :submission,
+          width: '10', height: '12', depth: '1.75', dimensions_metric: 'in'
+        )
       expect(helper.formatted_dimensions(submission)).to eq '12x10x1.75in'
     end
 
@@ -46,53 +53,44 @@ describe SubmissionsHelper, type: :helper do
 
   context 'formatted_editions' do
     it 'it correctly formats the editions fields' do
-      submission = Fabricate(:submission,
-                             edition_size: 200,
-                             edition_number: '10a')
+      submission =
+        Fabricate(:submission, edition_size: 200, edition_number: '10a')
       expect(helper.formatted_editions(submission)).to eq '10a/200'
     end
 
     it 'returns nil if there is no edition_number' do
-      submission = Fabricate(:submission,
-                             edition_size: 200,
-                             edition_number: nil)
+      submission =
+        Fabricate(:submission, edition_size: 200, edition_number: nil)
       expect(helper.formatted_editions(submission)).to eq nil
     end
   end
 
   context 'formatted_category' do
     it 'correctly formats category and medium fields if both are present' do
-      submission = Fabricate(:submission,
-                             category: 'Painting',
-                             medium: 'Oil on linen')
-      expect(helper.formatted_category(submission)).to eq 'Painting, Oil on linen'
+      submission =
+        Fabricate(:submission, category: 'Painting', medium: 'Oil on linen')
+      expect(
+        helper.formatted_category(submission)
+      ).to eq 'Painting, Oil on linen'
     end
 
     it 'correctly formats category and medium fields if category is nil' do
-      submission = Fabricate(:submission,
-                             category: nil,
-                             medium: 'Oil on linen')
+      submission = Fabricate(:submission, category: nil, medium: 'Oil on linen')
       expect(helper.formatted_category(submission)).to eq 'Oil on linen'
     end
 
     it 'correctly formats category and medium fields if medium is nil' do
-      submission = Fabricate(:submission,
-                             category: 'Painting',
-                             medium: nil)
+      submission = Fabricate(:submission, category: 'Painting', medium: nil)
       expect(helper.formatted_category(submission)).to eq 'Painting'
     end
 
     it 'correctly formats category and medium fields if category is empty' do
-      submission = Fabricate(:submission,
-                             category: nil,
-                             medium: 'Oil on linen')
+      submission = Fabricate(:submission, category: nil, medium: 'Oil on linen')
       expect(helper.formatted_category(submission)).to eq 'Oil on linen'
     end
 
     it 'correctly formats category and medium fields if medium is empty' do
-      submission = Fabricate(:submission,
-                             category: 'Painting',
-                             medium: '')
+      submission = Fabricate(:submission, category: 'Painting', medium: '')
       expect(helper.formatted_category(submission)).to eq 'Painting'
     end
   end
@@ -111,16 +109,19 @@ describe SubmissionsHelper, type: :helper do
       )
     end
     it 'displays the correct text when all info is present' do
-      expect(helper.formatted_medium_metadata(submission)).to eq 'Oil on linen, 10x10x15cm, Edition 10a/100'
+      expect(
+        helper.formatted_medium_metadata(submission)
+      ).to eq 'Oil on linen, 10x10x15cm, Edition 10a/100'
     end
     it 'truncates the medium correctly' do
       submission.update!(
-        medium: 'Since the late 1990s, KAWS has produced art toys to be circulated as global commodities. '\
-                'By engaging directly with branding, production, and distribution, his toys compel their '\
-                'collectors to consider what the commodity status of art objects is today. Seen here, the '\
-                "\"Accomplice” characters from KAWS are appropriately branded with the artist's trademark \"X\" "\
-                "to replace each of the figure's original eyes. The black example is from an edition of 500 "\
-                'and the pink example is from an edition of 1000'
+        medium:
+          'Since the late 1990s, KAWS has produced art toys to be circulated as global commodities. ' \
+            'By engaging directly with branding, production, and distribution, his toys compel their ' \
+            'collectors to consider what the commodity status of art objects is today. Seen here, the ' \
+            "\"Accomplice” characters from KAWS are appropriately branded with the artist's trademark \"X\" " \
+            "to replace each of the figure's original eyes. The black example is from an edition of 500 " \
+            'and the pink example is from an edition of 1000'
       )
       expect(helper.formatted_medium_metadata(submission)).to eq(
         'Since the late 1990s, KAWS has produced art toys to be circulated as global commodities. By engag..., 10x10x15cm, Edition 10a/100'
@@ -128,30 +129,51 @@ describe SubmissionsHelper, type: :helper do
     end
     it 'displays the correct text when there is no medium' do
       submission.update!(medium: nil)
-      expect(helper.formatted_medium_metadata(submission)).to eq '10x10x15cm, Edition 10a/100'
+      expect(
+        helper.formatted_medium_metadata(submission)
+      ).to eq '10x10x15cm, Edition 10a/100'
     end
     it 'displays the correct text when there is no edition number/size' do
       submission.update!(edition_number: nil, edition_size: nil)
-      expect(helper.formatted_medium_metadata(submission)).to eq 'Oil on linen, 10x10x15cm'
+      expect(
+        helper.formatted_medium_metadata(submission)
+      ).to eq 'Oil on linen, 10x10x15cm'
     end
     it 'displays the correct text when there are no dimensions' do
       submission.update!(height: nil, width: nil, depth: nil)
-      expect(helper.formatted_medium_metadata(submission)).to eq 'Oil on linen, Edition 10a/100'
+      expect(
+        helper.formatted_medium_metadata(submission)
+      ).to eq 'Oil on linen, Edition 10a/100'
     end
     it 'displays the correct text when there is only a medium' do
-      submission.update!(height: nil, width: nil, depth: nil, edition_number: nil, edition_size: nil)
+      submission.update!(
+        height: nil,
+        width: nil,
+        depth: nil,
+        edition_number: nil,
+        edition_size: nil
+      )
       expect(helper.formatted_medium_metadata(submission)).to eq 'Oil on linen'
     end
     it 'displays the correct text when there is only an edition number/size' do
       submission.update!(height: nil, width: nil, depth: nil, medium: nil)
-      expect(helper.formatted_medium_metadata(submission)).to eq 'Edition 10a/100'
+      expect(
+        helper.formatted_medium_metadata(submission)
+      ).to eq 'Edition 10a/100'
     end
     it 'displays the correct text when there are only dimensions' do
       submission.update!(medium: nil, edition_number: nil, edition_size: nil)
       expect(helper.formatted_medium_metadata(submission)).to eq '10x10x15cm'
     end
     it 'displays the correct text when there is no info' do
-      submission.update!(medium: nil, edition_number: nil, edition_size: nil, height: nil, width: nil, depth: nil)
+      submission.update!(
+        medium: nil,
+        edition_number: nil,
+        edition_size: nil,
+        height: nil,
+        width: nil,
+        depth: nil
+      )
       expect(helper.formatted_medium_metadata(submission)).to eq ''
     end
   end
@@ -160,13 +182,15 @@ describe SubmissionsHelper, type: :helper do
     it 'shows the correct label for an approved submission' do
       stub_gravity_root
       stub_gravity_user
-      submission = Fabricate(:submission, state: 'approved', approved_by: 'userid')
+      submission =
+        Fabricate(:submission, state: 'approved', approved_by: 'userid')
       expect(helper.reviewer_byline(submission)).to eq 'Approved by Jon Jonson'
     end
     it 'shows the correct label for a rejected submissions' do
       stub_gravity_root
       stub_gravity_user
-      submission = Fabricate(:submission, state: 'rejected', rejected_by: 'userid')
+      submission =
+        Fabricate(:submission, state: 'rejected', rejected_by: 'userid')
       expect(helper.reviewer_byline(submission)).to eq 'Rejected by Jon Jonson'
     end
     it 'shows the correct label for an approved submission with no user' do

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -2,30 +2,42 @@ require 'rails_helper'
 
 describe UrlHelper, type: :helper do
   before do
-    allow(Convection.config).to receive(:artsy_url).and_return('https://test.artsy.net')
+    allow(Convection.config).to receive(:artsy_url).and_return(
+      'https://test.artsy.net'
+    )
   end
 
   describe '#upload_photo_url' do
     it 'returns a url without utm params if none are provided' do
-      expect(helper.upload_photo_url(19)).to eq('https://test.artsy.net/consign/submission/19/upload?')
+      expect(helper.upload_photo_url(19)).to eq(
+        'https://test.artsy.net/consign/submission/19/upload?'
+      )
     end
     it 'returns a url with utm params if some are provided' do
       utm_params = { utm_source: 'reminder', utm_campaign: 'consignments' }
-      expect(helper.upload_photo_url(19, utm_params)).to eq('https://test.artsy.net/consign/submission/19/upload?utm_campaign=consignments&utm_source=reminder')
+      expect(helper.upload_photo_url(19, utm_params)).to eq(
+        'https://test.artsy.net/consign/submission/19/upload?utm_campaign=consignments&utm_source=reminder'
+      )
     end
   end
 
   describe '#offer_form_url' do
     before do
-      allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction?entry.blahblah=SUBMISSION_NUMBER')
+      allow(Convection.config).to receive(:auction_offer_form_url).and_return(
+        'https://google.com/auction?entry.blahblah=SUBMISSION_NUMBER'
+      )
     end
 
     it 'returns the correct url for an auction' do
-      expect(helper.offer_form_url).to eq('https://google.com/auction?entry.blahblah=')
+      expect(helper.offer_form_url).to eq(
+        'https://google.com/auction?entry.blahblah='
+      )
     end
 
     it 'correctly replaces the submission number if one is supplied' do
-      expect(helper.offer_form_url(submission_id: 123)).to eq('https://google.com/auction?entry.blahblah=123')
+      expect(helper.offer_form_url(submission_id: 123)).to eq(
+        'https://google.com/auction?entry.blahblah=123'
+      )
     end
   end
 
@@ -37,11 +49,17 @@ describe UrlHelper, type: :helper do
     end
 
     it 'returns the correct url for a user to respond' do
-      expect(helper.offer_response_form_url).to eq('https://google.com/response?entry.blahblah=&entry.blah2=')
+      expect(helper.offer_response_form_url).to eq(
+        'https://google.com/response?entry.blahblah=&entry.blah2='
+      )
     end
 
     it 'correctly replaces the submission number if one is supplied' do
-      expect(helper.offer_response_form_url(submission_id: 123, partner_name: 'gagosian gallery')).to eq(
+      expect(
+        helper.offer_response_form_url(
+          submission_id: 123, partner_name: 'gagosian gallery'
+        )
+      ).to eq(
         'https://google.com/response?entry.blahblah=123&entry.blah2=gagosian gallery'
       )
     end

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -7,12 +7,10 @@ class AdminMailerPreview < ActionMailer::Preview
 
   def receipt_mail_params
     {
-      submission: OpenStruct.new(
-        id: '12',
-        processed_images: []
-      ),
+      submission: OpenStruct.new(id: '12', processed_images: []),
       artist: OpenStruct.new(id: 'artist_id', name: 'Andy Warhol'),
-      user_detail: OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
+      user_detail:
+        OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
       user: OpenStruct.new(id: 'x', name: 'William Black')
     }
   end

--- a/spec/mailers/previews/base_preview.rb
+++ b/spec/mailers/previews/base_preview.rb
@@ -12,9 +12,10 @@ class BasePreview < ActionMailer::Preview
       low_estimate_cents: 12_300,
       high_estimate_cents: 15_000,
       notes: 'We would love to sell your work!',
-      partner_submission: OpenStruct.new(
-        partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')
-      ),
+      partner_submission:
+        OpenStruct.new(
+          partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')
+        ),
       partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery'),
       submission: base_submission
     )
@@ -28,22 +29,24 @@ class BasePreview < ActionMailer::Preview
       processed_images: [],
       images: [],
       title: 'My Favorite Artwork',
-      year: 1992,
+      year: 1_992,
       height: 12,
       width: 14,
       dimensions_metric: 'in',
       category: 'Painting',
-      medium: 'Since the late 1990s, KAWS has produced art toys to be circulated as global commodities. '\
-              'By engaging directly with branding, production, and distribution, his toys compel their '\
-              'collectors to consider what the commodity status of art objects is today. Seen here, the '\
-              "\"Accomplice” characters from KAWS are appropriately branded with the artist's trademark \"X\" "\
-              "to replace each of the figure's original eyes. The black example is from an edition of 500 "\
-              'and the pink example is from an edition of 1000',
+      medium:
+        'Since the late 1990s, KAWS has produced art toys to be circulated as global commodities. ' \
+          'By engaging directly with branding, production, and distribution, his toys compel their ' \
+          'collectors to consider what the commodity status of art objects is today. Seen here, the ' \
+          "\"Accomplice” characters from KAWS are appropriately branded with the artist's trademark \"X\" " \
+          "to replace each of the figure's original eyes. The black example is from an edition of 500 " \
+          'and the pink example is from an edition of 1000',
       artist_name: 'Damien Hirst',
       location_city: 'New York',
       location_state: 'NY',
       location_country: 'USA',
-      provenance: 'Inherited from my mother who got it from her father after he divorced from his second wife.',
+      provenance:
+        'Inherited from my mother who got it from her father after he divorced from his second wife.',
       edition_number: '12a',
       edition_size: 100,
       large_images: [
@@ -62,7 +65,8 @@ class BasePreview < ActionMailer::Preview
     s = base_submission
     s.minimum_price_cents = 50_000_00
     s.currency = 'USD'
-    s.minimum_price_display = Money.new(s.minimum_price_cents, s.currency).format(no_cents: true)
+    s.minimum_price_display =
+      Money.new(s.minimum_price_cents, s.currency).format(no_cents: true)
     s
   end
 end

--- a/spec/mailers/previews/partner_mailer_preview.rb
+++ b/spec/mailers/previews/partner_mailer_preview.rb
@@ -1,11 +1,17 @@
 class PartnerMailerPreview < BasePreview
   def submission_digest_auction
-    params = submission_digest_mail_params.merge(partner_name: 'Phillips', partner_type: 'Auction', email: 'foo@foo.com')
+    params =
+      submission_digest_mail_params.merge(
+        partner_name: 'Phillips', partner_type: 'Auction', email: 'foo@foo.com'
+      )
     PartnerMailer.submission_digest(params)
   end
 
   def submission_digest_gallery
-    params = submission_digest_mail_params.merge(partner_name: 'Gagosian', partner_type: 'Gallery', email: 'foo@foo.com')
+    params =
+      submission_digest_mail_params.merge(
+        partner_name: 'Gagosian', partner_type: 'Gallery', email: 'foo@foo.com'
+      )
     PartnerMailer.submission_digest(params)
   end
 
@@ -31,11 +37,9 @@ class PartnerMailerPreview < BasePreview
     sub1 = base_submission
     sub2 = base_submission
     sub2.user = OpenStruct.new(unique_code_for_digest: 12_312)
-    users_to_submissions = [sub1, sub2, base_submission_with_minimum_price].group_by(&:user)
+    users_to_submissions =
+      [sub1, sub2, base_submission_with_minimum_price].group_by(&:user)
 
-    {
-      users_to_submissions: users_to_submissions,
-      submissions_count: 3
-    }
+    { users_to_submissions: users_to_submissions, submissions_count: 3 }
   end
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -27,78 +27,91 @@ class UserMailerPreview < BasePreview
     UserMailer.offer(
       offer: auction_offer,
       artist: OpenStruct.new(id: 'artist_id', name: 'Andy Warhol'),
-      user_detail: OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
+      user_detail:
+        OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
       user: OpenStruct.new(id: 'x', name: 'William Black')
     )
   end
 
   def retail_offer
     UserMailer.offer(
-      offer: OpenStruct.new(
-        id: '123',
-        offer_type: 'retail',
-        reference_id: '12345',
-        currency: 'USD',
-        rejection_reason: 'High shipping/marketing costs',
-        price_cents: 12_300,
-        commission_percent: 0.10,
-        sale_period_start: Date.new(2014, 1, 4),
-        sale_period_end: Date.new(2014, 10, 4),
-        notes: 'We would love to sell your work!',
-        partner_submission: OpenStruct.new(
-          partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')
+      offer:
+        OpenStruct.new(
+          id: '123',
+          offer_type: 'retail',
+          reference_id: '12345',
+          currency: 'USD',
+          rejection_reason: 'High shipping/marketing costs',
+          price_cents: 12_300,
+          commission_percent: 0.10,
+          sale_period_start: Date.new(2_014, 1, 4),
+          sale_period_end: Date.new(2_014, 10, 4),
+          notes: 'We would love to sell your work!',
+          partner_submission:
+            OpenStruct.new(
+              partner:
+                OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')
+            ),
+          partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery'),
+          submission: base_submission
         ),
-        partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery'),
-        submission: base_submission
-      ),
       artist: OpenStruct.new(id: 'artist_id', name: 'Andy Warhol'),
-      user_detail: OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
+      user_detail:
+        OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
       user: OpenStruct.new(id: 'x', name: 'William Black')
     )
   end
 
   def purchase_offer
     UserMailer.offer(
-      offer: OpenStruct.new(
-        id: '123',
-        offer_type: 'purchase',
-        reference_id: '12345',
-        currency: 'USD',
-        rejection_reason: 'High shipping/marketing costs',
-        price_cents: 12_300,
-        notes: 'We would love to sell your work!',
-        partner_submission: OpenStruct.new(
-          partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')
+      offer:
+        OpenStruct.new(
+          id: '123',
+          offer_type: 'purchase',
+          reference_id: '12345',
+          currency: 'USD',
+          rejection_reason: 'High shipping/marketing costs',
+          price_cents: 12_300,
+          notes: 'We would love to sell your work!',
+          partner_submission:
+            OpenStruct.new(
+              partner:
+                OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')
+            ),
+          partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery'),
+          submission: base_submission
         ),
-        partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery'),
-        submission: base_submission
-      ),
       artist: OpenStruct.new(id: 'artist_id', name: 'Andy Warhol'),
-      user_detail: OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
+      user_detail:
+        OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
       user: OpenStruct.new(id: 'x', name: 'William Black')
     )
   end
 
   def net_price_offer
     UserMailer.offer(
-      offer: OpenStruct.new(
-        id: '123',
-        offer_type: 'net price',
-        reference_id: '12345',
-        currency: 'USD',
-        sale_period_start: Date.new(2014, 1, 4),
-        sale_period_end: Date.new(2014, 10, 4),
-        rejection_reason: 'High shipping/marketing costs',
-        price_cents: 12_300,
-        notes: 'We would love to sell your work!',
-        partner_submission: OpenStruct.new(
-          partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')
+      offer:
+        OpenStruct.new(
+          id: '123',
+          offer_type: 'net price',
+          reference_id: '12345',
+          currency: 'USD',
+          sale_period_start: Date.new(2_014, 1, 4),
+          sale_period_end: Date.new(2_014, 10, 4),
+          rejection_reason: 'High shipping/marketing costs',
+          price_cents: 12_300,
+          notes: 'We would love to sell your work!',
+          partner_submission:
+            OpenStruct.new(
+              partner:
+                OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')
+            ),
+          partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery'),
+          submission: base_submission
         ),
-        partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery'),
-        submission: base_submission
-      ),
       artist: OpenStruct.new(id: 'artist_id', name: 'Andy Warhol'),
-      user_detail: OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
+      user_detail:
+        OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
       user: OpenStruct.new(id: 'x', name: 'William Black')
     )
   end
@@ -109,7 +122,8 @@ class UserMailerPreview < BasePreview
     {
       submission: base_submission,
       artist: OpenStruct.new(id: 'artist_id', name: 'Andy Warhol'),
-      user_detail: OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
+      user_detail:
+        OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
       user: OpenStruct.new(id: 'x', name: 'William Black')
     }
   end
@@ -117,7 +131,8 @@ class UserMailerPreview < BasePreview
   def reminder_mail_params
     {
       submission: OpenStruct.new(id: '12'),
-      user_detail: OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
+      user_detail:
+        OpenStruct.new(id: 'high_bidder_id', email: 'themaninblack@yahoo.com'),
       user: OpenStruct.new(id: 'x', name: 'William Black')
     }
   end

--- a/spec/models/asset_spec.rb
+++ b/spec/models/asset_spec.rb
@@ -15,29 +15,37 @@ describe Asset do
     it 'adds a new image version url' do
       params = { image_url: { square: 'https://square-image.jpg' } }
       asset.update_image_urls!(params)
-      expect(asset.reload.image_urls).to eq('square' => 'https://square-image.jpg')
+      expect(asset.reload.image_urls).to eq(
+        'square' => 'https://square-image.jpg'
+      )
     end
 
     it 'adds a new image version url to a pre-populated hash' do
       asset.update!(image_urls: { round: 'https://round-image.jpg' })
       params = { image_url: { square: 'https://square-image.jpg' } }
       asset.update_image_urls!(params)
-      expect(asset.reload.image_urls).to eq('round' => 'https://round-image.jpg',
-                                            'square' => 'https://square-image.jpg')
+      expect(asset.reload.image_urls).to eq(
+        'round' => 'https://round-image.jpg',
+        'square' => 'https://square-image.jpg'
+      )
     end
 
     it 'updates an existing image version url' do
       asset.update!(image_urls: { round: 'https://round-image.jpg' })
       params = { image_url: { round: 'https://square-image.jpg' } }
       asset.update_image_urls!(params)
-      expect(asset.reload.image_urls).to eq('round' => 'https://square-image.jpg')
+      expect(asset.reload.image_urls).to eq(
+        'round' => 'https://square-image.jpg'
+      )
     end
 
     it 'does nothing if the params are empty' do
       asset.update!(image_urls: { round: 'https://round-image.jpg' })
       params = { image_url: {} }
       asset.update_image_urls!(params)
-      expect(asset.reload.image_urls).to eq('round' => 'https://round-image.jpg')
+      expect(asset.reload.image_urls).to eq(
+        'round' => 'https://round-image.jpg'
+      )
     end
   end
 
@@ -45,8 +53,12 @@ describe Asset do
     let(:asset) { Fabricate(:image, gemini_token: nil) }
 
     before do
-      allow(Convection.config).to receive(:gemini_app).and_return('https://media-test.artsy.net')
-      allow(Convection.config).to receive(:gemini_account_key).and_return('convection-test')
+      allow(Convection.config).to receive(:gemini_app).and_return(
+        'https://media-test.artsy.net'
+      )
+      allow(Convection.config).to receive(:gemini_account_key).and_return(
+        'convection-test'
+      )
     end
 
     it 'does nothing if there is no gemini_token' do
@@ -55,13 +67,15 @@ describe Asset do
 
     it 'returns an image location' do
       asset.update!(gemini_token: 'foo')
-      stub_request(:get, 'https://media-test.artsy.net/original.json?token=foo').to_return(status: 302)
+      stub_request(:get, 'https://media-test.artsy.net/original.json?token=foo')
+        .to_return(status: 302)
       expect { asset.original_image }.to_not raise_error
     end
 
     it 'raises an exception if the response is not successful' do
       asset.update!(gemini_token: 'foo')
-      stub_request(:get, 'https://media-test.artsy.net/original.json?token=foo').to_return(status: 400, body: 'ruh roh')
+      stub_request(:get, 'https://media-test.artsy.net/original.json?token=foo')
+        .to_return(status: 400, body: 'ruh roh')
       expect { asset.original_image }.to raise_error '400: ruh roh'
     end
   end

--- a/spec/models/demand_calculator_spec.rb
+++ b/spec/models/demand_calculator_spec.rb
@@ -4,7 +4,10 @@ describe DemandCalculator do
   let(:artist_id) { 'artistid' }
 
   let!(:artist_standing_score) do
-    Fabricate(:artist_standing_score, artist_id: artist_id, artist_score: 0.50, auction_score: 1.0)
+    Fabricate(
+      :artist_standing_score,
+      artist_id: artist_id, artist_score: 0.50, auction_score: 1.0
+    )
   end
 
   context 'finding artist scores' do
@@ -21,23 +24,35 @@ describe DemandCalculator do
     end
 
     it 'uses the one created first when there are two matches' do
-      duplicate_standing_score = Fabricate(:artist_standing_score, artist_id: artist_id, artist_score: 0.33, auction_score: 0.66, created_at: 1.day.ago)
+      duplicate_standing_score =
+        Fabricate(
+          :artist_standing_score,
+          artist_id: artist_id,
+          artist_score: 0.33,
+          auction_score: 0.66,
+          created_at: 1.day.ago
+        )
       scores = DemandCalculator.score(artist_id, 'Painting')
       expect(scores[:artist_score]).to eq duplicate_standing_score.artist_score
-      expect(scores[:auction_score]).to eq duplicate_standing_score.auction_score
+      expect(scores[:auction_score]).to eq duplicate_standing_score
+           .auction_score
     end
   end
 
   context 'modifiers' do
     it 'uses the modifier when it can be found' do
       scores = DemandCalculator.score(artist_id, 'Print')
-      expected_artist_score = artist_standing_score.artist_score * DemandCalculator::CATEGORY_MODIFIERS['Print']
+      expected_artist_score =
+        artist_standing_score.artist_score *
+          DemandCalculator::CATEGORY_MODIFIERS['Print']
       expect(scores[:artist_score]).to eq expected_artist_score
     end
 
     it 'uses the default when category modifier does not exist' do
       scores = DemandCalculator.score(artist_id, 'Photography')
-      expected_artist_score = artist_standing_score.artist_score * DemandCalculator::CATEGORY_MODIFIERS['Default']
+      expected_artist_score =
+        artist_standing_score.artist_score *
+          DemandCalculator::CATEGORY_MODIFIERS['Default']
       expect(scores[:artist_score]).to eq expected_artist_score
     end
   end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -3,7 +3,9 @@ require 'support/gravity_helper'
 
 describe Offer do
   let(:offer) { Fabricate(:offer) }
-  let(:approved_submission) { Fabricate(:submission, state: Submission::APPROVED) }
+  let(:approved_submission) do
+    Fabricate(:submission, state: Submission::APPROVED)
+  end
 
   context 'state' do
     it 'correctly sets the initial state to sent' do
@@ -83,9 +85,21 @@ describe Offer do
     before do
       partner1 = Fabricate(:partner, name: 'Gagosian')
       partner2 = Fabricate(:partner, name: 'Heritage Auctions')
-      @offer1 = Fabricate(:offer, partner_submission: Fabricate(:partner_submission, partner: partner1))
-      @offer2 = Fabricate(:offer, partner_submission: Fabricate(:partner_submission, partner: partner1))
-      @offer3 = Fabricate(:offer, partner_submission: Fabricate(:partner_submission, partner: partner2))
+      @offer1 =
+        Fabricate(
+          :offer,
+          partner_submission: Fabricate(:partner_submission, partner: partner1)
+        )
+      @offer2 =
+        Fabricate(
+          :offer,
+          partner_submission: Fabricate(:partner_submission, partner: partner1)
+        )
+      @offer3 =
+        Fabricate(
+          :offer,
+          partner_submission: Fabricate(:partner_submission, partner: partner2)
+        )
     end
 
     it 'allows you to search for offers by reference_id' do

--- a/spec/models/partner_submission_spec.rb
+++ b/spec/models/partner_submission_spec.rb
@@ -33,12 +33,14 @@ describe PartnerSubmission do
 
   context 'deletion' do
     it 'deletes associated offers, but not the submission' do
-      Fabricate(:offer, submission: partner_submission.submission, partner_submission: partner_submission)
-      expect do
-        partner_submission.destroy
-      end
-        .to change { Submission.count }.by(0)
-                                       .and change { Offer.count }.by(-1)
+      Fabricate(
+        :offer,
+        submission: partner_submission.submission,
+        partner_submission: partner_submission
+      )
+      expect { partner_submission.destroy }.to change { Submission.count }.by(
+        0
+      ).and change { Offer.count }.by(-1)
     end
 
     it 'nullifies consigned_partner_submission_id on offer' do

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -37,17 +37,26 @@ describe Submission do
     let(:artist_id) { 'artistid' }
 
     let!(:artist_standing_score) do
-      Fabricate(:artist_standing_score, artist_id: artist_id, artist_score: 0.50, auction_score: 1.0)
+      Fabricate(
+        :artist_standing_score,
+        artist_id: artist_id, artist_score: 0.50, auction_score: 1.0
+      )
     end
 
     let!(:other_standing_score) do
-      Fabricate(:artist_standing_score, artist_id: 'other', artist_score: 0.33, auction_score: 0.66)
+      Fabricate(
+        :artist_standing_score,
+        artist_id: 'other', artist_score: 0.33, auction_score: 0.66
+      )
     end
 
     let(:submission_state) { 'draft' }
 
     let(:submission) do
-      Fabricate(:submission, artist_id: artist_id, medium: 'Painting', state: submission_state)
+      Fabricate(
+        :submission,
+        artist_id: artist_id, medium: 'Painting', state: submission_state
+      )
     end
 
     it 'is set on create' do
@@ -68,7 +77,8 @@ describe Submission do
         submission.update(artist_id: 'other')
 
         expect(submission.artist_score).to eq other_standing_score.artist_score
-        expect(submission.auction_score).to eq other_standing_score.auction_score
+        expect(submission.auction_score).to eq other_standing_score
+             .auction_score
       end
 
       it 'does not re-calcuate when unrelated things change' do
@@ -84,7 +94,8 @@ describe Submission do
         submission.update(artist_id: 'other')
 
         expect(submission.artist_score).to eq artist_standing_score.artist_score
-        expect(submission.auction_score).to eq artist_standing_score.auction_score
+        expect(submission.auction_score).to eq artist_standing_score
+             .auction_score
       end
     end
 
@@ -93,7 +104,8 @@ describe Submission do
         submission.update(artist_id: 'other', state: 'approved')
 
         expect(submission.artist_score).to eq artist_standing_score.artist_score
-        expect(submission.auction_score).to eq artist_standing_score.auction_score
+        expect(submission.auction_score).to eq artist_standing_score
+             .auction_score
       end
     end
   end
@@ -157,7 +169,10 @@ describe Submission do
   context 'artist' do
     it 'returns nil if it cannot find the object' do
       stub_gravity_root
-      stub_request(:get, "#{Convection.config.gravity_api_url}/artists/#{submission.artist_id}")
+      stub_request(
+        :get,
+        "#{Convection.config.gravity_api_url}/artists/#{submission.artist_id}"
+      )
         .to_raise(Faraday::ResourceNotFound)
       expect(submission.artist).to be_nil
       expect(submission.artist_name).to be_nil
@@ -178,7 +193,11 @@ describe Submission do
       expect(submission.thumbnail).to eq nil
     end
     it 'returns the first image with a thumbnail url' do
-      Fabricate(:image, submission: submission, image_urls: { 'thumbnail' => 'https://thumb.jpg' })
+      Fabricate(
+        :image,
+        submission: submission,
+        image_urls: { 'thumbnail' => 'https://thumb.jpg' }
+      )
       expect(submission.thumbnail).to eq 'https://thumb.jpg'
     end
   end
@@ -187,11 +206,9 @@ describe Submission do
     it 'deletes associated partner submissions and offers' do
       Fabricate(:partner_submission, submission: submission)
       Fabricate(:offer, submission: submission)
-      expect do
-        submission.destroy
-      end
-        .to change { PartnerSubmission.count }.by(-1)
-                                              .and change { Offer.count }.by(-1)
+      expect { submission.destroy }.to change { PartnerSubmission.count }.by(
+        -1
+      ).and change { Offer.count }.by(-1)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,14 +7,14 @@ describe User do
   let(:user) { Fabricate(:user, gravity_user_id: 'userid') }
 
   it 'generates a consistent consignor number' do
-    travel_to Time.zone.local(2019, 1, 1, 0, 0, 0) do
+    travel_to Time.zone.local(2_019, 1, 1, 0, 0, 0) do
       user.id = 1
       expect(user.unique_code_for_digest).to eq(801)
       user.id = 9
       expect(user.unique_code_for_digest).to eq(809)
     end
 
-    travel_to Time.zone.local(2019, 8, 7, 6, 5, 4) do
+    travel_to Time.zone.local(2_019, 8, 7, 6, 5, 4) do
       user1 = Fabricate(:user)
       user1.id = 1
       expect(user1.unique_code_for_digest).to eq(57_905)
@@ -24,7 +24,10 @@ describe User do
   context 'gravity_user' do
     it 'returns nil if it cannot find the object' do
       stub_gravity_root
-      stub_request(:get, "#{Convection.config.gravity_api_url}/users/#{user.gravity_user_id}")
+      stub_request(
+        :get,
+        "#{Convection.config.gravity_api_url}/users/#{user.gravity_user_id}"
+      )
         .to_raise(Faraday::ResourceNotFound)
       expect(user.gravity_user).to be_nil
       expect(user.name).to be_nil
@@ -41,7 +44,12 @@ describe User do
     it 'returns nil if it cannot find the object' do
       stub_gravity_root
       stub_gravity_user(id: user.gravity_user_id, name: 'Buster Bluth')
-      stub_request(:get, "#{Convection.config.gravity_api_url}/user_details/#{user.gravity_user_id}")
+      stub_request(
+        :get,
+        "#{Convection.config.gravity_api_url}/user_details/#{
+          user.gravity_user_id
+        }"
+      )
         .to_raise(Faraday::ResourceNotFound)
       expect(user.name).to eq 'Buster Bluth'
       expect(user.user_detail).to be_nil
@@ -51,14 +59,19 @@ describe User do
     it 'returns the object if it can find it' do
       stub_gravity_root
       stub_gravity_user(id: user.gravity_user_id, name: 'Buster Bluth')
-      stub_gravity_user_detail(id: user.gravity_user_id, email: 'buster@bluth.com')
+      stub_gravity_user_detail(
+        id: user.gravity_user_id, email: 'buster@bluth.com'
+      )
       expect(user.name).to eq 'Buster Bluth'
       expect(user.user_detail.email).to eq 'buster@bluth.com'
     end
 
     it 'returns nil if there is no gravity_user' do
       stub_gravity_root
-      stub_request(:get, "#{Convection.config.gravity_api_url}/users/#{user.gravity_user_id}")
+      stub_request(
+        :get,
+        "#{Convection.config.gravity_api_url}/users/#{user.gravity_user_id}"
+      )
         .to_raise(Faraday::ResourceNotFound)
       expect(user.user_detail).to be_nil
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,14 +3,18 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
-abort('The Rails environment is running in production mode!') if Rails.env.production?
+if Rails.env.production?
+  abort('The Rails environment is running in production mode!')
+end
 require 'spec_helper'
 require 'rspec/rails'
 require 'sidekiq/testing'
 require 'webmock/rspec'
 require 'rack_session_access/capybara'
 
-WebMock.disable_net_connect!(allow_localhost: true, allow: 'chromedriver.storage.googleapis.com')
+WebMock.disable_net_connect!(
+  allow_localhost: true, allow: 'chromedriver.storage.googleapis.com'
+)
 
 ActiveRecord::Migration.maintain_test_schema!
 
@@ -20,13 +24,9 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
   config.infer_spec_type_from_file_location!
 
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :truncation
-  end
+  config.before(:suite) { DatabaseCleaner.strategy = :truncation }
 
-  config.around do |example|
-    DatabaseCleaner.cleaning { example.run }
-  end
+  config.around { |example| DatabaseCleaner.cleaning { example.run } }
 
   config.before(:each) do
     Sidekiq::Worker.clear_all
@@ -36,14 +36,15 @@ end
 
 Capybara.server = :puma, { Silent: true }
 Capybara.configure do |config|
-  config.javascript_driver = ENV['NO_HEADLESS'] ? :selenium_chrome : :headless_chrome
+  config.javascript_driver =
+    ENV['NO_HEADLESS'] ? :selenium_chrome : :headless_chrome
   config.default_max_wait_time = 10
   config.ignore_hidden_elements = false
 end
 
 def prepare_chromedriver(selenium_driver_args)
   if (driver_path = ENV['CHROMEDRIVER_PATH'])
-    service = Selenium::WebDriver::Service.new(path: driver_path, port: 9005)
+    service = Selenium::WebDriver::Service.new(path: driver_path, port: 9_005)
     selenium_driver_args[:service] = service
   else
     require 'webdrivers/chromedriver'
@@ -51,18 +52,17 @@ def prepare_chromedriver(selenium_driver_args)
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  caps = Selenium::WebDriver::Remote::Capabilities.chrome(loggingPrefs: { browser: 'ALL' })
+  caps =
+    Selenium::WebDriver::Remote::Capabilities.chrome(
+      loggingPrefs: { browser: 'ALL' }
+    )
   opts = Selenium::WebDriver::Chrome::Options.new(options: { 'w3c' => false })
 
   opts.add_argument('--headless')
   opts.add_argument('--no-sandbox')
   opts.add_argument('--window-size=1440,900')
 
-  args = {
-    browser: :chrome,
-    options: opts,
-    desired_capabilities: caps
-  }
+  args = { browser: :chrome, options: opts, desired_capabilities: caps }
 
   prepare_chromedriver(args)
 

--- a/spec/requests/api/assets/create_spec.rb
+++ b/spec/requests/api/assets/create_spec.rb
@@ -2,16 +2,23 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Create Asset' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret)
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
-  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid')) }
+  let(:submission) do
+    Fabricate(
+      :submission,
+      artist_id: 'andy-warhol',
+      user: Fabricate(:user, gravity_user_id: 'userid')
+    )
+  end
 
   describe 'POST /assets' do
     it 'rejects unauthorized requests' do
-      post '/api/assets', params: {
-        gemini_token: 'gemini',
-        submission_id: submission.id
-      }, headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      post '/api/assets',
+           params: { gemini_token: 'gemini', submission_id: submission.id },
+           headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 401
     end
 
@@ -21,16 +28,20 @@ describe 'Create Asset' do
     end
 
     it 'rejects assets without a gemini_token' do
-      post '/api/assets', params: { submission_id: submission.id }, headers: headers
+      post '/api/assets',
+           params: { submission_id: submission.id }, headers: headers
       expect(response.status).to eq 400
-      expect(JSON.parse(response.body)['error']).to eq 'Parameter gemini_token is required'
+      expect(
+        JSON.parse(response.body)['error']
+      ).to eq 'Parameter gemini_token is required'
     end
 
     it 'creates an asset' do
-      post '/api/assets', params: {
-        submission_id: submission.id,
-        gemini_token: 'gemini-token'
-      }, headers: headers
+      post '/api/assets',
+           params: {
+             submission_id: submission.id, gemini_token: 'gemini-token'
+           },
+           headers: headers
       expect(response.status).to eq 201
       body = JSON.parse(response.body)
       expect(body['asset_type']).to eq('image')
@@ -45,12 +56,13 @@ describe 'Create Asset' do
       stub_gravity_artist
 
       submission.update!(state: 'submitted')
-      expect do
-        post '/api/assets', params: {
-          submission_id: submission.id,
-          gemini_token: 'gemini-token'
-        }, headers: headers
-      end.to raise_error('Still processing images.')
+      expect {
+        post '/api/assets',
+             params: {
+               submission_id: submission.id, gemini_token: 'gemini-token'
+             },
+             headers: headers
+      }.to raise_error('Still processing images.')
     end
   end
 end

--- a/spec/requests/api/assets/index_spec.rb
+++ b/spec/requests/api/assets/index_spec.rb
@@ -2,15 +2,23 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Assets Index' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret)
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
-  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid')) }
+  let(:submission) do
+    Fabricate(
+      :submission,
+      artist_id: 'andy-warhol',
+      user: Fabricate(:user, gravity_user_id: 'userid')
+    )
+  end
 
   describe 'GET /assets' do
     it 'rejects unauthorized requests' do
-      get '/api/assets', params: {
-        submission_id: submission.id
-      }, headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      get '/api/assets',
+          params: { submission_id: submission.id },
+          headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 401
     end
 
@@ -20,8 +28,18 @@ describe 'Assets Index' do
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
-      asset = submission.assets.create!(asset_type: 'image', gemini_token: 'gemini', submission_id: submission.id)
+      submission =
+        Fabricate(
+          :submission,
+          artist_id: 'andy-warhol',
+          user: Fabricate(:user, gravity_user_id: 'buster-bluth')
+        )
+      asset =
+        submission.assets.create!(
+          asset_type: 'image',
+          gemini_token: 'gemini',
+          submission_id: submission.id
+        )
       get "/api/assets/#{asset.id}", headers: headers
       expect(response.status).to eq 401
     end
@@ -29,9 +47,8 @@ describe 'Assets Index' do
     it 'returns the assets for a given submission' do
       Fabricate(:image, submission: submission, gemini_token: 'foo')
       Fabricate(:image, submission: submission, gemini_token: 'boo')
-      get '/api/assets', params: {
-        submission_id: submission.id
-      }, headers: headers
+      get '/api/assets',
+          params: { submission_id: submission.id }, headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body.length).to eq 2
@@ -42,9 +59,8 @@ describe 'Assets Index' do
       12.times { Fabricate(:image, submission: submission) }
       expect(submission.assets.count).to eq 12
 
-      get '/api/assets', params: {
-        submission_id: submission.id
-      }, headers: headers
+      get '/api/assets',
+          params: { submission_id: submission.id }, headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body.length).to eq 10

--- a/spec/requests/api/assets/show_spec.rb
+++ b/spec/requests/api/assets/show_spec.rb
@@ -2,12 +2,15 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Show Asset' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret)
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
   describe 'GET /assets/:id' do
     it 'rejects unauthorized requests' do
-      get '/api/assets/foo', headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      get '/api/assets/foo',
+          headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 401
     end
 
@@ -19,14 +22,24 @@ describe 'Show Asset' do
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
+      submission =
+        Fabricate(
+          :submission,
+          artist_id: 'andy-warhol',
+          user: Fabricate(:user, gravity_user_id: 'buster-bluth')
+        )
       asset = Fabricate(:image, submission: submission)
       get "/api/assets/#{asset.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid'))
+      submission =
+        Fabricate(
+          :submission,
+          artist_id: 'andy-warhol',
+          user: Fabricate(:user, gravity_user_id: 'userid')
+        )
       asset = Fabricate(:image, submission: submission)
       get "/api/assets/#{asset.id}", headers: headers
       expect(response.status).to eq 200

--- a/spec/requests/api/callbacks/gemini_spec.rb
+++ b/spec/requests/api/callbacks/gemini_spec.rb
@@ -2,7 +2,13 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Gemini Callback' do
-  let(:submission) { Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid')) }
+  let(:submission) do
+    Fabricate(
+      :submission,
+      artist_id: 'andy-warhol',
+      user: Fabricate(:user, gravity_user_id: 'userid')
+    )
+  end
 
   before do
     allow(Convection.config).to receive(:access_token).and_return('auth-token')
@@ -10,48 +16,57 @@ describe 'Gemini Callback' do
 
   describe 'POST /gemini' do
     it 'rejects unauthorized callbacks' do
-      post '/api/callbacks/gemini', params: {
-        access_token: 'wrong-token',
-        token: 'gemini',
-        image_url: { square: 'https://new-image.jpg' },
-        metadata: { id: submission.id, _type: 'Consignment' }
-      }
+      post '/api/callbacks/gemini',
+           params: {
+             access_token: 'wrong-token',
+             token: 'gemini',
+             image_url: { square: 'https://new-image.jpg' },
+             metadata: { id: submission.id, _type: 'Consignment' }
+           }
       expect(response.status).to eq 401
     end
 
     it 'rejects callbacks without an image_url' do
-      post '/api/callbacks/gemini', params: {
-        access_token: 'auth-token',
-        token: 'gemini',
-        'metadata' => { id: submission.id, _type: 'Consignment' }
-      }
+      post '/api/callbacks/gemini',
+           params: {
+             access_token: 'auth-token',
+             token: 'gemini',
+             'metadata' => { id: submission.id, _type: 'Consignment' }
+           }
       expect(response.status).to eq 400
     end
 
     it 'rejects callbacks if there is no matching asset' do
-      post '/api/callbacks/gemini', params: {
-        access_token: 'auth-token',
-        token: 'gemini',
-        image_url: { square: 'https://new-image.jpg' },
-        metadata: { id: submission.id, _type: 'Consignment' }
-      }
+      post '/api/callbacks/gemini',
+           params: {
+             access_token: 'auth-token',
+             token: 'gemini',
+             image_url: { square: 'https://new-image.jpg' },
+             metadata: { id: submission.id, _type: 'Consignment' }
+           }
 
       expect(response.status).to eq 404
       expect(JSON.parse(response.body)['error']).to eq 'Not Found'
     end
 
     it 'updates the asset to have the right image url' do
-      Fabricate(:unprocessed_image, submission: submission, gemini_token: 'gemini')
-      post '/api/callbacks/gemini', params: {
-        access_token: 'auth-token',
-        token: 'gemini',
-        image_url: { square: 'https://new-image.jpg' },
-        metadata: { id: submission.id, _type: 'Consignment' }
-      }
+      Fabricate(
+        :unprocessed_image,
+        submission: submission, gemini_token: 'gemini'
+      )
+      post '/api/callbacks/gemini',
+           params: {
+             access_token: 'auth-token',
+             token: 'gemini',
+             image_url: { square: 'https://new-image.jpg' },
+             metadata: { id: submission.id, _type: 'Consignment' }
+           }
 
       expect(response.status).to eq 200
       expect(JSON.parse(response.body)['submission_id']).to eq(submission.id)
-      expect(JSON.parse(response.body)['image_urls']).to eq('square' => 'https://new-image.jpg')
+      expect(JSON.parse(response.body)['image_urls']).to eq(
+        'square' => 'https://new-image.jpg'
+      )
     end
   end
 end

--- a/spec/requests/api/graphql/create_spec.rb
+++ b/spec/requests/api/graphql/create_spec.rb
@@ -2,7 +2,12 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Create Submission With Graphql' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid', roles: 'user' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode(
+      { aud: 'gravity', sub: 'userid', roles: 'user' },
+      Convection.config.jwt_secret
+    )
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
   let(:create_mutation) do
@@ -38,28 +43,37 @@ describe 'Create Submission With Graphql' do
 
   describe 'POST /graphql' do
     it 'rejects unauthorized requests' do
-      post '/api/graphql', params: {
-        query: create_mutation
-      }, headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      post '/api/graphql',
+           params: { query: create_mutation },
+           headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body['data']['createConsignmentSubmission']).to eq nil
-      expect(body['errors'][0]['message']).to eq "Can't access createConsignmentSubmission"
+      expect(
+        body['errors'][0]['message']
+      ).to eq "Can't access createConsignmentSubmission"
     end
 
     it 'rejects requests without an app token' do
-      user_token = JWT.encode({ sub: 'userid', roles: 'user' }, Convection.config.jwt_secret)
-      post '/api/graphql', params: {
-        query: create_mutation
-      }, headers: { 'Authorization' => "Bearer #{user_token}" }
+      user_token =
+        JWT.encode(
+          { sub: 'userid', roles: 'user' },
+          Convection.config.jwt_secret
+        )
+      post '/api/graphql',
+           params: { query: create_mutation },
+           headers: { 'Authorization' => "Bearer #{user_token}" }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body['data']['createConsignmentSubmission']).to eq nil
-      expect(body['errors'][0]['message']).to eq "Can't access createConsignmentSubmission"
+      expect(
+        body['errors'][0]['message']
+      ).to eq "Can't access createConsignmentSubmission"
     end
 
     it 'rejects when missing artist_id' do
-      post '/api/graphql', params: { query: create_mutation_no_artist_id }, headers: headers
+      post '/api/graphql',
+           params: { query: create_mutation_no_artist_id }, headers: headers
       expect(response.status).to eq 200
     end
 
@@ -68,29 +82,60 @@ describe 'Create Submission With Graphql' do
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
 
-      expect do
-        post '/api/graphql', params: {
-          query: create_mutation
-        }, headers: headers
+      expect {
+        post '/api/graphql',
+             params: { query: create_mutation }, headers: headers
         expect(response.status).to eq 200
         body = JSON.parse(response.body)
-        expect(body['data']['createConsignmentSubmission']['consignment_submission']['id']).not_to be_nil
-        expect(body['data']['createConsignmentSubmission']['consignment_submission']['title']).to eq 'soup'
-        expect(body['data']['createConsignmentSubmission']['consignment_submission']['category']).to eq 'JEWELRY'
-        expect(body['data']['createConsignmentSubmission']['consignment_submission']['state']).to eq 'REJECTED'
-        expect(body['data']['createConsignmentSubmission']['consignment_submission']['minimum_price_dollars']).to eq 50_000
-        expect(body['data']['createConsignmentSubmission']['consignment_submission']['currency']).to eq 'GBP'
-        expect(body['data']['createConsignmentSubmission']['clientMutationId']).to eq '2'
-      end.to change(Submission, :count).by(1)
+        expect(
+          body['data']['createConsignmentSubmission']['consignment_submission'][
+            'id'
+          ]
+        ).not_to be_nil
+        expect(
+          body['data']['createConsignmentSubmission']['consignment_submission'][
+            'title'
+          ]
+        ).to eq 'soup'
+        expect(
+          body['data']['createConsignmentSubmission']['consignment_submission'][
+            'category'
+          ]
+        ).to eq 'JEWELRY'
+        expect(
+          body['data']['createConsignmentSubmission']['consignment_submission'][
+            'state'
+          ]
+        ).to eq 'REJECTED'
+        expect(
+          body['data']['createConsignmentSubmission']['consignment_submission'][
+            'minimum_price_dollars'
+          ]
+        ).to eq 50_000
+        expect(
+          body['data']['createConsignmentSubmission']['consignment_submission'][
+            'currency'
+          ]
+        ).to eq 'GBP'
+        expect(
+          body['data']['createConsignmentSubmission']['clientMutationId']
+        ).to eq '2'
+      }.to change(Submission, :count).by(1)
     end
 
     it 'creates an asset' do
-      expect do
-        submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'userid'))
+      expect {
+        submission =
+          Fabricate(
+            :submission,
+            user: Fabricate(:user, gravity_user_id: 'userid')
+          )
 
         create_asset = <<-GRAPHQL
         mutation {
-          addAssetToConsignmentSubmission(input: { clientMutationId: "test", submission_id: #{submission.id}, gemini_token: "gemini-token-hash" }){
+          addAssetToConsignmentSubmission(input: { clientMutationId: "test", submission_id: #{
+          submission.id
+        }, gemini_token: "gemini-token-hash" }){
             clientMutationId
             asset {
               id
@@ -100,15 +145,20 @@ describe 'Create Submission With Graphql' do
         }
         GRAPHQL
 
-        post '/api/graphql', params: {
-          query: create_asset
-        }, headers: headers
+        post '/api/graphql', params: { query: create_asset }, headers: headers
         expect(response.status).to eq 200
 
         body = JSON.parse(response.body)
-        expect(body['data']['addAssetToConsignmentSubmission']['asset']['id']).not_to be_nil
-        expect(body['data']['addAssetToConsignmentSubmission']['asset']['submission_id'].to_i).to eq submission.id
-      end.to change(Asset, :count).by(1)
+        expect(
+          body['data']['addAssetToConsignmentSubmission']['asset']['id']
+        ).not_to be_nil
+        expect(
+          body['data']['addAssetToConsignmentSubmission']['asset'][
+            'submission_id'
+          ]
+            .to_i
+        ).to eq submission.id
+      }.to change(Asset, :count).by(1)
     end
   end
 end

--- a/spec/requests/api/graphql/query_spec.rb
+++ b/spec/requests/api/graphql/query_spec.rb
@@ -1,11 +1,25 @@
 require 'rails_helper'
 
 describe 'Query Submissions With Graphql' do
-  let(:admin_jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid', roles: 'admin' }, Convection.config.jwt_secret) }
-  let(:user_jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid', roles: 'user' }, Convection.config.jwt_secret) }
+  let(:admin_jwt_token) do
+    JWT.encode(
+      { aud: 'gravity', sub: 'userid', roles: 'admin' },
+      Convection.config.jwt_secret
+    )
+  end
+  let(:user_jwt_token) do
+    JWT.encode(
+      { aud: 'gravity', sub: 'userid', roles: 'user' },
+      Convection.config.jwt_secret
+    )
+  end
   let(:headers) { { 'Authorization' => "Bearer #{admin_jwt_token}" } }
-  let(:submission) { Fabricate(:submission, artist_id: 'abbas-kiarostami', title: 'rain') }
-  let!(:submission2) { Fabricate(:submission, artist_id: 'andy-warhol', title: 'no-rain') }
+  let(:submission) do
+    Fabricate(:submission, artist_id: 'abbas-kiarostami', title: 'rain')
+  end
+  let!(:submission2) do
+    Fabricate(:submission, artist_id: 'andy-warhol', title: 'no-rain')
+  end
   let(:asset) { Fabricate(:asset, submission: submission) }
 
   let(:query_submissions) do
@@ -26,9 +40,9 @@ describe 'Query Submissions With Graphql' do
 
   describe 'POST /graphql' do
     it 'rejects unauthorized requests' do
-      post '/api/graphql', params: {
-        query: query_submissions
-      }, headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      post '/api/graphql',
+           params: { query: query_submissions },
+           headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body['data']['submissions']).to eq nil
@@ -36,9 +50,9 @@ describe 'Query Submissions With Graphql' do
     end
 
     it 'throws an error if a user tries to access' do
-      post '/api/graphql', params: {
-        query: query_submissions
-      }, headers: { 'Authorization' => "Bearer #{user_jwt_token}" }
+      post '/api/graphql',
+           params: { query: query_submissions },
+           headers: { 'Authorization' => "Bearer #{user_jwt_token}" }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body['data']['submissions']).to eq nil
@@ -46,9 +60,8 @@ describe 'Query Submissions With Graphql' do
     end
 
     it 'finds two existing submissions' do
-      post '/api/graphql', params: {
-        query: query_submissions
-      }, headers: headers
+      post '/api/graphql',
+           params: { query: query_submissions }, headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body['data']['submissions']['edges'].count).to eq 2

--- a/spec/requests/api/graphql/update_spec.rb
+++ b/spec/requests/api/graphql/update_spec.rb
@@ -1,16 +1,30 @@
 require 'rails_helper'
 
 describe 'Update Submission With Graphql' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid', roles: 'user' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode(
+      { aud: 'gravity', sub: 'userid', roles: 'user' },
+      Convection.config.jwt_secret
+    )
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
   let(:submission) do
-    Fabricate(:submission, state: 'submitted', category: 'Painting', artist_id: 'abbas-kiarostami', title: 'rain', user: Fabricate(:user, gravity_user_id: 'userid'))
+    Fabricate(
+      :submission,
+      state: 'submitted',
+      category: 'Painting',
+      artist_id: 'abbas-kiarostami',
+      title: 'rain',
+      user: Fabricate(:user, gravity_user_id: 'userid')
+    )
   end
 
   let(:update_mutation) do
     <<-GRAPHQL
     mutation {
-      updateConsignmentSubmission(input: { state: DRAFT, category: JEWELRY, clientMutationId: "test", id: #{submission.id}, artist_id: "andy-warhol", title: "soup" }){
+      updateConsignmentSubmission(input: { state: DRAFT, category: JEWELRY, clientMutationId: "test", id: #{
+      submission.id
+    }, artist_id: "andy-warhol", title: "soup" }){
         clientMutationId
         consignment_submission {
           category
@@ -41,31 +55,43 @@ describe 'Update Submission With Graphql' do
 
   describe 'POST /graphql' do
     it 'rejects unauthorized requests' do
-      post '/api/graphql', params: {
-        query: update_mutation
-      }, headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      post '/api/graphql',
+           params: { query: update_mutation },
+           headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body['data']['updateConsignmentSubmission']).to eq nil
-      expect(body['errors'][0]['message']).to eq "Can't access updateConsignmentSubmission"
+      expect(
+        body['errors'][0]['message']
+      ).to eq "Can't access updateConsignmentSubmission"
     end
 
     it 'rejects requests without and app token' do
-      user_token = JWT.encode({ sub: 'userid', roles: 'user' }, Convection.config.jwt_secret)
-      post '/api/graphql', params: {
-        query: update_mutation
-      }, headers: { 'Authorization' => "Bearer #{user_token}" }
+      user_token =
+        JWT.encode(
+          { sub: 'userid', roles: 'user' },
+          Convection.config.jwt_secret
+        )
+      post '/api/graphql',
+           params: { query: update_mutation },
+           headers: { 'Authorization' => "Bearer #{user_token}" }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body['data']['updateConsignmentSubmission']).to eq nil
-      expect(body['errors'][0]['message']).to eq "Can't access updateConsignmentSubmission"
+      expect(
+        body['errors'][0]['message']
+      ).to eq "Can't access updateConsignmentSubmission"
     end
 
     it 'rejects requests to update a submission that you do not own' do
-      another_token = JWT.encode({ aud: 'app', sub: 'userid2', roles: 'user' }, Convection.config.jwt_secret)
-      post '/api/graphql', params: {
-        query: update_mutation
-      }, headers: { 'Authorization' => "Bearer #{another_token}" }
+      another_token =
+        JWT.encode(
+          { aud: 'app', sub: 'userid2', roles: 'user' },
+          Convection.config.jwt_secret
+        )
+      post '/api/graphql',
+           params: { query: update_mutation },
+           headers: { 'Authorization' => "Bearer #{another_token}" }
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body['data']['updateConsignmentSubmission']).to eq nil
@@ -73,22 +99,44 @@ describe 'Update Submission With Graphql' do
     end
 
     it 'errors for unknown submission id' do
-      post '/api/graphql', params: { query: update_mutation_random_id }, headers: headers
+      post '/api/graphql',
+           params: { query: update_mutation_random_id }, headers: headers
       expect(response.status).to eq 200
-      expect(JSON.parse(response.body)['errors'].first['message']).to eq 'Submission from ID Not Found'
+      expect(
+        JSON.parse(response.body)['errors'].first['message']
+      ).to eq 'Submission from ID Not Found'
     end
 
     it 'updates the submission' do
-      post '/api/graphql', params: {
-        query: update_mutation
-      }, headers: headers
+      post '/api/graphql', params: { query: update_mutation }, headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body['data']['updateConsignmentSubmission']['consignment_submission']['id'].to_i).to eq submission.id
-      expect(body['data']['updateConsignmentSubmission']['consignment_submission']['title']).to eq 'soup'
-      expect(body['data']['updateConsignmentSubmission']['consignment_submission']['artist_id']).to eq 'andy-warhol'
-      expect(body['data']['updateConsignmentSubmission']['consignment_submission']['category']).to eq 'JEWELRY'
-      expect(body['data']['updateConsignmentSubmission']['consignment_submission']['state']).to eq 'DRAFT'
+      expect(
+        body['data']['updateConsignmentSubmission']['consignment_submission'][
+          'id'
+        ]
+          .to_i
+      ).to eq submission.id
+      expect(
+        body['data']['updateConsignmentSubmission']['consignment_submission'][
+          'title'
+        ]
+      ).to eq 'soup'
+      expect(
+        body['data']['updateConsignmentSubmission']['consignment_submission'][
+          'artist_id'
+        ]
+      ).to eq 'andy-warhol'
+      expect(
+        body['data']['updateConsignmentSubmission']['consignment_submission'][
+          'category'
+        ]
+      ).to eq 'JEWELRY'
+      expect(
+        body['data']['updateConsignmentSubmission']['consignment_submission'][
+          'state'
+        ]
+      ).to eq 'DRAFT'
     end
   end
 end

--- a/spec/requests/api/submissions/create_spec.rb
+++ b/spec/requests/api/submissions/create_spec.rb
@@ -2,21 +2,28 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Create Submission' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid', roles: 'user' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode(
+      { aud: 'gravity', sub: 'userid', roles: 'user' },
+      Convection.config.jwt_secret
+    )
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
   describe 'POST /submissions' do
     it 'rejects unauthorized submissions' do
-      post '/api/submissions', params: {
-        artist_id: 'artistid'
-      }, headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      post '/api/submissions',
+           params: { artist_id: 'artistid' },
+           headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 401
     end
 
     it 'rejects submissions without an artist_id' do
       post '/api/submissions', params: {}, headers: headers
       expect(response.status).to eq 400
-      expect(JSON.parse(response.body)['error']).to eq 'Parameter artist_id is required'
+      expect(
+        JSON.parse(response.body)['error']
+      ).to eq 'Parameter artist_id is required'
     end
 
     it 'creates a submission' do
@@ -24,12 +31,11 @@ describe 'Create Submission' do
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
 
-      expect do
-        post '/api/submissions', params: {
-          title: 'my sartwork',
-          artist_id: 'artistid'
-        }, headers: headers
-      end.to change { Submission.count }.by(1)
+      expect {
+        post '/api/submissions',
+             params: { title: 'my sartwork', artist_id: 'artistid' },
+             headers: headers
+      }.to change { Submission.count }.by(1)
     end
 
     it 'creates a submission with edition fields' do
@@ -37,18 +43,20 @@ describe 'Create Submission' do
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
 
-      expect do
-        post '/api/submissions', params: {
-          title: 'my sartwork',
-          artist_id: 'artistid',
-          edition: true,
-          edition_size: 100,
-          edition_number: '23a',
-          category: 'Painting'
-        }, headers: headers
+      expect {
+        post '/api/submissions',
+             params: {
+               title: 'my sartwork',
+               artist_id: 'artistid',
+               edition: true,
+               edition_size: 100,
+               edition_number: '23a',
+               category: 'Painting'
+             },
+             headers: headers
 
         expect(JSON.parse(response.body)['edition_size']).to eq 100
-      end.to change { Submission.count }.by(1)
+      }.to change { Submission.count }.by(1)
     end
 
     it 'creates a submission with a minimum price' do
@@ -56,23 +64,25 @@ describe 'Create Submission' do
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
 
-      expect do
-        post '/api/submissions', params: {
-          title: 'my sartwork',
-          artist_id: 'artistid',
-          edition: true,
-          edition_size: 100,
-          edition_number: '23a',
-          category: 'Painting',
-          minimum_price_dollars: 50_000,
-          currency: 'GBP'
-        }, headers: headers.merge('User-Agent' => 'Eigen')
+      expect {
+        post '/api/submissions',
+             params: {
+               title: 'my sartwork',
+               artist_id: 'artistid',
+               edition: true,
+               edition_size: 100,
+               edition_number: '23a',
+               category: 'Painting',
+               minimum_price_dollars: 50_000,
+               currency: 'GBP'
+             },
+             headers: headers.merge('User-Agent' => 'Eigen')
 
         expect(JSON.parse(response.body)['edition_size']).to eq 100
         expect(JSON.parse(response.body)['minimum_price_dollars']).to eq 50_000
         expect(JSON.parse(response.body)['currency']).to eq 'GBP'
         expect(JSON.parse(response.body)['user_agent']).to eq 'Eigen'
-      end.to change { Submission.count }.by(1)
+      }.to change { Submission.count }.by(1)
     end
   end
 end

--- a/spec/requests/api/submissions/index_spec.rb
+++ b/spec/requests/api/submissions/index_spec.rb
@@ -3,17 +3,24 @@ require 'support/gravity_helper'
 
 describe 'Show Submission' do
   let!(:user) { Fabricate(:user, gravity_user_id: 'userid') }
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret)
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
   describe 'GET /submissions' do
     it 'rejects unauthorized requests' do
-      get '/api/submissions', headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      get '/api/submissions',
+          headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 401
     end
 
     it "doesn't return other people's submissions" do
-      Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'), state: 'approved')
+      Fabricate(
+        :submission,
+        user: Fabricate(:user, gravity_user_id: 'buster-bluth'),
+        state: 'approved'
+      )
       get '/api/submissions', headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
@@ -22,7 +29,11 @@ describe 'Show Submission' do
 
     it 'returns your own submissions' do
       submission = Fabricate(:submission, user: user, state: 'approved')
-      Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'), state: 'approved')
+      Fabricate(
+        :submission,
+        user: Fabricate(:user, gravity_user_id: 'buster-bluth'),
+        state: 'approved'
+      )
 
       get '/api/submissions', headers: headers
       expect(response.status).to eq 200

--- a/spec/requests/api/submissions/show_spec.rb
+++ b/spec/requests/api/submissions/show_spec.rb
@@ -2,30 +2,44 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Show Submission' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret)
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
   describe 'GET /submissions' do
     it 'rejects unauthorized requests' do
-      get '/api/submissions/foo', headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      get '/api/submissions/foo',
+          headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 401
     end
 
     it 'returns an error if it cannot find the submission' do
-      Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
+      Fabricate(
+        :submission,
+        user: Fabricate(:user, gravity_user_id: 'buster-bluth')
+      )
       get '/api/submissions/foo', headers: headers
       expect(response.status).to eq 404
       expect(JSON.parse(response.body)['error']).to eq 'Not Found'
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
+      submission =
+        Fabricate(
+          :submission,
+          user: Fabricate(:user, gravity_user_id: 'buster-bluth')
+        )
       get "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'userid'))
+      submission =
+        Fabricate(
+          :submission,
+          user: Fabricate(:user, gravity_user_id: 'userid')
+        )
       get "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)

--- a/spec/requests/api/submissions/update_spec.rb
+++ b/spec/requests/api/submissions/update_spec.rb
@@ -2,33 +2,47 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Update Submission' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret)
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
   describe 'PUT /submissions' do
     it 'rejects unauthorized requests' do
-      put '/api/submissions/foo', headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+      put '/api/submissions/foo',
+          headers: { 'Authorization' => 'Bearer foo.bar.baz' }
       expect(response.status).to eq 401
     end
 
     it 'returns an error if it cannot find the submission' do
-      Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
+      Fabricate(
+        :submission,
+        user: Fabricate(:user, gravity_user_id: 'buster-bluth')
+      )
       put '/api/submissions/foo', headers: headers
       expect(response.status).to eq 404
       expect(JSON.parse(response.body)['error']).to eq 'Not Found'
     end
 
     it "rejects requests for someone else's submission" do
-      submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'buster-bluth'))
+      submission =
+        Fabricate(
+          :submission,
+          user: Fabricate(:user, gravity_user_id: 'buster-bluth')
+        )
       put "/api/submissions/#{submission.id}", headers: headers
       expect(response.status).to eq 401
     end
 
     it 'accepts requests for your own submission' do
-      submission = Fabricate(:submission, artist_id: 'andy-warhol', user: Fabricate(:user, gravity_user_id: 'userid'))
-      put "/api/submissions/#{submission.id}", params: {
-        artist_id: 'kara-walker'
-      }, headers: headers
+      submission =
+        Fabricate(
+          :submission,
+          artist_id: 'andy-warhol',
+          user: Fabricate(:user, gravity_user_id: 'userid')
+        )
+      put "/api/submissions/#{submission.id}",
+          params: { artist_id: 'kara-walker' }, headers: headers
       expect(response.status).to eq 201
       body = JSON.parse(response.body)
       expect(body['id']).to eq submission.id
@@ -38,12 +52,19 @@ describe 'Update Submission' do
     describe 'submitting' do
       describe 'with a valid submission' do
         before do
-          @submission = Fabricate(:submission, user: Fabricate(:user, gravity_user_id: 'userid'), artist_id: 'artistid')
+          @submission =
+            Fabricate(
+              :submission,
+              user: Fabricate(:user, gravity_user_id: 'userid'),
+              artist_id: 'artistid'
+            )
         end
 
         it 'sends a receipt when your state is updated to submitted' do
           expect(NotificationService).to receive(:post_submission_event).once
-          allow(Convection.config).to receive(:admin_email_address).and_return('lucille@bluth.com')
+          allow(Convection.config).to receive(:admin_email_address).and_return(
+            'lucille@bluth.com'
+          )
           stub_gravity_root
           stub_gravity_user
           stub_gravity_user_detail(email: 'michael@bluth.com')
@@ -51,9 +72,8 @@ describe 'Update Submission' do
 
           Fabricate(:image, submission: @submission)
 
-          put "/api/submissions/#{@submission.id}", params: {
-            state: 'submitted'
-          }, headers: headers
+          put "/api/submissions/#{@submission.id}",
+              params: { state: 'submitted' }, headers: headers
 
           expect(response.status).to eq 201
           expect(@submission.reload.receipt_sent_at).to_not be_nil
@@ -74,25 +94,28 @@ describe 'Update Submission' do
           @submission.update!(receipt_sent_at: Time.now.utc)
           @submission.update!(admin_receipt_sent_at: Time.now.utc)
 
-          put "/api/submissions/#{@submission.id}", params: {
-            state: 'submitted'
-          }, headers: headers
+          put "/api/submissions/#{@submission.id}",
+              params: { state: 'submitted' }, headers: headers
           expect(ActionMailer::Base.deliveries.length).to eq 0
         end
       end
 
       it 'returns an error if you try to submit without all of the relevant fields' do
-        submission = Fabricate(:submission,
-                               artist_id: 'andy-warhol',
-                               user: Fabricate(:user, gravity_user_id: 'userid'),
-                               title: nil)
-        put "/api/submissions/#{submission.id}", params: {
-          artist_id: 'kara-walker',
-          state: 'submitted'
-        }, headers: headers
+        submission =
+          Fabricate(
+            :submission,
+            artist_id: 'andy-warhol',
+            user: Fabricate(:user, gravity_user_id: 'userid'),
+            title: nil
+          )
+        put "/api/submissions/#{submission.id}",
+            params: { artist_id: 'kara-walker', state: 'submitted' },
+            headers: headers
 
         expect(response.status).to eq 400
-        expect(JSON.parse(response.body)['error']).to eq('Missing fields for submission.')
+        expect(JSON.parse(response.body)['error']).to eq(
+          'Missing fields for submission.'
+        )
         expect(submission.reload.artist_id).to eq 'andy-warhol'
       end
     end

--- a/spec/requests/api/users/anonymize_user_email_spec.rb
+++ b/spec/requests/api/users/anonymize_user_email_spec.rb
@@ -5,14 +5,18 @@ describe 'Anonymize user email' do
   let!(:user1) { Fabricate(:user, email: 'test1@test.com') }
   let!(:user2) { Fabricate(:user, email: 'test2@test.com') }
   let!(:user3) { Fabricate(:user, email: 'test2@test.com') }
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', roles: 'trusted' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode(
+      { aud: 'gravity', roles: 'trusted' },
+      Convection.config.jwt_secret
+    )
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
   it 'finds users with this email address and nils it out' do
     expect(User.where(email: 'test1@test.com').count).to eq(1)
     put '/api/anonymize_user_email',
-        params: { email: 'test1@test.com' },
-        headers: headers
+        params: { email: 'test1@test.com' }, headers: headers
 
     expect(User.where(email: 'test1@test.com').count).to eq(0)
     expect(user1.reload.email).to be_nil
@@ -22,8 +26,7 @@ describe 'Anonymize user email' do
   it 'works when multiple users are returned' do
     expect(User.where(email: 'test2@test.com').count).to eq(2)
     put '/api/anonymize_user_email',
-        params: { email: 'test2@test.com' },
-        headers: headers
+        params: { email: 'test2@test.com' }, headers: headers
 
     expect(User.where(email: 'test2@test.com').count).to eq(0)
     expect(user2.reload.email).to be_nil
@@ -34,8 +37,7 @@ describe 'Anonymize user email' do
   it 'does not error out when no users are found' do
     expect(User.where(email: 'test3@test.com').count).to eq(0)
     put '/api/anonymize_user_email',
-        params: { email: 'test3@test.com' },
-        headers: headers
+        params: { email: 'test3@test.com' }, headers: headers
 
     expect(response.status).to eq(201)
   end
@@ -48,15 +50,25 @@ describe 'Anonymize user email' do
   end
 
   it 'requires a valid token' do
-    bad_token = JWT.encode({ whatever: 'random', roles: 'trusted' }, Convection.config.jwt_secret)
+    bad_token =
+      JWT.encode(
+        { whatever: 'random', roles: 'trusted' },
+        Convection.config.jwt_secret
+      )
 
-    put '/api/anonymize_user_email', headers: { 'Authorization' => "Bearer #{bad_token}" }
+    put '/api/anonymize_user_email',
+        headers: { 'Authorization' => "Bearer #{bad_token}" }
     expect(response.status).to eq 401
   end
 
   it 'requires a trusted role' do
-    bad_token = JWT.encode({ aud: 'gravity', roles: 'foo,bar,baz' }, Convection.config.jwt_secret)
-    put '/api/anonymize_user_email', headers: { 'Authorization' => "Bearer #{bad_token}" }
+    bad_token =
+      JWT.encode(
+        { aud: 'gravity', roles: 'foo,bar,baz' },
+        Convection.config.jwt_secret
+      )
+    put '/api/anonymize_user_email',
+        headers: { 'Authorization' => "Bearer #{bad_token}" }
     expect(response.status).to eq 401
   end
 end

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -2,7 +2,9 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe 'Submission Flow' do
-  let(:jwt_token) { JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret) }
+  let(:jwt_token) do
+    JWT.encode({ aud: 'gravity', sub: 'userid' }, Convection.config.jwt_secret)
+  end
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
   before do
@@ -17,40 +19,42 @@ describe 'Submission Flow' do
     stub_gravity_artist
 
     # first create the submission, without a location_city
-    post '/api/submissions', params: {
-      artist_id: 'artistid',
-      user: Fabricate(:user, gravity_user_id: 'userid'),
-      title: 'My Artwork',
-      medium: 'painting',
-      year: '1992',
-      height: '12',
-      width: '14',
-      dimensions_metric: 'in',
-      location_state: 'Tokyo',
-      location_country: 'Japan',
-      category: 'Painting'
-    }, headers: headers
+    post '/api/submissions',
+         params: {
+           artist_id: 'artistid',
+           user: Fabricate(:user, gravity_user_id: 'userid'),
+           title: 'My Artwork',
+           medium: 'painting',
+           year: '1992',
+           height: '12',
+           width: '14',
+           dimensions_metric: 'in',
+           location_state: 'Tokyo',
+           location_country: 'Japan',
+           category: 'Painting'
+         },
+         headers: headers
 
     expect(response.status).to eq 201
     submission = Submission.find(JSON.parse(response.body)['id'])
     expect(submission.assets.count).to eq 0
 
-    put "/api/submissions/#{submission.id}", params: {
-      state: 'submitted'
-    }, headers: headers
+    put "/api/submissions/#{submission.id}",
+        params: { state: 'submitted' }, headers: headers
     expect(response.status).to eq 201
     expect(submission.reload.state).to eq 'submitted'
 
     emails = ActionMailer::Base.deliveries
     expect(emails.length).to eq 4
-    expect(emails.first.to).to eq(['consign@artsy.net'])
+    expect(emails.first.to).to eq(%w[consign@artsy.net])
     expect(emails[1].subject).to include("You're Almost Done")
-    expect(emails[1].to).to eq(['michael@bluth.com'])
-    # sidekiq flushes everything at once
+    expect(emails[1].to).to eq(%w[michael@bluth.com]) # sidekiq flushes everything at once
     expect(emails[2].subject).to include("You're Almost Done")
-    expect(emails[2].to).to eq(['michael@bluth.com'])
-    expect(emails.last.subject).to include('Last chance to complete your consignment')
-    expect(emails.last.to).to eq(['michael@bluth.com'])
+    expect(emails[2].to).to eq(%w[michael@bluth.com])
+    expect(emails.last.subject).to include(
+      'Last chance to complete your consignment'
+    )
+    expect(emails.last.to).to eq(%w[michael@bluth.com])
   end
 
   describe 'Creating a submission without a photo initially' do
@@ -61,40 +65,42 @@ describe 'Submission Flow' do
       stub_gravity_artist
 
       # first create the submission
-      post '/api/submissions', params: {
-        artist_id: 'artistid',
-        user: Fabricate(:user, gravity_user_id: 'userid'),
-        title: 'My Artwork',
-        medium: 'painting',
-        year: '1992',
-        height: '12',
-        width: '14',
-        dimensions_metric: 'in',
-        location_city: 'New York',
-        category: 'Painting'
-      }, headers: headers
+      post '/api/submissions',
+           params: {
+             artist_id: 'artistid',
+             user: Fabricate(:user, gravity_user_id: 'userid'),
+             title: 'My Artwork',
+             medium: 'painting',
+             year: '1992',
+             height: '12',
+             width: '14',
+             dimensions_metric: 'in',
+             location_city: 'New York',
+             category: 'Painting'
+           },
+           headers: headers
 
       expect(response.status).to eq 201
       @submission = Submission.find(JSON.parse(response.body)['id'])
 
       expect(@submission.assets.count).to eq 0
 
-      put "/api/submissions/#{@submission.id}", params: {
-        state: 'submitted'
-      }, headers: headers
+      put "/api/submissions/#{@submission.id}",
+          params: { state: 'submitted' }, headers: headers
       expect(response.status).to eq 201
       expect(@submission.reload.state).to eq 'submitted'
 
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 4
-      expect(emails.first.to).to eq(['consign@artsy.net'])
+      expect(emails.first.to).to eq(%w[consign@artsy.net])
       expect(emails[1].subject).to include("You're Almost Done")
-      expect(emails[1].to).to eq(['michael@bluth.com'])
-      # sidekiq flushes everything at once
+      expect(emails[1].to).to eq(%w[michael@bluth.com]) # sidekiq flushes everything at once
       expect(emails[2].subject).to include("You're Almost Done")
-      expect(emails[2].to).to eq(['michael@bluth.com'])
-      expect(emails.last.subject).to include('Last chance to complete your consignment')
-      expect(emails.last.to).to eq(['michael@bluth.com'])
+      expect(emails[2].to).to eq(%w[michael@bluth.com])
+      expect(emails.last.subject).to include(
+        'Last chance to complete your consignment'
+      )
+      expect(emails.last.to).to eq(%w[michael@bluth.com])
     end
   end
 
@@ -106,59 +112,70 @@ describe 'Submission Flow' do
       stub_gravity_artist
 
       # first create the submission
-      post '/api/submissions', params: {
-        artist_id: 'artistid',
-        user: Fabricate(:user, gravity_user_id: 'userid'),
-        title: 'My Artwork',
-        medium: 'painting',
-        year: '1992',
-        height: '12',
-        width: '14',
-        dimensions_metric: 'in',
-        location_city: 'New York',
-        category: 'Painting'
-      }, headers: headers
+      post '/api/submissions',
+           params: {
+             artist_id: 'artistid',
+             user: Fabricate(:user, gravity_user_id: 'userid'),
+             title: 'My Artwork',
+             medium: 'painting',
+             year: '1992',
+             height: '12',
+             width: '14',
+             dimensions_metric: 'in',
+             location_city: 'New York',
+             category: 'Painting'
+           },
+           headers: headers
 
       expect(response.status).to eq 201
       submission = Submission.find(JSON.parse(response.body)['id'])
 
       # upload assets to that submission
-      post '/api/assets', params: {
-        submission_id: submission.id,
-        gemini_token: 'gemini-token'
-      }, headers: headers
+      post '/api/assets',
+           params: {
+             submission_id: submission.id, gemini_token: 'gemini-token'
+           },
+           headers: headers
 
-      post '/api/assets', params: {
-        submission_id: submission.id,
-        gemini_token: 'gemini-token2'
-      }, headers: headers
+      post '/api/assets',
+           params: {
+             submission_id: submission.id, gemini_token: 'gemini-token2'
+           },
+           headers: headers
 
       expect(submission.assets.count).to eq 2
       expect(submission.assets.map(&:image_urls).uniq).to eq([{}])
 
       # accept gemini callbacks for image urls
-      post '/api/callbacks/gemini', params: {
-        access_token: 'auth-token',
-        token: 'gemini-token',
-        image_url: { square: 'https://new-image.jpg' },
-        metadata: { id: submission.id }
-      }
+      post '/api/callbacks/gemini',
+           params: {
+             access_token: 'auth-token',
+             token: 'gemini-token',
+             image_url: { square: 'https://new-image.jpg' },
+             metadata: { id: submission.id }
+           }
 
-      post '/api/callbacks/gemini', params: {
-        access_token: 'auth-token',
-        token: 'gemini-token2',
-        image_url: { square: 'https://another-image.jpg' },
-        metadata: { id: submission.id }
-      }
-      expect(submission.assets.detect { |a| a.gemini_token == 'gemini-token' }.reload.image_urls)
-        .to eq('square' => 'https://new-image.jpg')
-      expect(submission.assets.detect { |a| a.gemini_token == 'gemini-token2' }.reload.image_urls)
-        .to eq('square' => 'https://another-image.jpg')
+      post '/api/callbacks/gemini',
+           params: {
+             access_token: 'auth-token',
+             token: 'gemini-token2',
+             image_url: { square: 'https://another-image.jpg' },
+             metadata: { id: submission.id }
+           }
+      expect(
+        submission.assets.detect { |a| a.gemini_token == 'gemini-token' }.reload
+          .image_urls
+      ).to eq('square' => 'https://new-image.jpg')
+      expect(
+        submission.assets.detect { |a|
+          a.gemini_token == 'gemini-token2'
+        }.reload
+          .image_urls
+      ).to eq('square' => 'https://another-image.jpg')
 
       # update the submission status and notify
-      put "/api/submissions/#{submission.id}", params: {
-        state: 'submitted'
-      }, headers: headers
+      put "/api/submissions/#{submission.id}",
+          params: { state: 'submitted' }, headers: headers
       expect(response.status).to eq 201
       expect(submission.reload.state).to eq 'submitted'
       emails = ActionMailer::Base.deliveries
@@ -166,10 +183,12 @@ describe 'Submission Flow' do
       expect(emails.first.html_part.body).to include('https://new-image.jpg')
 
       # GET to retrieve the image url for the submission
-      get '/api/assets', params: { submission_id: submission.id }, headers: headers
+      get '/api/assets',
+          params: { submission_id: submission.id }, headers: headers
       expect(response.status).to eq 200
-      expect(JSON.parse(response.body).map { |a| a['gemini_token'] })
-        .to include('gemini-token', 'gemini-token2')
+      expect(
+        JSON.parse(response.body).map { |a| a['gemini_token'] }
+      ).to include('gemini-token', 'gemini-token2')
     end
   end
 end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -2,24 +2,25 @@ require 'rails_helper'
 
 describe NotificationService do
   let(:submission) do
-    Fabricate(:submission,
-              artist_id: 'artistid',
-              user: Fabricate(:user, gravity_user_id: 'userid'),
-              title: 'My Artwork',
-              medium: 'painting',
-              year: '1992',
-              height: '12',
-              width: '14',
-              dimensions_metric: 'in',
-              location_city: 'New York',
-              category: 'Painting')
+    Fabricate(
+      :submission,
+      artist_id: 'artistid',
+      user: Fabricate(:user, gravity_user_id: 'userid'),
+      title: 'My Artwork',
+      medium: 'painting',
+      year: '1992',
+      height: '12',
+      width: '14',
+      dimensions_metric: 'in',
+      location_city: 'New York',
+      category: 'Painting'
+    )
   end
 
   describe '#post_submission_event' do
     it 'calls Artsy::EventService.post_event with an instance of BaseEvent' do
       expect(Artsy::EventService).to receive(:post_event).once.with(
-        topic: 'consignments',
-        event: instance_of(SubmissionEvent)
+        topic: 'consignments', event: instance_of(SubmissionEvent)
       )
       NotificationService.post_submission_event(submission.id, 'submitted')
     end

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -12,7 +12,12 @@ describe OfferService do
   context 'create_offer' do
     describe 'with a submission in submitted state' do
       it 'updates the submission state to approved' do
-        OfferService.create_offer(submitted_submission.id, partner.id, {}, user.id)
+        OfferService.create_offer(
+          submitted_submission.id,
+          partner.id,
+          {},
+          user.id
+        )
         expect(submitted_submission.reload.state).to eq 'approved'
         expect(submitted_submission.reload.approved_by).to eq user.id.to_s
         expect(submitted_submission.reload.approved_at).to_not be_nil
@@ -20,26 +25,52 @@ describe OfferService do
     end
     describe 'with a submission in a draft state' do
       it 'raises an error' do
-        expect { OfferService.create_offer(draft_submission.id, partner.id, {}, user.id) }.to raise_error do |error|
+        expect {
+          OfferService.create_offer(
+            draft_submission.id,
+            partner.id,
+            {},
+            user.id
+          )
+        }.to raise_error do |error|
           expect(error).to be_a OfferService::OfferError
-          expect(error.message).to eq 'Invalid submission state for offer creation'
+          expect(
+            error.message
+          ).to eq 'Invalid submission state for offer creation'
         end
       end
     end
     describe 'with a submission in a rejected state' do
       it 'raises an error' do
-        expect { OfferService.create_offer(rejected_submission.id, partner.id, {}, user.id) }.to raise_error do |error|
+        expect {
+          OfferService.create_offer(
+            rejected_submission.id,
+            partner.id,
+            {},
+            user.id
+          )
+        }.to raise_error do |error|
           expect(error).to be_a OfferService::OfferError
-          expect(error.message).to eq 'Invalid submission state for offer creation'
+          expect(
+            error.message
+          ).to eq 'Invalid submission state for offer creation'
         end
       end
     end
     describe 'with no initial partner submission' do
       it 'creates a draft offer' do
-        expect(PartnerSubmission.where(submission: submission, partner: partner).count).to eq 0
+        expect(
+          PartnerSubmission.where(submission: submission, partner: partner)
+            .count
+        ).to eq 0
         OfferService.create_offer(submission.id, partner.id)
-        expect(PartnerSubmission.where(submission: submission, partner: partner).count).to eq 1
-        ps = PartnerSubmission.where(submission: submission, partner: partner).first
+        expect(
+          PartnerSubmission.where(submission: submission, partner: partner)
+            .count
+        ).to eq 1
+        ps =
+          PartnerSubmission.where(submission: submission, partner: partner)
+            .first
         expect(ps.offers.count).to eq 1
         expect(ps.offers.first.state).to eq 'draft'
         expect(ps.notified_at).to_not be_nil
@@ -48,7 +79,11 @@ describe OfferService do
 
     describe 'with an initial partner submission' do
       before do
-        @partner_submission = Fabricate(:partner_submission, partner: partner, submission: submission)
+        @partner_submission =
+          Fabricate(
+            :partner_submission,
+            partner: partner, submission: submission
+          )
       end
 
       it 'creates multiple draft offers' do
@@ -58,60 +93,74 @@ describe OfferService do
 
         OfferService.create_offer(submission.id, partner.id)
         expect(@partner_submission.offers.count).to eq 2
-        expect(@partner_submission.offers.pluck(:state).uniq).to eq ['draft']
+        expect(@partner_submission.offers.pluck(:state).uniq).to eq %w[draft]
       end
 
       it 'fails if the partner does not exist' do
-        expect do
+        expect {
           OfferService.create_offer(submission.id, 'blah')
-        end.to raise_error(OfferService::OfferError)
+        }.to raise_error(OfferService::OfferError)
       end
 
       it 'fails if the submission does not exist' do
-        expect do
-          OfferService.create_offer('blah', partner.id)
-        end.to raise_error(OfferService::OfferError)
+        expect { OfferService.create_offer('blah', partner.id) }.to raise_error(
+          OfferService::OfferError
+        )
       end
 
       it 'fails if no partner_id param is passed' do
-        expect do
-          OfferService.create_offer(submission.id, nil)
-        end.to raise_error(OfferService::OfferError)
+        expect { OfferService.create_offer(submission.id, nil) }.to raise_error(
+          OfferService::OfferError
+        )
       end
 
       it 'fails if no submission_id param is passed' do
-        expect do
-          OfferService.create_offer(nil, partner.id)
-        end.to raise_error(OfferService::OfferError)
+        expect { OfferService.create_offer(nil, partner.id) }.to raise_error(
+          OfferService::OfferError
+        )
       end
     end
   end
 
   context 'update_offer' do
     it 'updates the offer with the new params' do
-      offer = Fabricate(:offer,
-                        low_estimate_cents: 10_000,
-                        high_estimate_cents: 20_000,
-                        commission_percent: 10,
-                        offer_type: 'auction consignment')
-      OfferService.update_offer(offer, 'userid', high_estimate_cents: 30_000, notes: 'New offer notes!')
+      offer =
+        Fabricate(
+          :offer,
+          low_estimate_cents: 10_000,
+          high_estimate_cents: 20_000,
+          commission_percent: 10,
+          offer_type: 'auction consignment'
+        )
+      OfferService.update_offer(
+        offer,
+        'userid',
+        high_estimate_cents: 30_000, notes: 'New offer notes!'
+      )
       expect(offer.reload.high_estimate_cents).to eq 30_000
       expect(offer.reload.notes).to eq 'New offer notes!'
     end
 
     it 'raises an error if validation fails' do
-      offer = Fabricate(:offer,
-                        low_estimate_cents: 10_000,
-                        high_estimate_cents: 20_000,
-                        commission_percent: 10,
-                        offer_type: 'auction consignment')
-      expect do
+      offer =
+        Fabricate(
+          :offer,
+          low_estimate_cents: 10_000,
+          high_estimate_cents: 20_000,
+          commission_percent: 10,
+          offer_type: 'auction consignment'
+        )
+      expect {
         OfferService.update_offer(offer, 'userid', offer_type: 'non-valid-type')
-      end.to raise_error(OfferService::OfferError)
+      }.to raise_error(OfferService::OfferError)
     end
 
     it 'sends no emails if the state has not been changed' do
-      OfferService.update_offer(Fabricate(:offer), 'userid', price_cents: 20_000)
+      OfferService.update_offer(
+        Fabricate(:offer),
+        'userid',
+        price_cents: 20_000
+      )
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 0
     end
@@ -120,16 +169,30 @@ describe OfferService do
   context 'with an offer' do
     let(:partner) { Fabricate(:partner, name: 'Happy Gallery') }
     let(:submission) { Fabricate(:submission) }
-    let(:partner_submission) { Fabricate(:partner_submission, partner: partner, submission: submission) }
-    let(:offer) { Fabricate(:offer, offer_type: 'purchase', price_cents: 10_000, state: 'draft', partner_submission: partner_submission) }
+    let(:partner_submission) do
+      Fabricate(:partner_submission, partner: partner, submission: submission)
+    end
+    let(:offer) do
+      Fabricate(
+        :offer,
+        offer_type: 'purchase',
+        price_cents: 10_000,
+        state: 'draft',
+        partner_submission: partner_submission
+      )
+    end
 
     before do
       stub_gravity_root
       stub_gravity_user(id: offer.submission.user.gravity_user_id)
-      stub_gravity_user_detail(email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id)
+      stub_gravity_user_detail(
+        email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id
+      )
       stub_gravity_artist(id: submission.artist_id)
       stub_gravity_partner(id: partner.gravity_partner_id)
-      stub_gravity_partner_communications(partner_id: partner.gravity_partner_id)
+      stub_gravity_partner_communications(
+        partner_id: partner.gravity_partner_id
+      )
       stub_gravity_partner_contacts(
         partner_id: partner.gravity_partner_id,
         override_body: [
@@ -137,8 +200,12 @@ describe OfferService do
           { email: 'contact2@partner.com' }
         ]
       )
-      allow(Convection.config).to receive(:offer_response_form_url).and_return('https://google.com/response_form?entry.1=SUBMISSION_NUMBER&entry.2=PARTNER_NAME')
-      allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/offer_form?entry.1=SUBMISSION_NUMBER')
+      allow(Convection.config).to receive(:offer_response_form_url).and_return(
+        'https://google.com/response_form?entry.1=SUBMISSION_NUMBER&entry.2=PARTNER_NAME'
+      )
+      allow(Convection.config).to receive(:auction_offer_form_url).and_return(
+        'https://google.com/offer_form?entry.1=SUBMISSION_NUMBER'
+      )
     end
 
     describe 'sending an offer' do
@@ -146,18 +213,26 @@ describe OfferService do
         OfferService.update_offer(offer, 'userid', state: 'sent')
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
-        expect(emails.first.to).to eq(['michael@bluth.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
-        expect(emails.first.subject).to eq('An offer for your consignment submission')
+        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+        expect(emails.first.to).to eq(%w[michael@bluth.com])
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
+        expect(emails.first.subject).to eq(
+          'An offer for your consignment submission'
+        )
 
         email_body = emails.first.html_part.body
         expect(email_body).to include(
           'Great news, an offer has been made for your work.'
         )
-        expect(email_body).to include('The work will be purchased directly from you by the partner')
+        expect(email_body).to include(
+          'The work will be purchased directly from you by the partner'
+        )
         expect(email_body).to include('Happy Gallery')
-        expect(email_body).to include("https://google.com/response_form?entry.1=#{submission.id}&amp;entry.2=Happy%20Gallery")
+        expect(email_body).to include(
+          "https://google.com/response_form?entry.1=#{
+            submission.id
+          }&amp;entry.2=Happy%20Gallery"
+        )
         expect(offer.reload.state).to eq 'sent'
         expect(offer.sent_by).to eq 'userid'
         expect(offer.sent_at).to_not be_nil
@@ -176,15 +251,21 @@ describe OfferService do
         OfferService.update_offer(offer, 'userid', state: 'review')
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 2
-        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
-        expect(emails.map(&:to).flatten).to eq(['contact1@partner.com', 'contact2@partner.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
-        expect(emails.first.subject).to eq('The consignor has expressed interest in your offer')
+        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+        expect(emails.map(&:to).flatten).to eq(
+          %w[contact1@partner.com contact2@partner.com]
+        )
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
+        expect(emails.first.subject).to eq(
+          'The consignor has expressed interest in your offer'
+        )
         expect(emails.first.html_part.body).to include(
           'Your offer has been reviewed, and the consignor has expressed interest your offer'
         )
         expect(emails.first.html_part.body).to include('Happy Gallery')
-        expect(emails.first.html_part.body).to_not include('The work will be purchased directly from you by the partner')
+        expect(emails.first.html_part.body).to_not include(
+                                                     'The work will be purchased directly from you by the partner'
+                                                   )
         expect(offer.reload.state).to eq 'review'
         expect(offer.review_started_at).to_not be_nil
       end
@@ -193,23 +274,38 @@ describe OfferService do
     describe 'consigning an offer' do
       context 'with an offer on a non-approved submission' do
         it 'raises an error' do
-          expect { OfferService.update_offer(offer, 'userid', state: 'consigned') }.to raise_error do |error|
+          expect {
+            OfferService.update_offer(offer, 'userid', state: 'consigned')
+          }.to raise_error do |error|
             expect(error).to be_a OfferService::OfferError
-            expect(error.message).to eq 'Cannot complete consignment on non-approved submission'
+            expect(
+              error.message
+            ).to eq 'Cannot complete consignment on non-approved submission'
           end
         end
       end
       context 'with an offer on an approved submission' do
-        let(:approved_submission) { Fabricate(:submission, state: Submission::APPROVED) }
-        let(:ps) { Fabricate(:partner_submission, submission: approved_submission) }
+        let(:approved_submission) do
+          Fabricate(:submission, state: Submission::APPROVED)
+        end
+        let(:ps) do
+          Fabricate(:partner_submission, submission: approved_submission)
+        end
         let(:consignable_offer) { Fabricate(:offer, partner_submission: ps) }
         it 'sets fields on submission and partner submission' do
-          OfferService.update_offer(consignable_offer, 'userid', state: 'consigned')
+          OfferService.update_offer(
+            consignable_offer,
+            'userid',
+            state: 'consigned'
+          )
           expect(ActionMailer::Base.deliveries.count).to eq 0
           expect(ps.state).to eq 'open'
           expect(ps.accepted_offer).to eq consignable_offer
-          expect(ps.partner_commission_percent).to eq consignable_offer.commission_percent
-          expect(ps.submission.consigned_partner_submission).to eq consignable_offer.partner_submission
+          expect(ps.partner_commission_percent).to eq consignable_offer
+               .commission_percent
+          expect(
+            ps.submission.consigned_partner_submission
+          ).to eq consignable_offer.partner_submission
           expect(consignable_offer.consigned_at).to_not be_nil
         end
       end
@@ -220,18 +316,26 @@ describe OfferService do
         OfferService.update_offer(offer, 'userid', state: 'rejected')
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 2
-        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
-        expect(emails.map(&:to).flatten).to eq(['contact1@partner.com', 'contact2@partner.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
-        expect(emails.first.subject).to eq('A response to your consignment offer')
+        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+        expect(emails.map(&:to).flatten).to eq(
+          %w[contact1@partner.com contact2@partner.com]
+        )
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
+        expect(emails.first.subject).to eq(
+          'A response to your consignment offer'
+        )
 
         email_body = emails.first.html_part.body
         expect(email_body).to include(
           'Your offer has been reviewed, and the consignor has rejected your offer.'
         )
         expect(email_body).to include('Happy Gallery')
-        expect(email_body).to_not include('The work will be purchased directly from you by the partner')
-        expect(email_body).to include("https://google.com/offer_form?entry.1=#{submission.id}")
+        expect(email_body).to_not include(
+                                    'The work will be purchased directly from you by the partner'
+                                  )
+        expect(email_body).to include(
+          "https://google.com/offer_form?entry.1=#{submission.id}"
+        )
         expect(offer.reload.state).to eq 'rejected'
         expect(offer.rejected_by).to eq 'userid'
         expect(offer.rejected_at).to_not be_nil

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -13,8 +13,12 @@ describe PartnerSubmissionService do
     stub_gravity_artist
     stub_gravity_partner_communications
     stub_gravity_partner_contacts
-    allow(Time).to receive(:now).and_return(Time.new(2017, 9, 27).in_time_zone('UTC')) # stub time for email subject lines
-    allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction')
+    allow(Time).to receive(:now).and_return(
+      Time.new(2_017, 9, 27).in_time_zone('UTC')
+    ) # stub time for email subject lines
+    allow(Convection.config).to receive(:auction_offer_form_url).and_return(
+      'https://google.com/auction'
+    )
   end
 
   describe '#generate_for_new_partner' do
@@ -24,15 +28,26 @@ describe PartnerSubmissionService do
       partner = Fabricate(:partner)
       PartnerSubmissionService.generate_for_new_partner(partner)
       expect(partner.partner_submissions.count).to eq 1
-      expect(PartnerSubmission.where(submission: submission, partner: partner).count).to eq 1
+      expect(
+        PartnerSubmission.where(submission: submission, partner: partner).count
+      ).to eq 1
     end
 
     it 'generates new partner submissions' do
       partner = Fabricate(:partner)
-      submission = Fabricate(:submission, state: 'submitted', user: @user, artist_id: 'artistid')
-      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'approved')
+      submission =
+        Fabricate(
+          :submission,
+          state: 'submitted', user: @user, artist_id: 'artistid'
+        )
+      expect(NotificationService).to receive(:post_submission_event).once.with(
+        submission.id,
+        'approved'
+      )
       SubmissionService.update_submission(submission, state: 'approved')
-      expect(PartnerSubmission.where(submission: submission, partner: partner).count).to eq 1
+      expect(
+        PartnerSubmission.where(submission: submission, partner: partner).count
+      ).to eq 1
       Fabricate(:submission, state: 'approved')
       PartnerSubmissionService.generate_for_new_partner(partner)
       expect(partner.partner_submissions.count).to eq 2
@@ -49,14 +64,14 @@ describe PartnerSubmissionService do
 
     it 'does nothing if there are no partners' do
       submission = Fabricate(:submission, state: 'approved')
-      expect { PartnerSubmissionService.generate_for_all_partners(submission.id) }.to_not change(PartnerSubmission, :count)
+      expect {
+        PartnerSubmissionService.generate_for_all_partners(submission.id)
+      }.to_not change(PartnerSubmission, :count)
     end
   end
 
   describe '#daily_digest' do
-    before do
-      stub_gravity_partner(name: 'Juliens Auctions')
-    end
+    before { stub_gravity_partner(name: 'Juliens Auctions') }
 
     it 'does not send any emails if there are no partner submissions' do
       Fabricate(:partner, gravity_partner_id: 'partnerid')
@@ -79,15 +94,19 @@ describe PartnerSubmissionService do
       before do
         @partner = Fabricate(:partner, gravity_partner_id: 'partnerid')
         Fabricate(:submission, state: 'submitted')
-        @approved1 = Fabricate(:submission,
-                               state: 'submitted',
-                               artist_id: 'artistid',
-                               user: @user,
-                               title: 'Approved artwork with minimum price',
-                               year: '1992',
-                               minimum_price_cents: 50_000_00,
-                               currency: 'USD')
-        expect(NotificationService).to receive(:post_submission_event).once.with(@approved1.id, 'approved')
+        @approved1 =
+          Fabricate(
+            :submission,
+            state: 'submitted',
+            artist_id: 'artistid',
+            user: @user,
+            title: 'Approved artwork with minimum price',
+            year: '1992',
+            minimum_price_cents: 50_000_00,
+            currency: 'USD'
+          )
+        expect(NotificationService).to receive(:post_submission_event).once
+          .with(@approved1.id, 'approved')
         SubmissionService.update_submission(@approved1, state: 'approved')
         PartnerSubmissionService.daily_digest
         @email = ActionMailer::Base.deliveries.last
@@ -102,13 +121,17 @@ describe PartnerSubmissionService do
       before do
         @partner = Fabricate(:partner, gravity_partner_id: 'partnerid')
         Fabricate(:submission, state: 'submitted')
-        @approved1 = Fabricate(:submission,
-                               state: 'submitted',
-                               artist_id: 'artistid',
-                               user: @user,
-                               title: 'Approved artwork with minimum price',
-                               year: '1992')
-        expect(NotificationService).to receive(:post_submission_event).once.with(@approved1.id, 'approved')
+        @approved1 =
+          Fabricate(
+            :submission,
+            state: 'submitted',
+            artist_id: 'artistid',
+            user: @user,
+            title: 'Approved artwork with minimum price',
+            year: '1992'
+          )
+        expect(NotificationService).to receive(:post_submission_event).once
+          .with(@approved1.id, 'approved')
         SubmissionService.update_submission(@approved1, state: 'approved')
       end
 
@@ -123,28 +146,40 @@ describe PartnerSubmissionService do
       before do
         @partner = Fabricate(:partner, gravity_partner_id: 'partnerid')
         Fabricate(:submission, state: 'submitted')
-        @approved1 = Fabricate(:submission,
-                               state: 'submitted',
-                               artist_id: 'artistid',
-                               user: @user,
-                               title: 'First approved artwork',
-                               year: '1992')
-        @approved2 = Fabricate(:submission,
-                               state: 'submitted',
-                               artist_id: 'artistid',
-                               user: @user2,
-                               title: 'Second approved artwork',
-                               year: '1993')
-        @approved3 = Fabricate(:submission,
-                               state: 'submitted',
-                               artist_id: 'artistid',
-                               user: @user,
-                               title: 'Third approved artwork',
-                               year: '1997')
+        @approved1 =
+          Fabricate(
+            :submission,
+            state: 'submitted',
+            artist_id: 'artistid',
+            user: @user,
+            title: 'First approved artwork',
+            year: '1992'
+          )
+        @approved2 =
+          Fabricate(
+            :submission,
+            state: 'submitted',
+            artist_id: 'artistid',
+            user: @user2,
+            title: 'Second approved artwork',
+            year: '1993'
+          )
+        @approved3 =
+          Fabricate(
+            :submission,
+            state: 'submitted',
+            artist_id: 'artistid',
+            user: @user,
+            title: 'Third approved artwork',
+            year: '1997'
+          )
         Fabricate(:submission, state: 'rejected')
-        expect(NotificationService).to receive(:post_submission_event).once.with(@approved1.id, 'approved')
-        expect(NotificationService).to receive(:post_submission_event).once.with(@approved2.id, 'approved')
-        expect(NotificationService).to receive(:post_submission_event).once.with(@approved3.id, 'approved')
+        expect(NotificationService).to receive(:post_submission_event).once
+          .with(@approved1.id, 'approved')
+        expect(NotificationService).to receive(:post_submission_event).once
+          .with(@approved2.id, 'approved')
+        expect(NotificationService).to receive(:post_submission_event).once
+          .with(@approved3.id, 'approved')
         SubmissionService.update_submission(@approved1, state: 'approved')
         SubmissionService.update_submission(@approved2, state: 'approved')
         SubmissionService.update_submission(@approved3, state: 'approved')
@@ -153,9 +188,7 @@ describe PartnerSubmissionService do
       end
 
       context 'with no partner contacts' do
-        before do
-          stub_gravity_partner_contacts(override_body: [])
-        end
+        before { stub_gravity_partner_contacts(override_body: []) }
 
         it 'skips sending to partner if there are no partner contacts' do
           PartnerSubmissionService.daily_digest
@@ -172,14 +205,24 @@ describe PartnerSubmissionService do
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 1
           email = emails.first
-          expect(email.subject).to include('New Artsy Consignments September 27: 3 works')
-          expect(email.bcc).to eq(['consignments-archive@artsymail.com'])
-          expect(email.from).to eq(['consign@artsy.net'])
-          expect(email.html_part.body).to include('<i>First approved artwork</i><span>, 1992</span>')
-          expect(email.html_part.body).to include('<i>Second approved artwork</i><span>, 1993</span>')
-          expect(email.html_part.body).to include('<i>Third approved artwork</i><span>, 1997</span>')
+          expect(email.subject).to include(
+            'New Artsy Consignments September 27: 3 works'
+          )
+          expect(email.bcc).to eq(%w[consignments-archive@artsymail.com])
+          expect(email.from).to eq(%w[consign@artsy.net])
+          expect(email.html_part.body).to include(
+            '<i>First approved artwork</i><span>, 1992</span>'
+          )
+          expect(email.html_part.body).to include(
+            '<i>Second approved artwork</i><span>, 1993</span>'
+          )
+          expect(email.html_part.body).to include(
+            '<i>Third approved artwork</i><span>, 1997</span>'
+          )
           expect(email.html_part.body).to include('https://google.com/auction')
-          expect(@partner.partner_submissions.map(&:notified_at).compact.length).to eq 3
+          expect(
+            @partner.partner_submissions.map(&:notified_at).compact.length
+          ).to eq 3
         end
 
         it 'sends an email digest to multiple partner contacts with only approved submissions' do
@@ -193,7 +236,10 @@ describe PartnerSubmissionService do
 
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 2
-          expect(emails.map(&:to)).to include(['contact1@partner.com'], ['contact2@partner.com'])
+          expect(emails.map(&:to)).to include(
+            %w[contact1@partner.com],
+            %w[contact2@partner.com]
+          )
         end
 
         it 'sends a digest with the first processed image' do
@@ -202,7 +248,9 @@ describe PartnerSubmissionService do
 
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 1
-          expect(emails.first.html_part.body).to include(first_image.image_urls['square'])
+          expect(emails.first.html_part.body).to include(
+            first_image.image_urls['square']
+          )
         end
 
         it 'sends a digest with the primary image' do
@@ -213,23 +261,49 @@ describe PartnerSubmissionService do
 
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 1
-          expect(emails.first.html_part.body).to include(second_image.image_urls['square'])
+          expect(emails.first.html_part.body).to include(
+            second_image.image_urls['square']
+          )
         end
 
         it 'includes links to additional images' do
           first_image = Fabricate(:image, submission: @approved1)
-          Fabricate(:image, submission: @approved1, image_urls: { 'square' => 'http://square1.jpg', 'large' => 'http://foo1.jpg' })
-          Fabricate(:image, submission: @approved1, image_urls: { 'square' => 'http://square2.jpg', 'large' => 'http://foo2.jpg' })
-          Fabricate(:image, submission: @approved1, image_urls: { 'square' => 'http://square3.jpg', 'large' => 'http://foo3.jpg' })
+          Fabricate(
+            :image,
+            submission: @approved1,
+            image_urls: {
+              'square' => 'http://square1.jpg', 'large' => 'http://foo1.jpg'
+            }
+          )
+          Fabricate(
+            :image,
+            submission: @approved1,
+            image_urls: {
+              'square' => 'http://square2.jpg', 'large' => 'http://foo2.jpg'
+            }
+          )
+          Fabricate(
+            :image,
+            submission: @approved1,
+            image_urls: {
+              'square' => 'http://square3.jpg', 'large' => 'http://foo3.jpg'
+            }
+          )
           PartnerSubmissionService.daily_digest
 
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 1
           email_body = emails.first.html_part.body
           expect(email_body).to include(first_image.image_urls['square'])
-          expect(email_body).to include('<a href="http://foo1.jpg" style="color: #000001;">Image 2</a>')
-          expect(email_body).to include('<a href="http://foo2.jpg" style="color: #000001;">Image 3</a>')
-          expect(email_body).to include('<a href="http://foo3.jpg" style="color: #000001;">Image 4</a>')
+          expect(email_body).to include(
+            '<a href="http://foo1.jpg" style="color: #000001;">Image 2</a>'
+          )
+          expect(email_body).to include(
+            '<a href="http://foo2.jpg" style="color: #000001;">Image 3</a>'
+          )
+          expect(email_body).to include(
+            '<a href="http://foo3.jpg" style="color: #000001;">Image 4</a>'
+          )
         end
 
         it 'displays the consignor information lines' do
@@ -257,15 +331,24 @@ describe PartnerSubmissionService do
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 2
           email = emails.first
-          expect(email.html_part.body).to include('<i>First approved artwork</i><span>, 1992</span>')
-          expect(email.html_part.body).to include('<i>Second approved artwork</i><span>, 1993</span>')
-          expect(email.html_part.body).to include('<i>Third approved artwork</i><span>, 1997</span>')
+          expect(email.html_part.body).to include(
+            '<i>First approved artwork</i><span>, 1992</span>'
+          )
+          expect(email.html_part.body).to include(
+            '<i>Second approved artwork</i><span>, 1993</span>'
+          )
+          expect(email.html_part.body).to include(
+            '<i>Third approved artwork</i><span>, 1997</span>'
+          )
         end
 
         it 'sends to only one partner if only one has partner contacts' do
-          contactless_partner = Fabricate(:partner, gravity_partner_id: 'phillips')
+          contactless_partner =
+            Fabricate(:partner, gravity_partner_id: 'phillips')
           stub_gravity_partner(name: 'Phillips Auctions', id: 'phillips')
-          stub_gravity_partner_contacts(partner_id: 'phillips', override_body: [])
+          stub_gravity_partner_contacts(
+            partner_id: 'phillips', override_body: []
+          )
           PartnerSubmissionService.daily_digest
 
           expect(@approved1.partner_submissions.count).to eq 1
@@ -277,16 +360,28 @@ describe PartnerSubmissionService do
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 1
           email = emails.first
-          expect(email.subject).to include('New Artsy Consignments September 27: 3 works')
-          expect(email.html_part.body).to include('<i>First approved artwork</i><span>, 1992</span>')
-          expect(email.html_part.body).to include('<i>Second approved artwork</i><span>, 1993</span>')
-          expect(email.html_part.body).to include('<i>Third approved artwork</i><span>, 1997</span>')
+          expect(email.subject).to include(
+            'New Artsy Consignments September 27: 3 works'
+          )
+          expect(email.html_part.body).to include(
+            '<i>First approved artwork</i><span>, 1992</span>'
+          )
+          expect(email.html_part.body).to include(
+            '<i>Second approved artwork</i><span>, 1993</span>'
+          )
+          expect(email.html_part.body).to include(
+            '<i>Third approved artwork</i><span>, 1997</span>'
+          )
         end
 
         it 'sends to a gallery partner' do
           gallery_partner = Fabricate(:partner, gravity_partner_id: 'gagosian')
-          stub_gravity_partner(name: 'Gagosian Gallery', id: 'gagosian', type: 'Gallery')
-          stub_gravity_partner_contacts(partner_id: 'gagosian', override_body: [])
+          stub_gravity_partner(
+            name: 'Gagosian Gallery', id: 'gagosian', type: 'Gallery'
+          )
+          stub_gravity_partner_contacts(
+            partner_id: 'gagosian', override_body: []
+          )
           PartnerSubmissionService.generate_for_new_partner(gallery_partner)
           PartnerSubmissionService.deliver_digest(gallery_partner.id)
 
@@ -295,14 +390,22 @@ describe PartnerSubmissionService do
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 1
           email = emails.first
-          expect(email.subject).to include('New Artsy Consignments September 27: 3 works')
+          expect(email.subject).to include(
+            'New Artsy Consignments September 27: 3 works'
+          )
           expect(email.html_part.body).to_not include('Submit Proposal')
           expect(email.html_part.body).to include(
             'Please respond directly to this email with your proposal, or if you have any questions'
           )
-          expect(email.html_part.body).to include('<i>First approved artwork</i><span>, 1992</span>')
-          expect(email.html_part.body).to include('<i>Second approved artwork</i><span>, 1993</span>')
-          expect(email.html_part.body).to include('<i>Third approved artwork</i><span>, 1997</span>')
+          expect(email.html_part.body).to include(
+            '<i>First approved artwork</i><span>, 1992</span>'
+          )
+          expect(email.html_part.body).to include(
+            '<i>Second approved artwork</i><span>, 1993</span>'
+          )
+          expect(email.html_part.body).to include(
+            '<i>Third approved artwork</i><span>, 1997</span>'
+          )
         end
       end
     end

--- a/spec/services/partner_update_service_spec.rb
+++ b/spec/services/partner_update_service_spec.rb
@@ -3,9 +3,18 @@ require 'support/gravity_helper'
 
 describe PartnerUpdateService do
   describe '#update_partners_from_gravity' do
-    let!(:partner1) { Fabricate(:partner, gravity_partner_id: 'phillips', name: 'Phillips') }
-    let!(:partner2) { Fabricate(:partner, gravity_partner_id: 'gagosian', name: 'Gagosian Gallery') }
-    let!(:partner3) { Fabricate(:partner, gravity_partner_id: 'pace', name: 'Pace Gallery') }
+    let!(:partner1) do
+      Fabricate(:partner, gravity_partner_id: 'phillips', name: 'Phillips')
+    end
+    let!(:partner2) do
+      Fabricate(
+        :partner,
+        gravity_partner_id: 'gagosian', name: 'Gagosian Gallery'
+      )
+    end
+    let!(:partner3) do
+      Fabricate(:partner, gravity_partner_id: 'pace', name: 'Pace Gallery')
+    end
 
     before do
       stub_gravity_root

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -2,9 +2,14 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe SubmissionService do
-  let!(:user) { Fabricate(:user, gravity_user_id: 'userid', email: 'michael@bluth.com') }
+  let!(:user) do
+    Fabricate(:user, gravity_user_id: 'userid', email: 'michael@bluth.com')
+  end
   let(:submission) do
-    Fabricate(:submission, artist_id: 'artistid', user: user, title: 'My Artwork')
+    Fabricate(
+      :submission,
+      artist_id: 'artistid', user: user, title: 'My Artwork'
+    )
   end
 
   before do
@@ -15,7 +20,9 @@ describe SubmissionService do
   end
 
   context 'create_submission' do
-    let(:params) { { artist_id: 'artistid', state: 'draft', title: 'My Artwork' } }
+    let(:params) do
+      { artist_id: 'artistid', state: 'draft', title: 'My Artwork' }
+    end
 
     it 'creates a submission and sets the user_id and email' do
       stub_gravity_root
@@ -31,12 +38,15 @@ describe SubmissionService do
 
     it 'raises an exception if the user_detail cannot be found' do
       stub_gravity_root
-      stub_request(:get, "#{Convection.config.gravity_api_url}/user_details/foo")
+      stub_request(
+        :get,
+        "#{Convection.config.gravity_api_url}/user_details/foo"
+      )
         .to_raise(Faraday::ResourceNotFound)
 
-      expect do
+      expect {
         SubmissionService.create_submission(params, 'foo')
-      end.to raise_error(Faraday::ResourceNotFound)
+      }.to raise_error(Faraday::ResourceNotFound)
     end
 
     it 'raises an error if the email is blank' do
@@ -44,9 +54,9 @@ describe SubmissionService do
       stub_gravity_user(id: 'foo')
       stub_gravity_user_detail(id: 'foo', email: '')
 
-      expect do
+      expect {
         SubmissionService.create_submission(params, 'foo')
-      end.to raise_error('User lacks email.')
+      }.to raise_error('User lacks email.')
     end
   end
 
@@ -58,14 +68,20 @@ describe SubmissionService do
     end
 
     it 'sends a reminder if the submission has no images' do
-      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'submitted')
+      expect(NotificationService).to receive(:post_submission_event).once.with(
+        submission.id,
+        'submitted'
+      )
       SubmissionService.update_submission(submission, state: 'submitted')
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 4
     end
 
     it 'sends no reminders if the submission has images' do
-      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'submitted')
+      expect(NotificationService).to receive(:post_submission_event).once.with(
+        submission.id,
+        'submitted'
+      )
       Fabricate(:image, submission: submission)
       SubmissionService.update_submission(submission, state: 'submitted')
       emails = ActionMailer::Base.deliveries
@@ -73,7 +89,11 @@ describe SubmissionService do
     end
 
     it 'sends no emails if the state is not being changed' do
-      SubmissionService.update_submission(submission, { title: 'Updated Artwork Title', state: 'draft' }, 'userid')
+      SubmissionService.update_submission(
+        submission,
+        { title: 'Updated Artwork Title', state: 'draft' },
+        'userid'
+      )
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 0
       expect(submission.title).to eq 'Updated Artwork Title'
@@ -84,7 +104,11 @@ describe SubmissionService do
     end
 
     it 'sends no emails if the state is not being changed to approved or rejected' do
-      SubmissionService.update_submission(submission, { state: 'draft' }, 'userid')
+      SubmissionService.update_submission(
+        submission,
+        { state: 'draft' },
+        'userid'
+      )
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 0
       expect(submission.rejected_by).to be_nil
@@ -94,12 +118,19 @@ describe SubmissionService do
     end
 
     it 'sends an approval notification if the submission state is changed to approved' do
-      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'approved')
-      SubmissionService.update_submission(submission, { state: 'approved' }, 'userid')
+      expect(NotificationService).to receive(:post_submission_event).once.with(
+        submission.id,
+        'approved'
+      )
+      SubmissionService.update_submission(
+        submission,
+        { state: 'approved' },
+        'userid'
+      )
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
-      expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
-      expect(emails.first.to).to eq(['michael@bluth.com'])
+      expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+      expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.html_part.body).to include(
         'Your work is currently being reviewed for consignment by our network of trusted partners'
       )
@@ -111,11 +142,18 @@ describe SubmissionService do
     end
 
     it 'generates partner submissions on an approval' do
-      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'approved')
+      expect(NotificationService).to receive(:post_submission_event).once.with(
+        submission.id,
+        'approved'
+      )
       partner1 = Fabricate(:partner, gravity_partner_id: 'partner1')
       partner2 = Fabricate(:partner, gravity_partner_id: 'partner2')
 
-      SubmissionService.update_submission(submission, { state: 'approved' }, 'userid')
+      SubmissionService.update_submission(
+        submission,
+        { state: 'approved' },
+        'userid'
+      )
       expect(ActionMailer::Base.deliveries.length).to eq 1
       expect(partner1.partner_submissions.length).to eq 1
       expect(partner2.partner_submissions.length).to eq 1
@@ -124,12 +162,16 @@ describe SubmissionService do
     end
 
     it 'sends a rejection notification if the submission state is changed to rejected' do
-      SubmissionService.update_submission(submission, { state: 'rejected' }, 'userid')
+      SubmissionService.update_submission(
+        submission,
+        { state: 'rejected' },
+        'userid'
+      )
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
-      expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
-      expect(emails.first.to).to eq(['michael@bluth.com'])
-      expect(emails.first.from).to eq(['consign@artsy.net'])
+      expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+      expect(emails.first.to).to eq(%w[michael@bluth.com])
+      expect(emails.first.from).to eq(%w[consign@artsy.net])
       expect(emails.first.html_part.body).to include(
         'they do not have a market for this work at the moment'
       )
@@ -144,16 +186,23 @@ describe SubmissionService do
   context 'undo' do
     describe 'with approved submission' do
       before do
-        expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'approved')
+        expect(NotificationService).to receive(:post_submission_event).once
+          .with(submission.id, 'approved')
         Fabricate(:partner, gravity_partner_id: 'partner1')
         Fabricate(:image, submission: submission)
-        SubmissionService.update_submission(submission, { state: 'approved' }, 'userid')
+        SubmissionService.update_submission(
+          submission,
+          { state: 'approved' },
+          'userid'
+        )
       end
 
       it 'deletes partner submissions and sends no emails on an undo approval' do
         expect(submission.partner_submissions.length).to eq 1
 
-        expect { SubmissionService.undo_approval(submission) }.to_not change { ActionMailer::Base.deliveries.length }
+        expect { SubmissionService.undo_approval(submission) }.to_not change {
+                        ActionMailer::Base.deliveries.length
+                      }
 
         submission.reload
         expect(submission.partner_submissions.length).to eq 0
@@ -165,9 +214,14 @@ describe SubmissionService do
       end
 
       it 'fails to undo an approval if there are any offers' do
-        Fabricate(:offer, partner_submission: submission.partner_submissions.first)
-        expect { SubmissionService.undo_approval(submission) }.to raise_error(SubmissionService::SubmissionError,
-                                                                              'Undoing approval of a submission with offers is not allowed!')
+        Fabricate(
+          :offer,
+          partner_submission: submission.partner_submissions.first
+        )
+        expect { SubmissionService.undo_approval(submission) }.to raise_error(
+          SubmissionService::SubmissionError,
+          'Undoing approval of a submission with offers is not allowed!'
+        )
       end
     end
 
@@ -175,7 +229,11 @@ describe SubmissionService do
       before do
         Fabricate(:partner, gravity_partner_id: 'partner1')
         Fabricate(:image, submission: submission)
-        SubmissionService.update_submission(submission, { state: 'rejected' }, 'userid')
+        SubmissionService.update_submission(
+          submission,
+          { state: 'rejected' },
+          'userid'
+        )
       end
 
       it 'sends no emails for an undo rejection' do
@@ -197,24 +255,25 @@ describe SubmissionService do
 
   context 'notify_user' do
     describe 'with assets' do
-      before do
-        Fabricate(:image, submission: submission)
-      end
+      before { Fabricate(:image, submission: submission) }
 
       it 'sends a receipt' do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.first.html_part.body).to include('Thank you for submitting your work to our consignments network')
-        expect(emails.first.to).to eq(['michael@bluth.com'])
+        expect(emails.first.html_part.body).to include(
+          'Thank you for submitting your work to our consignments network'
+        )
+        expect(emails.first.to).to eq(%w[michael@bluth.com])
         expect(submission.reload.receipt_sent_at).to_not be nil
       end
 
       it 'does not send a receipt if one has already been sent' do
         submission.update!(receipt_sent_at: Time.now.utc)
-        expect do
-          SubmissionService.notify_user(submission.id)
-        end.to_not change(ActionMailer::Base.deliveries, :count)
+        expect { SubmissionService.notify_user(submission.id) }.to_not change(
+                        ActionMailer::Base.deliveries,
+                        :count
+                      )
       end
     end
 
@@ -223,12 +282,18 @@ describe SubmissionService do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
-        expect(emails.first.html_part.body).to include('Complete your consignment submission')
-        expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
-        expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e01')
-        expect(emails.first.to).to eq(['michael@bluth.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
+        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+        expect(emails.first.html_part.body).to include(
+          'Complete your consignment submission'
+        )
+        expect(emails.first.html_part.body).to include(
+          'utm_campaign=consignment-complete'
+        )
+        expect(emails.first.html_part.body).to include(
+          'utm_source=drip-consignment-reminder-e01'
+        )
+        expect(emails.first.to).to eq(%w[michael@bluth.com])
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
         expect(submission.reload.receipt_sent_at).to be nil
         expect(submission.reload.reminders_sent_count).to eq 1
       end
@@ -238,12 +303,18 @@ describe SubmissionService do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
-        expect(emails.first.html_part.body).to include("We're missing photos of your work")
-        expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
-        expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e02')
-        expect(emails.first.to).to eq(['michael@bluth.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
+        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+        expect(emails.first.html_part.body).to include(
+          "We're missing photos of your work"
+        )
+        expect(emails.first.html_part.body).to include(
+          'utm_campaign=consignment-complete'
+        )
+        expect(emails.first.html_part.body).to include(
+          'utm_source=drip-consignment-reminder-e02'
+        )
+        expect(emails.first.to).to eq(%w[michael@bluth.com])
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
         expect(submission.reload.receipt_sent_at).to be nil
         expect(submission.reload.reminders_sent_count).to eq 2
       end
@@ -253,18 +324,26 @@ describe SubmissionService do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.first.bcc).to eq(['consignments-archive@artsymail.com'])
-        expect(emails.first.html_part.body).to include("We're unable to complete your submission")
-        expect(emails.first.html_part.body).to include('utm_campaign=consignment-complete')
-        expect(emails.first.html_part.body).to include('utm_source=drip-consignment-reminder-e03')
-        expect(emails.first.to).to eq(['michael@bluth.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
+        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+        expect(emails.first.html_part.body).to include(
+          "We're unable to complete your submission"
+        )
+        expect(emails.first.html_part.body).to include(
+          'utm_campaign=consignment-complete'
+        )
+        expect(emails.first.html_part.body).to include(
+          'utm_source=drip-consignment-reminder-e03'
+        )
+        expect(emails.first.to).to eq(%w[michael@bluth.com])
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
         expect(submission.reload.receipt_sent_at).to be nil
         expect(submission.reload.reminders_sent_count).to eq 3
       end
 
       it 'does not send a reminder if a receipt has already been sent' do
-        submission.update!(reminders_sent_count: 1, receipt_sent_at: Time.now.utc)
+        submission.update!(
+          reminders_sent_count: 1, receipt_sent_at: Time.now.utc
+        )
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 0
@@ -281,41 +360,49 @@ describe SubmissionService do
 
   context 'notify_admin' do
     it 'sends an email if one has not been sent' do
-      expect(NotificationService).to receive(:post_submission_event).once.with(submission.id, 'submitted')
+      expect(NotificationService).to receive(:post_submission_event).once.with(
+        submission.id,
+        'submitted'
+      )
       SubmissionService.notify_admin(submission.id)
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
       expect(emails.first.html_part.body).to include('My Artwork')
-      expect(emails.first.to).to eq(['consign@artsy.net'])
+      expect(emails.first.to).to eq(%w[consign@artsy.net])
       expect(submission.reload.admin_receipt_sent_at).to_not be nil
     end
 
     it 'does not send an email if one has already been sent' do
       submission.update!(admin_receipt_sent_at: Time.now.utc)
-      expect do
-        SubmissionService.notify_admin(submission.id)
-      end.to_not change(ActionMailer::Base.deliveries, :count)
+      expect { SubmissionService.notify_admin(submission.id) }.to_not change(
+                      ActionMailer::Base.deliveries,
+                      :count
+                    )
     end
   end
 
   context 'deliver_submission_receipt' do
     it 'raises an exception if the submission cannot be found' do
-      expect do
+      expect {
         SubmissionService.deliver_submission_receipt('foo')
-      end.to raise_error("Couldn't find Submission with 'id'=foo")
+      }.to raise_error("Couldn't find Submission with 'id'=foo")
     end
 
     it 'raises an exception if all of the images have not been processed' do
       submission.update!(receipt_sent_at: Time.now.utc)
       Fabricate(:unprocessed_image, submission: submission)
-      expect do
+      expect {
         SubmissionService.deliver_submission_receipt(submission.id)
-      end.to raise_error('Still processing images.')
+      }.to raise_error('Still processing images.')
     end
 
     it 'sends an email if the enough time has passed since the initial attempt' do
-      allow(Convection.config).to receive(:processing_grace_seconds).and_return(600)
-      allow(Convection.config).to receive(:admin_email_address).and_return('lucille@bluth.com')
+      allow(Convection.config).to receive(:processing_grace_seconds).and_return(
+        600
+      )
+      allow(Convection.config).to receive(:admin_email_address).and_return(
+        'lucille@bluth.com'
+      )
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
@@ -326,29 +413,38 @@ describe SubmissionService do
       SubmissionService.deliver_submission_receipt(submission.id)
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
-      expect(emails.first.bcc).to include('consignments-archive@artsymail.com', 'lucille@bluth.com')
-      expect(emails.first.html_part.body).to include('Thank you for submitting your work to our consignments network')
+      expect(emails.first.bcc).to include(
+        'consignments-archive@artsymail.com',
+        'lucille@bluth.com'
+      )
+      expect(emails.first.html_part.body).to include(
+        'Thank you for submitting your work to our consignments network'
+      )
     end
   end
 
   context 'deliver_submission_notification' do
     it 'raises an exception if the submission cannot be found' do
-      expect do
+      expect {
         SubmissionService.deliver_submission_notification('foo')
-      end.to raise_error("Couldn't find Submission with 'id'=foo")
+      }.to raise_error("Couldn't find Submission with 'id'=foo")
     end
 
     it 'raises an exception if all of the images have not been processed' do
       submission.update!(receipt_sent_at: Time.now.utc)
       Fabricate(:unprocessed_image, submission: submission)
-      expect do
+      expect {
         SubmissionService.deliver_submission_notification(submission.id)
-      end.to raise_error('Still processing images.')
+      }.to raise_error('Still processing images.')
     end
 
     it 'sends an email if the enough time has passed since the initial attempt' do
-      allow(Convection.config).to receive(:processing_grace_seconds).and_return(600)
-      allow(Convection.config).to receive(:admin_email_address).and_return('lucille@bluth.com')
+      allow(Convection.config).to receive(:processing_grace_seconds).and_return(
+        600
+      )
+      allow(Convection.config).to receive(:admin_email_address).and_return(
+        'lucille@bluth.com'
+      )
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,6 @@ RSpec.configure do |config|
   end
 
   config.expect_with :rspec do |c|
-    c.syntax = [:expect]
+    c.syntax = %i[expect]
   end
 end

--- a/spec/support/gravity_helper.rb
+++ b/spec/support/gravity_helper.rb
@@ -1,24 +1,26 @@
 GRAVITY_ROOT = {
   _links: {
     artist: {
-      href: "#{Convection.config.gravity_api_url}/artists/{id}",
-      templated: true
+      href: "#{Convection.config.gravity_api_url}/artists/{id}", templated: true
     },
     partner: {
       href: "#{Convection.config.gravity_api_url}/partners/{id}",
       templated: true
     },
     partner_communications: {
-      href: "#{Convection.config.gravity_api_url}/partner_communications{?name}",
+      href:
+        "#{Convection.config.gravity_api_url}/partner_communications{?name}",
       templated: true
     },
     partner_contacts: {
-      href: "#{Convection.config.gravity_api_url}/partner_contacts{?partner_id,communication_id}",
+      href:
+        "#{
+          Convection.config.gravity_api_url
+        }/partner_contacts{?partner_id,communication_id}",
       templated: true
     },
     user: {
-      href: "#{Convection.config.gravity_api_url}/users/{id}",
-      templated: true
+      href: "#{Convection.config.gravity_api_url}/users/{id}", templated: true
     },
     user_detail: {
       href: "#{Convection.config.gravity_api_url}/user_details/{id}",
@@ -34,52 +36,53 @@ def stub_gravity_root
 end
 
 def stub_gravity_request(gravity_resource, body, more_headers = {})
-  stub = stub_request(:get, "#{Convection.config.gravity_api_url}#{gravity_resource}")
-         .to_return(body: body.to_json, headers: HEADERS)
+  stub =
+    stub_request(
+      :get,
+      "#{Convection.config.gravity_api_url}#{gravity_resource}"
+    )
+      .to_return(body: body.to_json, headers: HEADERS)
   stub.with(headers: more_headers) unless more_headers.empty?
 end
 
 def stub_gravity_artist(opts = {})
   name = opts[:name] || 'Gob Bluth'
-  body = {
-    id: 'artistid',
-    name: name,
-    slug: name.parameterize
-  }.deep_merge(opts)
+  body =
+    { id: 'artistid', name: name, slug: name.parameterize }.deep_merge(opts)
   stub_gravity_request("/artists/#{body[:id]}", body)
 end
 
 def stub_gravity_user(opts = {})
   id = opts[:id] || 'userid'
-  body = {
-    id: id,
-    name: 'Jon Jonson',
-    _links: {
-      user_detail: { href: "#{Convection.config.gravity_api_url}/user_details/#{id}" }
-    }
-  }.deep_merge(opts)
+  body =
+    {
+      id: id,
+      name: 'Jon Jonson',
+      _links: {
+        user_detail: {
+          href: "#{Convection.config.gravity_api_url}/user_details/#{id}"
+        }
+      }
+    }.deep_merge(opts)
   stub_gravity_request("/users/#{body[:id]}", body)
 end
 
 def stub_gravity_user_detail(opts = {})
-  body = {
-    id: 'userid',
-    receive_sms: true,
-    phone: '847-593-7743',
-    email: 'user@example.com',
-    reset_password_token: 'xyz',
-    paddle_number: 1234
-  }.deep_merge(opts)
+  body =
+    {
+      id: 'userid',
+      receive_sms: true,
+      phone: '847-593-7743',
+      email: 'user@example.com',
+      reset_password_token: 'xyz',
+      paddle_number: 1_234
+    }.deep_merge(opts)
   stub_gravity_request("/user_details/#{body[:id]}", body)
 end
 
 def stub_gravity_partner(opts = {})
   id = opts[:id] || 'partnerid'
-  body = {
-    id: id,
-    name: 'Phillips Auctions',
-    type: 'Auction'
-  }.deep_merge(opts)
+  body = { id: id, name: 'Phillips Auctions', type: 'Auction' }.deep_merge(opts)
   stub_gravity_request("/partners/#{body[:id]}", body)
 end
 
@@ -87,22 +90,28 @@ def stub_gravity_partner_communications(opts = {})
   name = opts[:name] || 'Consignment Submissions'
   id = opts[:id] || 'pc1'
   partner_id = opts[:partner_id] || 'partnerid'
-  communication = {
-    id: id,
-    name: name,
-    _links: {
-      partner_contacts: {
-        href: "#{Convection.config.gravity_api_url}/partner_contacts?communication_id=#{id}&partner_id=#{partner_id}"
+  communication =
+    {
+      id: id,
+      name: name,
+      _links: {
+        partner_contacts: {
+          href:
+            "#{
+              Convection.config.gravity_api_url
+            }/partner_contacts?communication_id=#{id}&partner_id=#{partner_id}"
+        }
       }
-    }
-  }.deep_merge(opts)
-  communication_items = opts.key?(:override_body) ? opts[:override_body] : [communication]
+    }.deep_merge(opts)
+  communication_items =
+    opts.key?(:override_body) ? opts[:override_body] : [communication]
   body = {
     total_count: nil,
-    next: "#{Convection.config.gravity_api_url}/partner_communications?cursor=next-cursor",
-    _embedded: {
-      partner_communications: communication_items
-    }
+    next:
+      "#{
+        Convection.config.gravity_api_url
+      }/partner_communications?cursor=next-cursor",
+    _embedded: { partner_communications: communication_items }
   }
   stub_gravity_request("/partner_communications?name=#{CGI.escape(name)}", body)
 end
@@ -110,18 +119,25 @@ end
 def stub_gravity_partner_contacts(opts = {})
   communication_id = opts[:partner_communication_id] || 'pc1'
   partner_id = opts[:partner_id] || 'partnerid'
-  contact = {
-    id: 'partnercontact1',
-    email: 'contact@partner.com',
-    partner_id: partner_id
-  }.deep_merge(opts)
+  contact =
+    {
+      id: 'partnercontact1',
+      email: 'contact@partner.com',
+      partner_id: partner_id
+    }.deep_merge(opts)
   contact_items = opts.key?(:override_body) ? opts[:override_body] : [contact]
   body = {
     total_count: nil,
-    next: "#{Convection.config.gravity_api_url}/partner_contacts?cursor=next-cursor",
-    _embedded: {
-      partner_contacts: contact_items
-    }
+    next:
+      "#{
+        Convection.config.gravity_api_url
+      }/partner_contacts?cursor=next-cursor",
+    _embedded: { partner_contacts: contact_items }
   }
-  stub_gravity_request("/partner_contacts?partner_id=#{partner_id}&communication_id=#{communication_id}", body)
+  stub_gravity_request(
+    "/partner_contacts?partner_id=#{partner_id}&communication_id=#{
+      communication_id
+    }",
+    body
+  )
 end

--- a/spec/views/admin/consignments/edit.html.erb_spec.rb
+++ b/spec/views/admin/consignments/edit.html.erb_spec.rb
@@ -4,15 +4,21 @@ require 'support/jwt_helper'
 
 describe 'admin/consignments/edit.html.erb', type: :feature do
   context 'with a consignment' do
-    let(:submission) { Fabricate(:submission, category: 'Painting', state: 'approved') }
+    let(:submission) do
+      Fabricate(:submission, category: 'Painting', state: 'approved')
+    end
     let(:partner) { Fabricate(:partner) }
-    let(:partner_submission) { Fabricate(:partner_submission, submission: submission, partner: partner) }
+    let(:partner_submission) do
+      Fabricate(:partner_submission, submission: submission, partner: partner)
+    end
     let(:offer) do
-      Fabricate(:offer,
-                partner_submission: partner_submission,
-                offer_type: 'purchase',
-                state: 'accepted',
-                price_cents: 12_000)
+      Fabricate(
+        :offer,
+        partner_submission: partner_submission,
+        offer_type: 'purchase',
+        state: 'accepted',
+        price_cents: 12_000
+      )
     end
 
     before do
@@ -23,7 +29,9 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
         sale_location: 'London'
       )
       submission.update!(consigned_partner_submission_id: partner_submission.id)
-      allow_any_instance_of(Admin::ConsignmentsController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::ConsignmentsController).to receive(
+        :require_artsy_authentication
+      )
 
       stub_jwt_header('userid')
       stub_gravity_root
@@ -32,7 +40,9 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
       stub_gravity_user(id: submission.user.gravity_user_id)
       stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_artists_response = {
         data: {
           artists: [
@@ -44,18 +54,19 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_artists_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
 
       page.visit edit_admin_consignment_path(partner_submission)
     end
 
     describe 'editing' do
       it 'displays the page title and content' do
-        expect(page).to have_content("Consignment ##{partner_submission.reference_id}")
+        expect(page).to have_content(
+          "Consignment ##{partner_submission.reference_id}"
+        )
       end
 
       it 'displays all of the shared fields' do
@@ -70,17 +81,27 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
         expect(page).to have_content('Artsy commission %')
         expect(page).to have_content('Notes')
 
-        expect(find_field('partner_submission_sale_name').value).to eq('July Prints & Multiples')
+        expect(find_field('partner_submission_sale_name').value).to eq(
+          'July Prints & Multiples'
+        )
       end
 
       it 'allows you to edit a consignment' do
         fill_in('partner_submission_sale_name', with: 'August Sale')
         fill_in('partner_submission_sale_price_dollars', with: '700')
-        fill_in('partner_submission_partner_commission_percent_whole', with: '10')
-        fill_in('partner_submission_artsy_commission_percent_whole', with: '8.8')
+        fill_in(
+          'partner_submission_partner_commission_percent_whole',
+          with: '10'
+        )
+        fill_in(
+          'partner_submission_artsy_commission_percent_whole',
+          with: '8.8'
+        )
 
         click_button('Save')
-        expect(page.current_path).to eq admin_consignment_path(partner_submission)
+        expect(page.current_path).to eq admin_consignment_path(
+             partner_submission
+           )
         expect(page).to have_content('Name August Sale')
         expect(page).to have_content('Price $700')
         expect(page).to have_content('Partner Commission % 10.0')
@@ -90,9 +111,14 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
       it 'shows the canceled reason box when canceled is selected', js: true do
         select('canceled', from: 'partner_submission_state')
         expect(page).to have_content 'Canceled Reason'
-        fill_in('partner_submission_canceled_reason', with: 'do not want this piece.')
+        fill_in(
+          'partner_submission_canceled_reason',
+          with: 'do not want this piece.'
+        )
         click_button('Save')
-        expect(page.current_path).to eq admin_consignment_path(partner_submission)
+        expect(page.current_path).to eq admin_consignment_path(
+             partner_submission
+           )
         expect(page).to have_content('State canceled')
         expect(page).to have_content('Canceled Reason do not want this piece.')
       end

--- a/spec/views/admin/consignments/index.html.erb_spec.rb
+++ b/spec/views/admin/consignments/index.html.erb_spec.rb
@@ -4,10 +4,14 @@ require 'support/gravity_helper'
 describe 'admin/consignments/index.html.erb', type: :feature do
   context 'always' do
     before do
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
 
       stub_gravity_root
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_artists_response = {
         data: {
           artists: [
@@ -19,13 +23,14 @@ describe 'admin/consignments/index.html.erb', type: :feature do
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_artists_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
 
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       page.visit admin_consignments_path
     end
 
@@ -45,9 +50,7 @@ describe 'admin/consignments/index.html.erb', type: :feature do
 
     context 'with some consignments' do
       before do
-        3.times do
-          Fabricate(:consignment, state: 'open')
-        end
+        3.times { Fabricate(:consignment, state: 'open') }
         page.visit admin_consignments_path
       end
 
@@ -60,7 +63,9 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         consignment = PartnerSubmission.consigned.first
         stub_gravity_root
         stub_gravity_user(id: consignment.submission.user.gravity_user_id)
-        stub_gravity_user_detail(id: consignment.submission.user.gravity_user_id)
+        stub_gravity_user_detail(
+          id: consignment.submission.user.gravity_user_id
+        )
         stub_gravity_artist(id: consignment.submission.artist_id)
         page.visit admin_consignments_path
 
@@ -80,13 +85,16 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         @partner1 = Fabricate(:partner, name: 'Gagosian Gallery')
         @partner2 = Fabricate(:partner, name: 'Heritage Auctions')
         3.times { Fabricate(:consignment, state: 'open', partner: @partner1) }
-        @consignment1 = Fabricate(:consignment, state: 'bought in', partner: @partner2)
+        @consignment1 =
+          Fabricate(:consignment, state: 'bought in', partner: @partner2)
         Fabricate(:consignment, state: 'sold', partner: @partner2)
         Fabricate(:consignment, state: 'canceled', partner: @partner2)
         page.visit admin_consignments_path
 
         stub_gravity_user(id: @consignment1.submission.user.gravity_user_id)
-        stub_gravity_user_detail(id: @consignment1.submission.user.gravity_user_id)
+        stub_gravity_user_detail(
+          id: @consignment1.submission.user.gravity_user_id
+        )
       end
 
       it 'lets you click into a filter option', js: true do
@@ -110,7 +118,8 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         expect(page).to have_content('Partner   Gagosian Gallery')
         click_link("partner-#{@partner1.id}")
         expect(current_url).to include "partner=#{@partner1.id}"
-        partner_names = page.all('.list-group-item-info--partner-name').map(&:text)
+        partner_names =
+          page.all('.list-group-item-info--partner-name').map(&:text)
         expect(partner_names.count).to eq 3
         expect(partner_names.uniq).to eq(['Gagosian Gallery'])
       end
@@ -128,14 +137,16 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         expect(page).to have_selector('.ui-autocomplete')
         expect(page).to have_content('Partner   Heritage Auctions')
         click_link("partner-#{@partner2.id}")
-        partner_names = page.all('.list-group-item-info--partner-name').map(&:text)
+        partner_names =
+          page.all('.list-group-item-info--partner-name').map(&:text)
         expect(partner_names.count).to eq 1
         expect(partner_names.first).to eq('Heritage Auctions')
         expect(current_url).to include "state=bought+in&partner=#{@partner2.id}"
         expect(page).to have_selector('.list-group-item', count: 2)
       end
 
-      it 'allows you to search by partner name, filter by state, and sort by sale_price_cents', js: true do
+      it 'allows you to search by partner name, filter by state, and sort by sale_price_cents',
+         js: true do
         select('bought in', from: 'state')
         fill_in('term', with: 'herit')
         expect(page).to have_selector('.ui-autocomplete')
@@ -143,7 +154,12 @@ describe 'admin/consignments/index.html.erb', type: :feature do
         click_link("partner-#{@partner2.id}")
         expect(current_url).to include "state=bought+in&partner=#{@partner2.id}"
         click_link('Price')
-        expect(current_url).to include("partner=#{@partner2.id}", 'state=bought+in', 'sort=sale_price_cents', 'direction=desc')
+        expect(current_url).to include(
+          "partner=#{@partner2.id}",
+          'state=bought+in',
+          'sort=sale_price_cents',
+          'direction=desc'
+        )
       end
     end
   end

--- a/spec/views/admin/consignments/show.html.erb_spec.rb
+++ b/spec/views/admin/consignments/show.html.erb_spec.rb
@@ -4,15 +4,26 @@ require 'support/jwt_helper'
 
 describe 'admin/consignments/show.html.erb', type: :feature do
   context 'always' do
-    let(:submission) { Fabricate(:submission, category: 'Painting', state: 'approved', user: Fabricate(:user, gravity_user_id: 'userid')) }
+    let(:submission) do
+      Fabricate(
+        :submission,
+        category: 'Painting',
+        state: 'approved',
+        user: Fabricate(:user, gravity_user_id: 'userid')
+      )
+    end
     let(:partner) { Fabricate(:partner) }
-    let(:partner_submission) { Fabricate(:partner_submission, submission: submission, partner: partner) }
+    let(:partner_submission) do
+      Fabricate(:partner_submission, submission: submission, partner: partner)
+    end
     let(:offer) do
-      Fabricate(:offer,
-                partner_submission: partner_submission,
-                offer_type: 'purchase',
-                state: 'accepted',
-                price_cents: 12_000)
+      Fabricate(
+        :offer,
+        partner_submission: partner_submission,
+        offer_type: 'purchase',
+        state: 'accepted',
+        price_cents: 12_000
+      )
     end
 
     before do
@@ -23,7 +34,9 @@ describe 'admin/consignments/show.html.erb', type: :feature do
         sale_location: 'London'
       )
       submission.update!(consigned_partner_submission_id: partner_submission.id)
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
 
       stub_jwt_header('userid')
       stub_gravity_root
@@ -32,7 +45,9 @@ describe 'admin/consignments/show.html.erb', type: :feature do
       stub_gravity_user(id: submission.user.gravity_user_id)
       stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_artists_response = {
         data: {
           artists: [
@@ -44,17 +59,18 @@ describe 'admin/consignments/show.html.erb', type: :feature do
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_artists_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
       page.visit admin_consignment_path(partner_submission)
     end
 
     describe 'performs basic functions' do
       it 'displays the page title and content' do
-        expect(page).to have_content("Consignment ##{partner_submission.reference_id}")
+        expect(page).to have_content(
+          "Consignment ##{partner_submission.reference_id}"
+        )
         expect(page).to have_content('Name July Prints & Multiples')
         expect(page).to have_content('Location London')
         expect(page).to_not have_content('Canceled Reason')
@@ -81,7 +97,9 @@ describe 'admin/consignments/show.html.erb', type: :feature do
       end
 
       it 'shows a canceled reason if the consignment has been canceled' do
-        partner_submission.update!(state: 'canceled', canceled_reason: 'done with this piece.')
+        partner_submission.update!(
+          state: 'canceled', canceled_reason: 'done with this piece.'
+        )
         page.visit admin_consignment_path(partner_submission)
         expect(page).to have_content 'Canceled Reason'
         expect(page).to have_content 'done with this piece.'
@@ -90,21 +108,31 @@ describe 'admin/consignments/show.html.erb', type: :feature do
       it 'lets you enter the edit view' do
         expect(page).to have_content 'Edit'
         click_link('Edit')
-        expect(page.current_path).to eq(edit_admin_consignment_path(partner_submission))
+        expect(page.current_path).to eq(
+          edit_admin_consignment_path(partner_submission)
+        )
       end
 
       it 'lets you change the partner_paid_at field' do
         expect(page).to have_selector('.partner-paid .toggle[data-state="no"]')
         page.find('.partner-paid .toggle').click
-        expect(page).to_not have_selector('.partner-paid .toggle[data-state="no"]')
+        expect(page).to_not have_selector(
+                              '.partner-paid .toggle[data-state="no"]'
+                            )
         expect(page).to have_selector('.partner-paid .toggle[data-state="yes"]')
       end
 
       it 'lets you change the partner_invoiced_at field' do
-        expect(page).to have_selector('.partner-invoiced .toggle[data-state="no"]')
+        expect(page).to have_selector(
+          '.partner-invoiced .toggle[data-state="no"]'
+        )
         page.find('.partner-invoiced .toggle').click
-        expect(page).to_not have_selector('.partner-invoiced .toggle[data-state="no"]')
-        expect(page).to have_selector('.partner-invoiced .toggle[data-state="yes"]')
+        expect(page).to_not have_selector(
+                              '.partner-invoiced .toggle[data-state="no"]'
+                            )
+        expect(page).to have_selector(
+          '.partner-invoiced .toggle[data-state="yes"]'
+        )
       end
     end
   end

--- a/spec/views/admin/dashboard/index.html.erb_spec.rb
+++ b/spec/views/admin/dashboard/index.html.erb_spec.rb
@@ -4,24 +4,23 @@ require 'support/gravity_helper'
 describe 'admin/dashboard/index.html.erb', type: :feature do
   context 'always' do
     before do
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
 
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_artists_response = {
-        data: {
-          artists: [
-            { id: 'artist1', name: 'Andy Warhol' }
-          ]
-        }
+        data: { artists: [{ id: 'artist1', name: 'Andy Warhol' }] }
       }
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_artists_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
 
       page.visit '/'
     end
@@ -108,7 +107,9 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
         consignment = PartnerSubmission.consigned.order(id: :desc).first
         stub_gravity_root
         stub_gravity_user(id: consignment.submission.user.gravity_user_id)
-        stub_gravity_user_detail(id: consignment.submission.user.gravity_user_id)
+        stub_gravity_user_detail(
+          id: consignment.submission.user.gravity_user_id
+        )
         stub_gravity_artist(id: consignment.submission.artist_id)
 
         find(".list-item--consignment[data-id='#{consignment.id}']").click
@@ -117,9 +118,7 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
       end
 
       it 'lets you view all consignments' do
-        within(:css, '.active-consignments') do
-          click_link('See All')
-        end
+        within(:css, '.active-consignments') { click_link('See All') }
 
         expect(page.current_path).to eq admin_consignments_path
       end

--- a/spec/views/admin/offers/edit.html.erb_spec.rb
+++ b/spec/views/admin/offers/edit.html.erb_spec.rb
@@ -4,21 +4,33 @@ describe 'admin/offers/edit.html.erb', type: :feature do
   context 'with an offer' do
     let(:partner) { Fabricate(:partner, name: 'Gagosian Gallery') }
     let(:submission) { Fabricate(:submission) }
-    let(:partner_submission) { Fabricate(:partner_submission, partner: partner, submission: submission) }
+    let(:partner_submission) do
+      Fabricate(:partner_submission, partner: partner, submission: submission)
+    end
 
     before do
-      allow_any_instance_of(Admin::OffersController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::OffersController).to receive(
+        :require_artsy_authentication
+      )
     end
 
     describe 'auction consignment offer' do
-      let(:offer) { Fabricate(:offer, offer_type: 'auction consignment', partner_submission: partner_submission) }
-      before do
-        page.visit "/admin/offers/#{offer.id}/edit"
+      let(:offer) do
+        Fabricate(
+          :offer,
+          offer_type: 'auction consignment',
+          partner_submission: partner_submission
+        )
       end
+      before { page.visit "/admin/offers/#{offer.id}/edit" }
 
       it 'displays the page title and content' do
         expect(page).to have_content("Offer ##{offer.reference_id}")
-        expect(page).to have_content("Auction consignment offer for Submission ##{submission.id} by Gagosian Gallery")
+        expect(page).to have_content(
+          "Auction consignment offer for Submission ##{
+            submission.id
+          } by Gagosian Gallery"
+        )
       end
 
       it 'displays all of the shared fields' do
@@ -43,15 +55,20 @@ describe 'admin/offers/edit.html.erb', type: :feature do
     end
 
     describe 'purchase offer' do
-      let(:offer) { Fabricate(:offer, offer_type: 'purchase', partner_submission: partner_submission) }
-
-      before do
-        page.visit "/admin/offers/#{offer.id}/edit"
+      let(:offer) do
+        Fabricate(
+          :offer,
+          offer_type: 'purchase', partner_submission: partner_submission
+        )
       end
+
+      before { page.visit "/admin/offers/#{offer.id}/edit" }
 
       it 'displays the page title and content' do
         expect(page).to have_content("Offer ##{offer.reference_id}")
-        expect(page).to have_content("Purchase offer for Submission ##{submission.id} by Gagosian Gallery")
+        expect(page).to have_content(
+          "Purchase offer for Submission ##{submission.id} by Gagosian Gallery"
+        )
       end
 
       it 'displays all of the shared fields' do
@@ -73,14 +90,19 @@ describe 'admin/offers/edit.html.erb', type: :feature do
     end
 
     describe 'retail offer' do
-      let(:offer) { Fabricate(:offer, offer_type: 'retail', partner_submission: partner_submission) }
-      before do
-        page.visit "/admin/offers/#{offer.id}/edit"
+      let(:offer) do
+        Fabricate(
+          :offer,
+          offer_type: 'retail', partner_submission: partner_submission
+        )
       end
+      before { page.visit "/admin/offers/#{offer.id}/edit" }
 
       it 'displays the page title and content' do
         expect(page).to have_content("Offer ##{offer.reference_id}")
-        expect(page).to have_content("Retail offer for Submission ##{submission.id} by Gagosian Gallery")
+        expect(page).to have_content(
+          "Retail offer for Submission ##{submission.id} by Gagosian Gallery"
+        )
       end
 
       it 'displays all of the shared fields' do
@@ -104,14 +126,19 @@ describe 'admin/offers/edit.html.erb', type: :feature do
     end
 
     describe 'net price offer' do
-      let(:offer) { Fabricate(:offer, offer_type: 'net price', partner_submission: partner_submission) }
-      before do
-        page.visit "/admin/offers/#{offer.id}/edit"
+      let(:offer) do
+        Fabricate(
+          :offer,
+          offer_type: 'net price', partner_submission: partner_submission
+        )
       end
+      before { page.visit "/admin/offers/#{offer.id}/edit" }
 
       it 'displays the page title and content' do
         expect(page).to have_content("Offer ##{offer.reference_id}")
-        expect(page).to have_content("Net price offer for Submission ##{submission.id} by Gagosian Gallery")
+        expect(page).to have_content(
+          "Net price offer for Submission ##{submission.id} by Gagosian Gallery"
+        )
       end
 
       it 'displays all of the shared fields' do

--- a/spec/views/admin/offers/index.html.erb_spec.rb
+++ b/spec/views/admin/offers/index.html.erb_spec.rb
@@ -6,24 +6,23 @@ describe 'admin/offers/index.html.erb', type: :feature do
     before do
       stub_gravity_root
 
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
 
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_artists_response = {
-        data: {
-          artists: [
-            { id: 'artist1', name: 'Andy Warhol' }
-          ]
-        }
+        data: { artists: [{ id: 'artist1', name: 'Andy Warhol' }] }
       }
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_artists_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
 
       page.visit admin_offers_path
     end
@@ -76,7 +75,11 @@ describe 'admin/offers/index.html.erb', type: :feature do
       end
 
       it 'displays a lock symbol if the offer is locked' do
-        ps = Fabricate(:partner_submission, submission: Fabricate(:submission, state: Submission::APPROVED))
+        ps =
+          Fabricate(
+            :partner_submission,
+            submission: Fabricate(:submission, state: Submission::APPROVED)
+          )
         accepted_offer = Fabricate(:offer, partner_submission: ps)
         Fabricate(:offer, partner_submission: ps)
         OfferService.consign!(accepted_offer)
@@ -89,10 +92,31 @@ describe 'admin/offers/index.html.erb', type: :feature do
       before do
         @partner1 = Fabricate(:partner, name: 'Gagosian')
         @partner2 = Fabricate(:partner, name: 'Heritage Auctions')
-        3.times { Fabricate(:offer, state: 'sent', partner_submission: Fabricate(:partner_submission, partner: @partner1)) }
-        @offer1 = Fabricate(:offer, state: 'accepted', partner_submission: Fabricate(:partner_submission, partner: @partner2))
-        Fabricate(:offer, state: 'rejected', partner_submission: Fabricate(:partner_submission, partner: @partner2))
-        Fabricate(:offer, state: 'draft', partner_submission: Fabricate(:partner_submission, partner: @partner1))
+        3.times do
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission:
+              Fabricate(:partner_submission, partner: @partner1)
+          )
+        end
+        @offer1 =
+          Fabricate(
+            :offer,
+            state: 'accepted',
+            partner_submission:
+              Fabricate(:partner_submission, partner: @partner2)
+          )
+        Fabricate(
+          :offer,
+          state: 'rejected',
+          partner_submission: Fabricate(:partner_submission, partner: @partner2)
+        )
+        Fabricate(
+          :offer,
+          state: 'draft',
+          partner_submission: Fabricate(:partner_submission, partner: @partner1)
+        )
 
         stub_gravity_user(id: @offer1.submission.user.gravity_user_id)
         stub_gravity_user_detail(id: @offer1.submission.user.gravity_user_id)
@@ -143,7 +167,8 @@ describe 'admin/offers/index.html.erb', type: :feature do
         expect(page).to have_content('draft', count: 1)
       end
 
-      it 'allows you to search by partner name, filter by state, and sort by price_cents', js: true do
+      it 'allows you to search by partner name, filter by state, and sort by price_cents',
+         js: true do
         select('sent', from: 'state')
         fill_in('term', with: 'Gag')
         expect(page).to have_selector('.ui-autocomplete')
@@ -151,7 +176,12 @@ describe 'admin/offers/index.html.erb', type: :feature do
         click_link("partner-#{@partner1.id}")
         expect(current_url).to include "state=sent&partner=#{@partner1.id}"
         click_link('Price')
-        expect(current_url).to include("partner=#{@partner1.id}", 'state=sent', 'sort=price_cents', 'direction=desc')
+        expect(current_url).to include(
+          "partner=#{@partner1.id}",
+          'state=sent',
+          'sort=price_cents',
+          'direction=desc'
+        )
       end
     end
   end

--- a/spec/views/admin/offers/new_step_0.html.erb_spec.rb
+++ b/spec/views/admin/offers/new_step_0.html.erb_spec.rb
@@ -7,7 +7,9 @@ describe 'admin/offers/new_step_0.html.erb', type: :feature do
 
   context 'with a submission' do
     before do
-      allow_any_instance_of(Admin::OffersController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::OffersController).to receive(
+        :require_artsy_authentication
+      )
       page.visit new_step_0_admin_offers_path(submission_id: submission.id)
     end
 
@@ -19,20 +21,26 @@ describe 'admin/offers/new_step_0.html.erb', type: :feature do
     it 'displays an error message if no partner is selected' do
       expect(find('input#offer_type_auction_consignment')).to be_checked
       click_button('Next')
-      expect(page).to have_content('Offer requires type, submission, and partner.')
+      expect(page).to have_content(
+        'Offer requires type, submission, and partner.'
+      )
     end
 
     it 'keeps the offer type selected when an error is shown' do
       choose('offer_type_purchase')
       click_button('Next')
-      expect(page).to have_content('Offer requires type, submission, and partner.')
+      expect(page).to have_content(
+        'Offer requires type, submission, and partner.'
+      )
       expect(find('input#offer_type_purchase')).to be_checked
     end
   end
 
   context 'without a submission', js: true do
     before do
-      allow_any_instance_of(Admin::OffersController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::OffersController).to receive(
+        :require_artsy_authentication
+      )
       page.visit new_step_0_admin_offers_path
     end
 
@@ -43,28 +51,38 @@ describe 'admin/offers/new_step_0.html.erb', type: :feature do
     it 'displays an error message if a submission and partner are not selected' do
       expect(find('input#offer_type_auction_consignment')).to be_checked
       click_button('Next')
-      expect(page).to have_content('Offer requires type, submission, and partner.')
+      expect(page).to have_content(
+        'Offer requires type, submission, and partner.'
+      )
     end
 
     it 'allows you to select a submission and partner' do
       evaluate_script("$('#submission_id').val(#{submission.id})")
       evaluate_script("$('#partner_id').val(#{partner.id})")
       click_button('Next')
-      expect(page).to have_content("Auction consignment offer for Submission ##{submission.id} by First Partner")
+      expect(page).to have_content(
+        "Auction consignment offer for Submission ##{
+          submission.id
+        } by First Partner"
+      )
     end
 
     it 'keeps the partner selected if you revisit the page on error' do
       evaluate_script("$('#partner_id').val(#{partner.id})")
       click_button('Next')
       expect(page).to have_content('Partner First Partner')
-      expect(page).to have_content('Offer requires type, submission, and partner.')
+      expect(page).to have_content(
+        'Offer requires type, submission, and partner.'
+      )
     end
 
     it 'keeps the submission selected if you revisit the page on error' do
       evaluate_script("$('#submission_id').val(#{submission.id})")
       click_button('Next')
       expect(page).to have_content("Submission ##{submission.id}")
-      expect(page).to have_content('Offer requires type, submission, and partner.')
+      expect(page).to have_content(
+        'Offer requires type, submission, and partner.'
+      )
     end
   end
 end

--- a/spec/views/admin/offers/new_step_1.html.erb_spec.rb
+++ b/spec/views/admin/offers/new_step_1.html.erb_spec.rb
@@ -5,20 +5,30 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
   context 'with an offer' do
     let(:partner) { Fabricate(:partner, name: 'Gagosian Gallery') }
     let(:submission) { Fabricate(:submission, state: Submission::APPROVED) }
-    let(:partner_submission) { Fabricate(:partner_submission, partner: partner, submission: submission) }
+    let(:partner_submission) do
+      Fabricate(:partner_submission, partner: partner, submission: submission)
+    end
 
     before do
-      allow_any_instance_of(Admin::OffersController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::OffersController).to receive(
+        :require_artsy_authentication
+      )
     end
 
     describe 'auction consignment offer' do
       before do
-        page.visit "/admin/offers/new_step_1?submission_id=#{submission.id}&partner_id=#{partner.id}&offer_type=auction+consignment"
+        page.visit "/admin/offers/new_step_1?submission_id=#{
+                     submission.id
+                   }&partner_id=#{partner.id}&offer_type=auction+consignment"
       end
 
       it 'displays the page title and content' do
         expect(page).to have_content('New Offer')
-        expect(page).to have_content("Auction consignment offer for Submission ##{submission.id} by Gagosian Gallery")
+        expect(page).to have_content(
+          "Auction consignment offer for Submission ##{
+            submission.id
+          } by Gagosian Gallery"
+        )
       end
 
       it 'displays all of the shared fields' do
@@ -46,7 +56,9 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
         stub_gravity_user(id: submission.user.gravity_user_id)
         stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
-        allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+        allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+          'xapp_token'
+        )
         gravql_artists_response = {
           data: {
             artists: [
@@ -58,11 +70,10 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
         stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
           .to_return(body: gravql_artists_response.to_json)
           .with(
-            headers: {
-              'X-XAPP-TOKEN' => 'xapp_token',
-              'Content-Type' => 'application/json'
-            }
-          )
+          headers: {
+            'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+          }
+        )
         fill_in('offer_commission_percent_whole', with: '10')
         fill_in('offer_low_estimate_dollars', with: '100')
         fill_in('offer_high_estimate_dollars', with: '300')
@@ -90,12 +101,16 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
 
     describe 'purchase offer' do
       before do
-        page.visit "/admin/offers/new_step_1?submission_id=#{submission.id}&partner_id=#{partner.id}&offer_type=purchase"
+        page.visit "/admin/offers/new_step_1?submission_id=#{
+                     submission.id
+                   }&partner_id=#{partner.id}&offer_type=purchase"
       end
 
       it 'displays the page title and content' do
         expect(page).to have_content('New Offer')
-        expect(page).to have_content("Purchase offer for Submission ##{submission.id} by Gagosian Gallery")
+        expect(page).to have_content(
+          "Purchase offer for Submission ##{submission.id} by Gagosian Gallery"
+        )
       end
 
       it 'displays all of the shared fields' do
@@ -120,7 +135,9 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
         stub_gravity_user(id: submission.user.gravity_user_id)
         stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
-        allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+        allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+          'xapp_token'
+        )
         gravql_artists_response = {
           data: {
             artists: [
@@ -132,11 +149,10 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
         stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
           .to_return(body: gravql_artists_response.to_json)
           .with(
-            headers: {
-              'X-XAPP-TOKEN' => 'xapp_token',
-              'Content-Type' => 'application/json'
-            }
-          )
+          headers: {
+            'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+          }
+        )
         fill_in('offer_price_dollars', with: '700')
         fill_in('offer_photography_dollars', with: '50')
         fill_in('offer_shipping_dollars', with: '70')
@@ -160,12 +176,16 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
 
     describe 'retail offer' do
       before do
-        page.visit "/admin/offers/new_step_1?submission_id=#{submission.id}&partner_id=#{partner.id}&offer_type=retail"
+        page.visit "/admin/offers/new_step_1?submission_id=#{
+                     submission.id
+                   }&partner_id=#{partner.id}&offer_type=retail"
       end
 
       it 'displays the page title and content' do
         expect(page).to have_content('New Offer')
-        expect(page).to have_content("Retail offer for Submission ##{submission.id} by Gagosian Gallery")
+        expect(page).to have_content(
+          "Retail offer for Submission ##{submission.id} by Gagosian Gallery"
+        )
       end
 
       it 'displays all of the shared fields' do
@@ -192,7 +212,9 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
         stub_gravity_user(id: submission.user.gravity_user_id)
         stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
-        allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+        allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+          'xapp_token'
+        )
         gravql_artists_response = {
           data: {
             artists: [
@@ -204,11 +226,10 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
         stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
           .to_return(body: gravql_artists_response.to_json)
           .with(
-            headers: {
-              'X-XAPP-TOKEN' => 'xapp_token',
-              'Content-Type' => 'application/json'
-            }
-          )
+          headers: {
+            'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+          }
+        )
 
         fill_in('offer_price_dollars', with: '700')
         fill_in('offer_commission_percent_whole', with: '12.5')
@@ -235,12 +256,16 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
 
     describe 'net price offer' do
       before do
-        page.visit "/admin/offers/new_step_1?submission_id=#{submission.id}&partner_id=#{partner.id}&offer_type=net+price"
+        page.visit "/admin/offers/new_step_1?submission_id=#{
+                     submission.id
+                   }&partner_id=#{partner.id}&offer_type=net+price"
       end
 
       it 'displays the page title and content' do
         expect(page).to have_content('New Offer')
-        expect(page).to have_content("Net price offer for Submission ##{submission.id} by Gagosian Gallery")
+        expect(page).to have_content(
+          "Net price offer for Submission ##{submission.id} by Gagosian Gallery"
+        )
       end
 
       it 'displays all of the shared fields' do
@@ -267,7 +292,9 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
         stub_gravity_user(id: submission.user.gravity_user_id)
         stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
-        allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+        allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+          'xapp_token'
+        )
         gravql_artists_response = {
           data: {
             artists: [
@@ -279,11 +306,10 @@ describe 'admin/offers/new_step_1.html.erb', type: :feature do
         stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
           .to_return(body: gravql_artists_response.to_json)
           .with(
-            headers: {
-              'X-XAPP-TOKEN' => 'xapp_token',
-              'Content-Type' => 'application/json'
-            }
-          )
+          headers: {
+            'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+          }
+        )
 
         fill_in('offer_price_dollars', with: '700')
         fill_in('offer_photography_dollars', with: '50')

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -6,11 +6,22 @@ describe 'admin/offers/show.html.erb', type: :feature do
   context 'always' do
     let(:submission) { Fabricate(:submission, state: Submission::APPROVED) }
     let(:partner) { Fabricate(:partner) }
-    let(:partner_submission) { Fabricate(:partner_submission, submission: submission, partner: partner) }
-    let(:offer) { Fabricate(:offer, partner_submission: partner_submission, offer_type: 'purchase', state: 'draft') }
+    let(:partner_submission) do
+      Fabricate(:partner_submission, submission: submission, partner: partner)
+    end
+    let(:offer) do
+      Fabricate(
+        :offer,
+        partner_submission: partner_submission,
+        offer_type: 'purchase',
+        state: 'draft'
+      )
+    end
 
     before do
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
       stub_jwt_header('userid')
 
       stub_gravity_root
@@ -18,7 +29,9 @@ describe 'admin/offers/show.html.erb', type: :feature do
       stub_gravity_user(id: submission.user.gravity_user_id)
       stub_gravity_user_detail(id: submission.user.gravity_user_id)
 
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_artists_response = {
         data: {
           artists: [
@@ -30,11 +43,10 @@ describe 'admin/offers/show.html.erb', type: :feature do
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_artists_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
       page.visit "/admin/offers/#{offer.id}"
     end
 
@@ -91,9 +103,11 @@ describe 'admin/offers/show.html.erb', type: :feature do
 
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.first.to).to eq(['user@example.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
-        expect(emails.first.subject).to eq('An offer for your consignment submission')
+        expect(emails.first.to).to eq(%w[user@example.com])
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
+        expect(emails.first.subject).to eq(
+          'An offer for your consignment submission'
+        )
       end
     end
 
@@ -123,10 +137,14 @@ describe 'admin/offers/show.html.erb', type: :feature do
         offer.update!(state: 'sent')
         stub_gravity_root
         stub_gravity_user(id: offer.submission.user.gravity_user_id)
-        stub_gravity_user_detail(email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id)
+        stub_gravity_user_detail(
+          email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id
+        )
         stub_gravity_artist(id: submission.artist_id)
         stub_gravity_partner(id: partner.gravity_partner_id)
-        stub_gravity_partner_communications(partner_id: partner.gravity_partner_id)
+        stub_gravity_partner_communications(
+          partner_id: partner.gravity_partner_id
+        )
         stub_gravity_partner_contacts(
           partner_id: partner.gravity_partner_id,
           override_body: [
@@ -155,9 +173,13 @@ describe 'admin/offers/show.html.erb', type: :feature do
 
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 2
-        expect(emails.map(&:to).flatten).to eq(['contact1@partner.com', 'contact2@partner.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
-        expect(emails.first.subject).to eq('The consignor has expressed interest in your offer')
+        expect(emails.map(&:to).flatten).to eq(
+          %w[contact1@partner.com contact2@partner.com]
+        )
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
+        expect(emails.first.subject).to eq(
+          'The consignor has expressed interest in your offer'
+        )
       end
 
       it 'allows you to provide an override e-mail' do
@@ -168,7 +190,7 @@ describe 'admin/offers/show.html.erb', type: :feature do
         end
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.map(&:to).flatten).to eq(['override@partner.com'])
+        expect(emails.map(&:to).flatten).to eq(%w[override@partner.com])
       end
     end
 
@@ -189,7 +211,9 @@ describe 'admin/offers/show.html.erb', type: :feature do
         expect(find('input#terms_signed')).to_not be_checked
         expect(page).to have_selector('.offer-consign-button.disabled-button')
         find('input#terms_signed').click
-        expect(page).to_not have_selector('.offer-consign-button.disabled-button')
+        expect(page).to_not have_selector(
+                              '.offer-consign-button.disabled-button'
+                            )
         find('.offer-consign-button').click
         page.driver.browser.switch_to.alert.accept
         expect(page).to have_content("Offer ##{offer.reference_id}")
@@ -202,7 +226,8 @@ describe 'admin/offers/show.html.erb', type: :feature do
 
     describe 'offer locked' do
       before do
-        accepted_offer = Fabricate(:offer, partner_submission: partner_submission)
+        accepted_offer =
+          Fabricate(:offer, partner_submission: partner_submission)
         offer.update!(state: 'review')
         OfferService.consign!(accepted_offer)
         stub_gravity_artist(id: submission.artist_id)
@@ -221,10 +246,14 @@ describe 'admin/offers/show.html.erb', type: :feature do
         offer.update!(state: 'sent')
         stub_gravity_root
         stub_gravity_user(id: offer.submission.user.gravity_user_id)
-        stub_gravity_user_detail(email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id)
+        stub_gravity_user_detail(
+          email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id
+        )
         stub_gravity_artist(id: submission.artist_id)
         stub_gravity_partner(id: partner.gravity_partner_id)
-        stub_gravity_partner_communications(partner_id: partner.gravity_partner_id)
+        stub_gravity_partner_communications(
+          partner_id: partner.gravity_partner_id
+        )
         stub_gravity_partner_contacts(
           partner_id: partner.gravity_partner_id,
           override_body: [
@@ -254,25 +283,38 @@ describe 'admin/offers/show.html.erb', type: :feature do
 
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 2
-        expect(emails.map(&:to).flatten).to eq(['contact1@partner.com', 'contact2@partner.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
-        expect(emails.first.subject).to eq('A response to your consignment offer')
+        expect(emails.map(&:to).flatten).to eq(
+          %w[contact1@partner.com contact2@partner.com]
+        )
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
+        expect(emails.first.subject).to eq(
+          'A response to your consignment offer'
+        )
       end
 
       it 'allows you to add notes to the rejection' do
         click_link('Reject Offer')
         within('[data-remodal-id="reject-offer-modal"]') do
           choose('offer_rejection_reason_other')
-          fill_in('offer_rejection_note', with: 'The user has issues with who the partner is.')
+          fill_in(
+            'offer_rejection_note',
+            with: 'The user has issues with who the partner is.'
+          )
           click_button('Save and Send')
         end
-        expect(page).to have_content('Rejected by Lucille Bluth. Other: The user has issues with who the partner is.')
+        expect(page).to have_content(
+          'Rejected by Lucille Bluth. Other: The user has issues with who the partner is.'
+        )
 
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 2
-        expect(emails.map(&:to).flatten).to eq(['contact1@partner.com', 'contact2@partner.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
-        expect(emails.first.subject).to eq('A response to your consignment offer')
+        expect(emails.map(&:to).flatten).to eq(
+          %w[contact1@partner.com contact2@partner.com]
+        )
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
+        expect(emails.first.subject).to eq(
+          'A response to your consignment offer'
+        )
       end
 
       it 'allows you to provide an override e-mail' do
@@ -284,9 +326,11 @@ describe 'admin/offers/show.html.erb', type: :feature do
         end
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
-        expect(emails.map(&:to).flatten).to eq(['override@partner.com'])
-        expect(emails.first.from).to eq(['consign@artsy.net'])
-        expect(emails.first.subject).to eq('A response to your consignment offer')
+        expect(emails.map(&:to).flatten).to eq(%w[override@partner.com])
+        expect(emails.first.from).to eq(%w[consign@artsy.net])
+        expect(emails.first.subject).to eq(
+          'A response to your consignment offer'
+        )
       end
     end
   end

--- a/spec/views/admin/partner_submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/partner_submissions/index.html.erb_spec.rb
@@ -3,63 +3,78 @@ require 'rails_helper'
 describe 'admin/partner_submissions/digest.html.erb', type: :feature do
   context 'always' do
     before do
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
-      @partner = Fabricate(:partner, gravity_partner_id: 'partnerid', name: 'Wright')
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
+      @partner =
+        Fabricate(:partner, gravity_partner_id: 'partnerid', name: 'Wright')
 
       gravql_artists_response = {
-        data: {
-          artists: [
-            { id: 'artist1', name: 'Andy Warhol' }
-          ]
-        }
+        data: { artists: [{ id: 'artist1', name: 'Andy Warhol' }] }
       }
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .with do |request|
-          parsed = JSON.parse(request.body)
-          parsed['variables']['ids'] == [] && parsed['query'].include?('artistsDetails')
-        end.to_return(body: gravql_artists_response.to_json)
+        parsed = JSON.parse(request.body)
+        parsed['variables']['ids'] == [] &&
+          parsed['query'].include?('artistsDetails')
+      end.to_return(body: gravql_artists_response.to_json)
 
       page.visit "/admin/partners/#{@partner.id}/submissions?notified_at="
     end
 
     it 'displays the page title and content' do
-      expect(page).to have_content('Submissions for Wright included in next digest')
+      expect(page).to have_content(
+        'Submissions for Wright included in next digest'
+      )
       expect(page).not_to have_selector('.list-item--submission')
     end
 
     describe 'with partner_submissions' do
       before do
-        @submission = Fabricate(:submission, state: 'approved', artist_id: 'artistid')
-        @already_notified_submission = Fabricate(:submission, state: 'approved', artist_id: 'artistid')
+        @submission =
+          Fabricate(:submission, state: 'approved', artist_id: 'artistid')
+        @already_notified_submission =
+          Fabricate(:submission, state: 'approved', artist_id: 'artistid')
 
-        Fabricate(:partner_submission, partner: @partner, submission: @submission)
-        Fabricate(:partner_submission, partner: @partner, submission: @already_notified_submission, notified_at: Time.now.utc)
+        Fabricate(
+          :partner_submission,
+          partner: @partner, submission: @submission
+        )
+        Fabricate(
+          :partner_submission,
+          partner: @partner,
+          submission: @already_notified_submission,
+          notified_at: Time.now.utc
+        )
 
         gravql_artists_response = {
-          data: {
-            artists: [
-              { id: 'artist1', name: 'Andy Warhol' }
-            ]
-          }
+          data: { artists: [{ id: 'artist1', name: 'Andy Warhol' }] }
         }
         stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
           .with do |request|
-            parsed = JSON.parse(request.body)
-            parsed['variables']['ids'] == ['artistid'] && parsed['query'].include?('artistsDetails')
-          end.to_return(body: gravql_artists_response.to_json)
+          parsed = JSON.parse(request.body)
+          parsed['variables']['ids'] == %w[artistid] &&
+            parsed['query'].include?('artistsDetails')
+        end.to_return(body: gravql_artists_response.to_json)
       end
 
       it 'displays partner_submissions with no notified_at' do
         page.visit "/admin/partners/#{@partner.id}/submissions?notified_at="
-        expect(page).to have_content('Submissions for Wright included in next digest')
+        expect(page).to have_content(
+          'Submissions for Wright included in next digest'
+        )
         expect(page).to have_selector('.list-item--submission', count: 1)
         expect(page).to have_content(@submission.id)
       end
 
       it 'displays all partner_submissions if notified_at is not passed in' do
         page.visit "/admin/partners/#{@partner.id}/submissions"
-        expect(page).to have_content('Submissions for Wright included in next digest')
+        expect(page).to have_content(
+          'Submissions for Wright included in next digest'
+        )
         expect(page).to have_selector('.list-item--submission', count: 2)
         expect(page).to have_content(@submission.id)
         expect(page).to have_content(@already_notified_submission.id)

--- a/spec/views/admin/partners/create.html.erb_spec.rb
+++ b/spec/views/admin/partners/create.html.erb_spec.rb
@@ -3,28 +3,27 @@ require 'rails_helper'
 describe 'partners create', type: :feature do
   context 'always', js: true do
     before do
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
       Fabricate(:partner, name: 'Gagosian Gallery')
       Fabricate(:partner, name: 'Alan Cristea Gallery')
       Fabricate(:partner, name: 'Rosier Gallery')
       Fabricate(:partner, name: 'Auction House')
 
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_match_partners_response = {
-        data: {
-          match_partners: [
-            { id: 'partner1', given_name: 'Storefront' }
-          ]
-        }
+        data: { match_partners: [{ id: 'partner1', given_name: 'Storefront' }] }
       }
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_match_partners_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
 
       page.visit '/admin/partners'
     end
@@ -32,11 +31,17 @@ describe 'partners create', type: :feature do
     it 'allows you to create a partner' do
       expect(Partner.count).to eq 4
       click_link('Add Partner')
-      expect(page).to have_selector('#partner-selections-form #partner-search-submit.disabled-button') # button is disabled at first
+      expect(page).to have_selector(
+        '#partner-selections-form #partner-search-submit.disabled-button'
+      ) # button is disabled at first
       fill_in('gravity_partner', with: 'store')
       expect(page).to have_selector('.ui-menu-item a')
-      page.execute_script("$('.ui-menu-item:contains(\"Storefront\")').find('a').trigger('mouseenter').click()")
-      expect(page).to_not have_selector('#partner-selections-form #partner-search-submit.disabled-button')
+      page.execute_script(
+        "$('.ui-menu-item:contains(\"Storefront\")').find('a').trigger('mouseenter').click()"
+      )
+      expect(page).to_not have_selector(
+                            '#partner-selections-form #partner-search-submit.disabled-button'
+                          )
       click_button('Create Partner')
       expect(page).to have_content('Partner successfully created.')
       expect(Partner.count).to eq 5
@@ -46,11 +51,17 @@ describe 'partners create', type: :feature do
     it 'does not create a partner if the create partner button is not clicked' do
       expect(Partner.count).to eq 4
       click_link('Add Partner')
-      expect(page).to have_selector('#partner-selections-form #partner-search-submit.disabled-button') # button is disabled at first
+      expect(page).to have_selector(
+        '#partner-selections-form #partner-search-submit.disabled-button'
+      ) # button is disabled at first
       fill_in('gravity_partner', with: 'store')
       expect(page).to have_selector('.ui-menu-item a')
-      page.execute_script("$('.ui-menu-item:contains(\"Storefront\")').find('a').trigger('mouseenter').click()")
-      expect(page).to_not have_selector('#partner-selections-form #partner-search-submit.disabled-button')
+      page.execute_script(
+        "$('.ui-menu-item:contains(\"Storefront\")').find('a').trigger('mouseenter').click()"
+      )
+      expect(page).to_not have_selector(
+                            '#partner-selections-form #partner-search-submit.disabled-button'
+                          )
       find('#create-partner-close').click
       expect(page).to_not have_content('Partner successfully created.')
       expect(Partner.count).to eq 4

--- a/spec/views/admin/partners/index.html.erb_spec.rb
+++ b/spec/views/admin/partners/index.html.erb_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 describe 'admin/partners/index.html.erb', type: :feature do
   context 'always' do
     before do
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
       Fabricate(:partner, name: 'Gagosian Gallery')
       Fabricate(:partner, name: 'Alan Cristea Gallery')
       Fabricate(:partner, name: 'Rosier Gallery')
@@ -13,7 +15,14 @@ describe 'admin/partners/index.html.erb', type: :feature do
 
     it 'displays all of the partners when no term is set' do
       partner_names = page.all('.list-item--partner--name').map(&:text)
-      expect(partner_names).to eq(['Alan Cristea Gallery', 'Auction House', 'Gagosian Gallery', 'Rosier Gallery'])
+      expect(partner_names).to eq(
+        [
+          'Alan Cristea Gallery',
+          'Auction House',
+          'Gagosian Gallery',
+          'Rosier Gallery'
+        ]
+      )
     end
 
     it 'allows for searching by prefix' do
@@ -27,7 +36,9 @@ describe 'admin/partners/index.html.erb', type: :feature do
       fill_in('term', with: 'gallery')
       click_button('Search')
       partner_names = page.all('.list-item--partner--name').map(&:text)
-      expect(partner_names).to eq(['Alan Cristea Gallery', 'Gagosian Gallery', 'Rosier Gallery'])
+      expect(partner_names).to eq(
+        ['Alan Cristea Gallery', 'Gagosian Gallery', 'Rosier Gallery']
+      )
     end
   end
 end

--- a/spec/views/admin/submissions/edit.html.erb_spec.rb
+++ b/spec/views/admin/submissions/edit.html.erb_spec.rb
@@ -4,15 +4,20 @@ require 'support/gravity_helper'
 describe 'admin/submissions/edit.html.erb', type: :feature do
   context 'always' do
     before do
-      allow_any_instance_of(Admin::SubmissionsController).to receive(:require_artsy_authentication)
-      @submission = Fabricate(:submission,
-                              title: 'my artwork',
-                              artist_id: 'artistid',
-                              edition: true,
-                              edition_size: 100,
-                              edition_number: '23a',
-                              category: 'Painting',
-                              user: Fabricate(:user, gravity_user_id: 'userid'))
+      allow_any_instance_of(Admin::SubmissionsController).to receive(
+        :require_artsy_authentication
+      )
+      @submission =
+        Fabricate(
+          :submission,
+          title: 'my artwork',
+          artist_id: 'artistid',
+          edition: true,
+          edition_size: 100,
+          edition_number: '23a',
+          category: 'Painting',
+          user: Fabricate(:user, gravity_user_id: 'userid')
+        )
 
       stub_gravity_root
       stub_gravity_user

--- a/spec/views/admin/submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/submissions/index.html.erb_spec.rb
@@ -9,23 +9,22 @@ describe 'admin/submissions/index.html.erb', type: :feature do
       stub_gravity_user(id: 'userid2')
       stub_gravity_user_detail(id: 'userid2')
 
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
-      allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
+      allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+        'xapp_token'
+      )
       gravql_artists_response = {
-        data: {
-          artists: [
-            { id: 'artist1', name: 'Andy Warhol' }
-          ]
-        }
+        data: { artists: [{ id: 'artist1', name: 'Andy Warhol' }] }
       }
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_artists_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
       page.visit admin_submissions_path
     end
 
@@ -47,7 +46,12 @@ describe 'admin/submissions/index.html.erb', type: :feature do
     context 'with submissions' do
       before do
         user = Fabricate(:user, gravity_user_id: 'userid')
-        3.times { Fabricate(:submission, user: user, artist_id: 'artistid', state: 'submitted') }
+        3.times do
+          Fabricate(
+            :submission,
+            user: user, artist_id: 'artistid', state: 'submitted'
+          )
+        end
         page.visit admin_submissions_path
       end
 
@@ -80,30 +84,44 @@ describe 'admin/submissions/index.html.erb', type: :feature do
 
     context 'with a variety of submissions' do
       before do
-        @user1 = Fabricate(:user, gravity_user_id: 'userid', email: 'jon-jonson@test.com')
-        @user2 = Fabricate(:user, gravity_user_id: 'userid2', email: 'percy@test.com')
+        @user1 =
+          Fabricate(
+            :user,
+            gravity_user_id: 'userid', email: 'jon-jonson@test.com'
+          )
+        @user2 =
+          Fabricate(:user, gravity_user_id: 'userid2', email: 'percy@test.com')
         3.times do
-          Fabricate(:submission,
-                    user: @user1,
-                    artist_id: 'artistid',
-                    state: 'submitted',
-                    title: 'blah')
+          Fabricate(
+            :submission,
+            user: @user1,
+            artist_id: 'artistid',
+            state: 'submitted',
+            title: 'blah'
+          )
         end
-        @submission = Fabricate(:submission,
-                                user: @user2,
-                                artist_id: 'artistid2',
-                                state: 'approved',
-                                title: 'my work')
-        Fabricate(:submission,
-                  user: @user2,
-                  artist_id: 'artistid4',
-                  state: 'rejected',
-                  title: 'title')
-        Fabricate(:submission,
-                  user: @user2,
-                  artist_id: 'artistid4',
-                  state: 'draft',
-                  title: 'blah blah')
+        @submission =
+          Fabricate(
+            :submission,
+            user: @user2,
+            artist_id: 'artistid2',
+            state: 'approved',
+            title: 'my work'
+          )
+        Fabricate(
+          :submission,
+          user: @user2,
+          artist_id: 'artistid4',
+          state: 'rejected',
+          title: 'title'
+        )
+        Fabricate(
+          :submission,
+          user: @user2,
+          artist_id: 'artistid4',
+          state: 'draft',
+          title: 'blah blah'
+        )
 
         gravql_artists_response = {
           data: {
@@ -118,11 +136,10 @@ describe 'admin/submissions/index.html.erb', type: :feature do
         stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
           .to_return(body: gravql_artists_response.to_json)
           .with(
-            headers: {
-              'X-XAPP-TOKEN' => 'xapp_token',
-              'Content-Type' => 'application/json'
-            }
-          )
+          headers: {
+            'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+          }
+        )
         page.visit admin_submissions_path
       end
 
@@ -175,7 +192,8 @@ describe 'admin/submissions/index.html.erb', type: :feature do
         expect(page).to have_content 'blah blah'
       end
 
-      it 'allows you to search by user email, filter by state, and sort by ID', js: true do
+      it 'allows you to search by user email, filter by state, and sort by ID',
+         js: true do
         select('approved', from: 'state')
         fill_in('term', with: 'percy')
         expect(page).to have_selector('.ui-autocomplete')
@@ -183,7 +201,12 @@ describe 'admin/submissions/index.html.erb', type: :feature do
         click_link("user-#{@user2.id}")
         expect(current_url).to include("user=#{@user2.id}", 'state=approved')
         click_link('ID')
-        expect(current_url).to include("user=#{@user2.id}", 'state=approved', 'sort=id', 'direction=desc')
+        expect(current_url).to include(
+          "user=#{@user2.id}",
+          'state=approved',
+          'sort=id',
+          'direction=desc'
+        )
       end
     end
   end

--- a/spec/views/admin/submissions/new.html.erb_spec.rb
+++ b/spec/views/admin/submissions/new.html.erb_spec.rb
@@ -4,7 +4,9 @@ require 'support/gravity_helper'
 describe 'admin/submissions/new.html.erb', type: :feature do
   context 'always' do
     before do
-      allow_any_instance_of(Admin::SubmissionsController).to receive(:require_artsy_authentication)
+      allow_any_instance_of(Admin::SubmissionsController).to receive(
+        :require_artsy_authentication
+      )
       page.visit '/admin/submissions/new'
     end
 

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -4,27 +4,36 @@ require 'support/jwt_helper'
 
 describe 'admin/submissions/show.html.erb', type: :feature do
   before do
-    allow(Convection.config).to receive(:gravity_xapp_token).and_return('xapp_token')
+    allow(Convection.config).to receive(:gravity_xapp_token).and_return(
+      'xapp_token'
+    )
   end
 
   context 'always' do
     before do
-      allow_any_instance_of(ApplicationController).to receive(:require_artsy_authentication)
-      allow(Convection.config).to receive(:auction_offer_form_url).and_return('https://google.com/auction')
+      allow_any_instance_of(ApplicationController).to receive(
+        :require_artsy_authentication
+      )
+      allow(Convection.config).to receive(:auction_offer_form_url).and_return(
+        'https://google.com/auction'
+      )
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail
       stub_gravity_artist
 
-      @submission = Fabricate(:submission,
-                              title: 'my sartwork',
-                              artist_id: 'artistid',
-                              edition: true,
-                              edition_size: 100,
-                              edition_number: '23a',
-                              category: 'Painting',
-                              user: Fabricate(:user, gravity_user_id: 'userid'),
-                              state: 'submitted')
+      @submission =
+        Fabricate(
+          :submission,
+          title: 'my sartwork',
+          artist_id: 'artistid',
+          edition: true,
+          edition_size: 100,
+          edition_number: '23a',
+          category: 'Painting',
+          user: Fabricate(:user, gravity_user_id: 'userid'),
+          state: 'submitted'
+        )
 
       stub_jwt_header('userid')
       page.visit "/admin/submissions/#{@submission.id}"
@@ -49,27 +58,27 @@ describe 'admin/submissions/show.html.erb', type: :feature do
     end
 
     it 'displays No for price in mind if there is no minimum_price' do
-      within('.minimum-price') do
-        expect(page).to have_content('No')
-      end
+      within('.minimum-price') { expect(page).to have_content('No') }
     end
 
     it 'displays a formatted minimum_price if present' do
       @submission.update!(minimum_price_cents: 5_000 * 100)
       page.visit "/admin/submissions/#{@submission.id}"
-      within('.minimum-price') do
-        expect(page).to have_content('Yes, $5,000')
-      end
+      within('.minimum-price') { expect(page).to have_content('Yes, $5,000') }
     end
 
     it 'displays the reviewer byline if the submission has been approved' do
-      @submission.update!(state: 'approved', approved_by: 'userid', approved_at: Time.now.utc)
+      @submission.update!(
+        state: 'approved', approved_by: 'userid', approved_at: Time.now.utc
+      )
       page.visit "/admin/submissions/#{@submission.id}"
       expect(page).to have_content 'Approved by Jon Jonson'
     end
 
     it 'displays the undo approval link if the submission has been approved' do
-      @submission.update!(state: 'approved', approved_by: 'userid', approved_at: Time.now.utc)
+      @submission.update!(
+        state: 'approved', approved_by: 'userid', approved_at: Time.now.utc
+      )
       page.visit "/admin/submissions/#{@submission.id}"
       expect(page).to have_content 'Undo approval'
       expect(page).to_not have_content 'Undo rejection'
@@ -83,20 +92,27 @@ describe 'admin/submissions/show.html.erb', type: :feature do
     end
 
     it 'displays the reviewer byline if the submission has been rejected' do
-      @submission.update!(state: 'rejected', rejected_by: 'userid', rejected_at: Time.now.utc)
+      @submission.update!(
+        state: 'rejected', rejected_by: 'userid', rejected_at: Time.now.utc
+      )
       page.visit "/admin/submissions/#{@submission.id}"
       expect(page).to have_content 'Rejected by Jon Jonson'
     end
 
     it 'displays the undo rejection link if the submission has been approved' do
-      @submission.update!(state: 'rejected', rejected_by: 'userid', rejected_at: Time.now.utc)
+      @submission.update!(
+        state: 'rejected', rejected_by: 'userid', rejected_at: Time.now.utc
+      )
       page.visit "/admin/submissions/#{@submission.id}"
       expect(page).to have_content 'Undo rejection'
       expect(page).to_not have_content 'Undo approval'
     end
 
     it 'does not display partners who have not been notified' do
-      expect(NotificationService).to receive(:post_submission_event).once.with(@submission.id, 'approved')
+      expect(NotificationService).to receive(:post_submission_event).once.with(
+        @submission.id,
+        'approved'
+      )
       partner1 = Fabricate(:partner, gravity_partner_id: 'partnerid')
       partner2 = Fabricate(:partner, gravity_partner_id: 'phillips')
       SubmissionService.update_submission(@submission, state: 'approved')
@@ -109,7 +125,10 @@ describe 'admin/submissions/show.html.erb', type: :feature do
     end
 
     it 'displays the partners that a submission has been shown to' do
-      expect(NotificationService).to receive(:post_submission_event).once.with(@submission.id, 'approved')
+      expect(NotificationService).to receive(:post_submission_event).once.with(
+        @submission.id,
+        'approved'
+      )
       stub_gravity_partner_communications
       stub_gravity_partner_contacts
       partner1 = Fabricate(:partner, gravity_partner_id: 'partnerid')
@@ -125,11 +144,10 @@ describe 'admin/submissions/show.html.erb', type: :feature do
       stub_request(:post, "#{Convection.config.gravity_api_url}/graphql")
         .to_return(body: gravql_partners_response.to_json)
         .with(
-          headers: {
-            'X-XAPP-TOKEN' => 'xapp_token',
-            'Content-Type' => 'application/json'
-          }
-        )
+        headers: {
+          'X-XAPP-TOKEN' => 'xapp_token', 'Content-Type' => 'application/json'
+        }
+      )
       SubmissionService.update_submission(@submission, state: 'approved')
       stub_gravity_partner(id: 'partnerid')
       stub_gravity_partner(id: 'phillips')
@@ -182,13 +200,9 @@ describe 'admin/submissions/show.html.erb', type: :feature do
         it 'displays zero when scores are empty' do
           page.visit "/admin/submissions/#{@submission.id}"
 
-          within('.artist-score') do
-            expect(page).to have_content(0)
-          end
+          within('.artist-score') { expect(page).to have_content(0) }
 
-          within('.auction-score') do
-            expect(page).to have_content(0)
-          end
+          within('.auction-score') { expect(page).to have_content(0) }
         end
       end
     end
@@ -200,7 +214,8 @@ describe 'admin/submissions/show.html.erb', type: :feature do
       end
 
       it 'approves a submission when the Approve button is clicked' do
-        expect(NotificationService).to receive(:post_submission_event).once.with(@submission.id, 'approved')
+        expect(NotificationService).to receive(:post_submission_event).once
+          .with(@submission.id, 'approved')
         expect(page).to_not have_content('Create Offer')
         expect(page).to have_content('submitted')
         click_link 'Approve'
@@ -231,15 +246,17 @@ describe 'admin/submissions/show.html.erb', type: :feature do
 
       describe 'undo actions' do
         let(:submission2) do
-          Fabricate(:submission,
-                    title: 'THE SECOND ARTWORK',
-                    artist_id: 'artistid',
-                    edition: true,
-                    edition_size: 100,
-                    edition_number: '23a',
-                    category: 'Painting',
-                    user: Fabricate(:user, gravity_user_id: 'userid3'),
-                    state: 'submitted')
+          Fabricate(
+            :submission,
+            title: 'THE SECOND ARTWORK',
+            artist_id: 'artistid',
+            edition: true,
+            edition_size: 100,
+            edition_number: '23a',
+            category: 'Painting',
+            user: Fabricate(:user, gravity_user_id: 'userid3'),
+            state: 'submitted'
+          )
         end
         before do
           partner = Fabricate(:partner, gravity_partner_id: 'partnerid')
@@ -261,8 +278,10 @@ describe 'admin/submissions/show.html.erb', type: :feature do
         end
 
         it 'removes the work from the digest when Undo approval is clicked' do
-          expect(NotificationService).to receive(:post_submission_event).once.with(@submission.id, 'approved')
-          expect(NotificationService).to receive(:post_submission_event).once.with(submission2.id, 'approved')
+          expect(NotificationService).to receive(:post_submission_event).once
+            .with(@submission.id, 'approved')
+          expect(NotificationService).to receive(:post_submission_event).once
+            .with(submission2.id, 'approved')
           SubmissionService.update_submission(@submission, state: 'approved')
           SubmissionService.update_submission(submission2, state: 'approved')
           expect(@submission.partner_submissions.count).to eq 2
@@ -273,7 +292,9 @@ describe 'admin/submissions/show.html.erb', type: :feature do
           expect(page).to have_content 'Approve'
           expect(@submission.partner_submissions.count).to eq 0
           ActionMailer::Base.deliveries = []
-          expect { PartnerSubmissionService.daily_digest }.to change { ActionMailer::Base.deliveries.length }
+          expect { PartnerSubmissionService.daily_digest }.to change {
+            ActionMailer::Base.deliveries.length
+          }
 
           email = ActionMailer::Base.deliveries.first
 
@@ -312,9 +333,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
         asset = @submission.assets.first
         selector = "div#submission-asset-#{asset.id}"
 
-        within(selector) do
-          click_link('Remove')
-        end
+        within(selector) { click_link('Remove') }
 
         page.driver.browser.switch_to.alert.accept
 
@@ -350,7 +369,8 @@ describe 'admin/submissions/show.html.erb', type: :feature do
 
     context 'with a consignment' do
       before do
-        consignment = Fabricate(:partner_submission, submission: @submission, state: 'open')
+        consignment =
+          Fabricate(:partner_submission, submission: @submission, state: 'open')
         @submission.update!(consigned_partner_submission: consignment)
         page.visit admin_submission_path(@submission)
       end


### PR DESCRIPTION
Wanted to get eyes on this for thoughts. I think prettier would be a great addition to rubocop's linting abilities. We're used to it in our JS projects, and it takes the style question out of things for consistency's sake. We'd still need to hook it into the overall pipeline, either through CI or githook or...? So far this just runs it over the project. 

See https://github.com/prettier/plugin-ruby

Thoughts? 