### PR TITLE
Update README with new PR policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Convection is the application that powers our consignments workflow, enabling us
 - **CI/Deploys:** [CircleCi](https://circleci.com/gh/artsy/convection); PRs merged to `artsy/convection#master` are automatically deployed to staging; PRs from `staging` to `release` are automatically deployed to production. Create such a PR with [`deploy_pr`][deploy_pr] or [this handy link][deploy].
 - **Cron Tasks:** A daily digest is sent to partners at 10am EST. The production database is exported daily at 12am EST, and imported to staging daily at 1am EST. 
 
+## Contributing Pull Requests
+
+Rosalind accepts PRs from branches on the main artsy/rosalind repo. PRs from forks will not be built in the CI environment and cannot be merged directly.
+
 ## Setup
 
 - Fork the project to your GitHub account


### PR DESCRIPTION
As we open source this project we have to change our CI settings so that our private ENVs are not leaked to forks. That means we have to PR from a branch on artsy/convection now, not from our forks. I stole this language from Rosalind's README so open to any edits, but seems legit.

FWIW, I recently installed `gh` and so now it's really easy to start a PR:

https://cli.github.com/

```
$ gh pr create
```

And then you can give a title/description and it'll create it as a branch on the main repo instead of your fork.

For #22 