### PR TITLE
CSGN-61: Fix offer notes in email

### DIFF
--- a/app/views/shared/email/_offer_note.html.erb
+++ b/app/views/shared/email/_offer_note.html.erb
@@ -12,7 +12,7 @@
         </tr>
         <tr>
           <td class='email-content-serif email-content-serif--small bottom-element top-element'>
-            <%= @offer.notes %>
+            <%= markdown_formatted(@offer.notes) %>
           </td>
         </tr>
       </table>

--- a/spec/mailers/previews/base_preview.rb
+++ b/spec/mailers/previews/base_preview.rb
@@ -13,7 +13,7 @@ class BasePreview < ActionMailer::Preview
       rejection_note: 'Not my type either',
       low_estimate_cents: 12_300,
       high_estimate_cents: 15_000,
-      notes: 'We would love to sell your work!',
+      notes: 'We would **love** to sell your work!',
       partner_submission:
         OpenStruct.new(
           partner: OpenStruct.new(id: 'partner_id', name: 'Gagosian Gallery')


### PR DESCRIPTION
This PR adds the markdown formatting to offer notes in the email that goes to consignors.

Here's a before/after:

<img width="1484" alt="Screen Shot 2020-03-02 at 10 53 27 AM" src="https://user-images.githubusercontent.com/79799/75698405-4ada3e80-5c74-11ea-93bd-1cb9d501c99f.png">
<img width="1484" alt="Screen Shot 2020-03-02 at 10 53 16 AM" src="https://user-images.githubusercontent.com/79799/75698415-4ca40200-5c74-11ea-9670-0648026d4b7d.png">

https://artsyproduct.atlassian.net/browse/CSGN-61