### PR TITLE
Add scope for available submissions

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -70,6 +70,8 @@ class Submission < ApplicationRecord
   scope :completed, -> { where.not(state: 'draft') }
   scope :draft, -> { where(state: 'draft') }
   scope :submitted, -> { where(state: 'submitted') }
+  scope :available,
+        -> { where(state: APPROVED, consigned_partner_submission_id: nil) }
 
   dollarize :minimum_price_cents
 

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -33,6 +33,26 @@ describe Submission do
         expect(Submission.completed.count).to eq(0)
       end
     end
+
+    describe 'available' do
+      it 'returns only approved submissions without an accepted offer' do
+        consigned_submission = Fabricate(:submission, state: 'approved')
+        partner_submission =
+          Fabricate(:partner_submission, submission: consigned_submission)
+        offer = Fabricate(:offer, partner_submission: partner_submission)
+
+        OfferService.consign!(offer)
+
+        approved_submission = Fabricate(:submission, state: 'approved')
+        Fabricate(:submission, state: 'rejected')
+        Fabricate(:submission, state: 'draft')
+        Fabricate(:submission, state: 'submitted')
+
+        available_submissions = Submission.available
+        expect(available_submissions.count).to eq(1)
+        expect(available_submissions.first).to eq(approved_submission)
+      end
+    end
   end
 
   context 'demand scores' do


### PR DESCRIPTION
This PR introduces a concept called "available submissions" where the Submission record is approved, but we have no consignment. This allows us to query convection for these types of Submissions and populate the list/detail pages in Volt.
