### PR TITLE
Update offer email and editing behavior

### DIFF
--- a/app/helpers/offers_helper.rb
+++ b/app/helpers/offers_helper.rb
@@ -25,6 +25,7 @@ module OffersHelper
       'Sale Period' => sale_period_display(offer),
       'Sale Date' => sale_date_display(offer),
       'Sale Name' => offer.sale_name,
+      'Deadline' => offer.deadline_to_consign,
       'Commission' => commission_display(offer),
       'Shipping' => offer.shipping_info,
       'Photography' => offer.photography_info,

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -65,6 +65,11 @@ class Offer < ApplicationRecord
     !draft? && !sent? && !review?
   end
 
+  def editable?
+    allowed_states = %w[draft sent]
+    allowed_states.include?(state)
+  end
+
   def locked?
     submission.consigned_partner_submission_id.present? &&
       submission.consigned_partner_submission.accepted_offer_id != id

--- a/app/views/admin/offers/show.html.erb
+++ b/app/views/admin/offers/show.html.erb
@@ -6,7 +6,7 @@
           <div class='overview-section'>
             <div class='overview-section-title--inline'>
               Details
-              <% if offer.draft? %>
+              <% if offer.editable? %>
                 <span class='overview-section-title--inline__link'>
                   <%= link_to 'Edit', edit_admin_offer_path(offer) %>
                 </span>

--- a/spec/mailers/previews/base_preview.rb
+++ b/spec/mailers/previews/base_preview.rb
@@ -12,6 +12,9 @@ class BasePreview < ActionMailer::Preview
       rejection_reason: 'High shipping/marketing costs',
       rejection_note: 'Not my type either',
       low_estimate_cents: 12_300,
+      sale_date: Time.zone.today,
+      sale_name: 'Some great sale',
+      deadline_to_consign: 'next week',
       high_estimate_cents: 15_000,
       notes: 'We would **love** to sell your work!',
       partner_submission:

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -54,6 +54,29 @@ describe Offer do
     end
   end
 
+  describe 'editable?' do
+    let(:allowed_states) { %w[draft sent] }
+
+    context 'when state is draft or sent' do
+      it 'returns true' do
+        allowed_states.each do |state|
+          offer = Fabricate(:offer, state: state)
+          expect(offer).to be_editable
+        end
+      end
+    end
+
+    context 'when state is any other value' do
+      it 'returns false' do
+        not_editable_states = Offer::STATES - allowed_states
+        not_editable_states.each do |state|
+          offer = Fabricate(:offer, state: state)
+          expect(offer).to_not be_editable
+        end
+      end
+    end
+  end
+
   context 'locked?' do
     it 'returns true if this offer is not the accepted_offer and the partner submission is consigned' do
       ps = Fabricate(:partner_submission, submission: approved_submission)


### PR DESCRIPTION
This PR is for these ones:

https://artsyproduct.atlassian.net/browse/CSGN-58
https://artsyproduct.atlassian.net/browse/CSGN-59

So it adds that new deadline field to the offer emails and then also updates the logic to showing the edit link to include sent offers.
<img width="1461" alt="Screen Shot 2020-03-02 at 12 43 19 PM" src="https://user-images.githubusercontent.com/79799/75707861-4cf8c900-5c85-11ea-8e62-7f7bf135c4cf.png">
