### PR TITLE
CSGN-60: Suppress approval email when no digest

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -77,13 +77,13 @@ class SubmissionService
 
     def approve!(submission, current_user, hide_from_partners)
       submission.update!(approved_by: current_user, approved_at: Time.now.utc)
-      delay.deliver_approval_notification(submission.id)
       NotificationService.delay.post_submission_event(
         submission.id,
         SubmissionEvent::APPROVED
       )
 
       unless hide_from_partners
+        delay.deliver_approval_notification(submission.id)
         PartnerSubmissionService.delay.generate_for_all_partners(submission.id)
       end
     end

--- a/app/views/admin/submissions/_state_actions.html.erb
+++ b/app/views/admin/submissions/_state_actions.html.erb
@@ -12,7 +12,7 @@
                   admin_submission_path(@submission, submission: { state: 'approved' }, hide_from_partners: 'true'),
                   method: :put,
                   class: 'btn btn-secondary btn-approve btn-small btn-full-width',
-                  data: { confirm: 'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network but thats not really true because this submission will be excluded from the digests. This action cannot be undone.' }) %>
+                  data: { confirm: 'No email will be sent to the consignor and this submission will be excluded from the digests.' }) %>
     </div>
     <div class='single-padding-top'>
       <%= link_to('Approve',

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -232,7 +232,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
         expect(page).to have_content('Create Offer')
       end
 
-      it 'approves a submission but does not include in digest when the Approve without digest button is clicked' do
+      it 'approves a submission but does not include in digest or send consignor an email when the Approve without digest button is clicked' do
         Fabricate(:partner)
         expect(PartnerSubmission.count).to eq 0
         expect(NotificationService).to receive(:post_submission_event).once
@@ -243,7 +243,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
         click_link 'Approve without digest'
 
         emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 1
+        expect(emails.length).to eq 0
         expect(page).to have_content 'Approved by Jon Jonson'
         expect(PartnerSubmission.count).to eq 0
         ActionMailer::Base.deliveries = []


### PR DESCRIPTION
This is some fallout from supporting two submission accept flows. Over on #450 we added the ability for an admin to approve a submission but remove it from the digest. Now we're wanting for no email to be sent to the consignor in this case, so this PR just moves that email inside the conditional.