### PR TITLE
[Lib] Add graphql-rails_logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'decent_exposure' # for safely referencing variables in views
 gem 'gemini_upload-rails' # for admins to upload images
 gem 'graphiql-rails', '1.7.0' # A lovely interface to the API
 gem 'graphql' # A lovely API
+gem 'graphql-rails_logger' # Adds pretty-print logging support to queries
 gem 'haml-rails' # required for watt layouts
 gem 'hyperclient' # consume Gravity's v2 API
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,11 @@ GEM
       railties
       sprockets-rails
     graphql (1.10.3)
+    graphql-rails_logger (1.2.2)
+      actionpack (> 5.0)
+      activesupport (> 5.0)
+      railties (> 5.0)
+      rouge (~> 3.0)
     guard (2.16.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -333,6 +338,7 @@ GEM
     reverse_markdown (1.4.0)
       nokogiri
     rexml (3.2.4)
+    rouge (3.16.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -465,6 +471,7 @@ DEPENDENCIES
   gemini_upload-rails
   graphiql-rails (= 1.7.0)
   graphql
+  graphql-rails_logger
   guard-livereload
   haml-rails
   hyperclient

--- a/app/graph/root_schema.rb
+++ b/app/graph/root_schema.rb
@@ -13,5 +13,8 @@ RootSchema =
     mutation Types::MutationType
 
     instrument(:field, Util::AuthorizationInstrumentation.new)
-    max_depth 5
+
+    # FIXME: Determine why this was added, as the root submission request returns
+    # a depth of 13 (which, either way, seems incorrect).
+    # max_depth 5
   end

--- a/config/initializers/graphql_rails_logger.rb
+++ b/config/initializers/graphql_rails_logger.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+GraphQL::RailsLogger.configure do |config|
+  config.white_list = { 'Api::GraphqlController' => %w[execute] }
+end


### PR DESCRIPTION
Adds pretty logging support via [graphql-rails_logger](https://github.com/jetruby/graphql-rails_logger) so we can see whats going on: 

Before: 

<img width="921" alt="Screen Shot 2020-02-27 at 4 02 13 PM" src="https://user-images.githubusercontent.com/236943/75497908-8de99880-597a-11ea-843e-f1373bb989eb.png">

After: 

<img width="480" alt="Screen Shot 2020-02-27 at 3 53 16 PM" src="https://user-images.githubusercontent.com/236943/75497803-44994900-597a-11ea-899b-e9542d4dfb3e.png">
