### PR TITLE
CSGN-28: Add script to pull staging data down

### DIFF
--- a/bin/pull_data
+++ b/bin/pull_data
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+environment="staging"
+dump_file="$environment.dump"
+target_database="convection_development"
+
+url=$(hokusai $environment env get DATABASE_URL | cut -d '=' -f 2)
+
+dropdb $target_database
+createdb $target_database
+pg_dump $url -O -Fc -x -f $dump_file
+pg_restore $dump_file -Fc --no-owner -d $target_database
+
+rm $dump_file

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,0 +1,35 @@
+# Scripts
+
+In the `/bin` folder there are a number of scripts to help one work with
+convection, here are some basic descriptions of the ones we've added:
+
+* `console` - open a rails console with proper env setup
+* `pull_data` - pull postgres data from staging
+* `server` - start a server with proper env setup
+* `worker` - start a worker with proper env setup
+
+To envoke any of these tasks, you can do this:
+
+```
+$ ./bin/console
+```
+
+So very friendly to scripting.
+
+## Pull Data from Staging
+
+In order to get one's local postgres database in sync with staging, you can run
+the `pull_data` task:
+
+```
+$ ./bin/pull_data
+```
+
+This will:
+
+* drop your dev database
+* create an empty dev database
+* dump the staging database
+* restore the staging database
+
+Note: you will need to be connected the VPN in order for this to work.


### PR DESCRIPTION
This PR adds a script to the bin folder that will use `pg_dump` and `pg_restore` to grab staging data and clobber your local dev database with it. It's a blunt instrument at this point, but works great!

Note: you have to be connected to the staging VPN or this will fail.
