### PR TITLE
[Stitching] Ensure schema matches existing MPv2 definitions

### DIFF
--- a/app/graph/mutations/add_asset_to_consignment_submission.rb
+++ b/app/graph/mutations/add_asset_to_consignment_submission.rb
@@ -6,9 +6,9 @@ module Mutations
       GraphQL::Relay::Mutation.define do
         name 'AddAssetToConsignmentSubmission'
 
-        input_field :submission_id, !types.ID
-        input_field :gemini_token, !types.String
-        input_field :asset_type, types.String
+        input_field :submissionID, !types.ID
+        input_field :geminiToken, !types.String
+        input_field :assetType, types.String
 
         return_field :asset, Types::AssetType
       end
@@ -17,7 +17,7 @@ module Mutations
       params = args.to_h['input'].except('clientMutationId')
       client_mutation_id = args.to_h['input']['clientMutationId']
 
-      submission = Submission.find_by(id: params['submission_id'])
+      submission = Submission.find_by(id: params['submissionID'])
       unless submission
         raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
       end
@@ -30,7 +30,11 @@ module Mutations
         raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
       end
 
-      params['asset_type'] ||= 'image'
+      params['assetType'] ||= 'image'
+
+      # Metaphysics uses camelCase properties and inputs
+      params = params.transform_keys(&:underscore)
+
       asset = submission.assets.create!(params)
       SubmissionService.notify_user(submission.id) if submission.submitted?
       OpenStruct.new(asset: asset, client_mutation_id: client_mutation_id)

--- a/app/graph/mutations/create_submission_mutation.rb
+++ b/app/graph/mutations/create_submission_mutation.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
 module Mutations
-  module CreateConsignmentSubmission
+  module CreateSubmissionMutation
     Definition =
       GraphQL::Relay::Mutation.define do
-        name 'CreateConsignmentSubmission'
+        name 'CreateSubmissionMutation'
 
-        input_field :additional_info, types.String
-        input_field :artist_id, !types.String
-        input_field :authenticity_certificate, types.Boolean
+        input_field :additionalInfo, types.String
+        input_field :artistID, !types.String
+        input_field :authenticityCertificate, types.Boolean
         input_field :category, Types::CategoryType
         input_field :currency, types.String
         input_field :depth, types.String
-        input_field :dimensions_metric, types.String
+        input_field :dimensionsMetric, types.String
         input_field :edition, types.Boolean
-        input_field :edition_number, types.String
-        input_field :edition_size, types.Int
+        input_field :editionNumber, types.String
+        input_field :editionSize, types.Int
         input_field :height, types.String
-        input_field :location_city, types.String
-        input_field :location_country, types.String
-        input_field :location_state, types.String
+        input_field :locationCity, types.String
+        input_field :locationCountry, types.String
+        input_field :locationState, types.String
         input_field :medium, types.String
-        input_field :minimum_price_dollars, types.Int
+        input_field :minimumPriceDollars, types.Int
         input_field :provenance, types.String
         input_field :signature, types.Boolean
         input_field :state, Types::StateType
@@ -29,16 +29,20 @@ module Mutations
         input_field :width, types.String
         input_field :year, types.String
 
-        return_field :consignment_submission, Types::SubmissionType
+        return_field :consignmentSubmission, Types::SubmissionType
       end
 
     def self.resolve(_obj, args, context)
       params = args.to_h['input'].except('clientMutationId')
       client_mutation_id = args.to_h['input']['clientMutationId']
+
+      # Metaphysics uses camelCase properties and inputs
+      params = params.transform_keys(&:underscore)
+
       submission =
         SubmissionService.create_submission(params, context[:current_user])
       OpenStruct.new(
-        consignment_submission: submission,
+        consignmentSubmission: submission,
         client_mutation_id: client_mutation_id
       )
     end

--- a/app/graph/mutations/update_submission_mutation.rb
+++ b/app/graph/mutations/update_submission_mutation.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
 module Mutations
-  module UpdateConsignmentSubmission
+  module UpdateSubmissionMutation
     Definition =
       GraphQL::Relay::Mutation.define do
-        name 'UpdateConsignmentSubmission'
+        name 'UpdateSubmissionMutation'
 
         input_field :id, !types.ID
-        input_field :additional_info, types.String
-        input_field :artist_id, types.String
-        input_field :authenticity_certificate, types.Boolean
+        input_field :additionalInfo, types.String
+        input_field :artistID, types.String
+        input_field :authenticityCertificate, types.Boolean
         input_field :category, Types::CategoryType
         input_field :currency, types.String
         input_field :depth, types.String
-        input_field :dimensions_metric, types.String
+        input_field :dimensionsMetric, types.String
         input_field :edition, types.Boolean
-        input_field :edition_number, types.String
-        input_field :edition_size, types.Int
+        input_field :editionNumber, types.String
+        input_field :editionSize, types.Int
         input_field :height, types.String
-        input_field :location_city, types.String
-        input_field :location_country, types.String
-        input_field :location_state, types.String
+        input_field :locationCity, types.String
+        input_field :locationCountry, types.String
+        input_field :locationState, types.String
         input_field :medium, types.String
-        input_field :minimum_price_dollars, types.Int
+        input_field :minimumPriceDollars, types.Int
         input_field :provenance, types.String
         input_field :signature, types.Boolean
         input_field :state, Types::StateType
@@ -30,12 +30,15 @@ module Mutations
         input_field :width, types.String
         input_field :year, types.String
 
-        return_field :consignment_submission, Types::SubmissionType
+        return_field :consignmentSubmission, Types::SubmissionType
       end
 
     def self.resolve(_obj, args, context)
       params = args.to_h['input'].except('clientMutationId')
       client_mutation_id = args.to_h['input']['clientMutationId']
+
+      # Metaphysics uses camelCase properties and inputs
+      params = params.transform_keys(&:underscore)
 
       submission = Submission.find_by(id: params['id'])
       unless submission
@@ -49,9 +52,12 @@ module Mutations
         raise(GraphQL::ExecutionError, 'Submission Not Found')
       end
 
+      # FIXME: Why does the API reject this property?
+      params.delete('dimensions_metric')
+
       SubmissionService.update_submission(submission, params.except('id'))
       OpenStruct.new(
-        consignment_submission: submission,
+        consignmentSubmission: submission,
         client_mutation_id: client_mutation_id
       )
     end

--- a/app/graph/types/asset_type.rb
+++ b/app/graph/types/asset_type.rb
@@ -10,5 +10,6 @@ module Types
       field :asset_type, !types.String, 'type of this Asset'
       field :gemini_token, types.String, 'gemini token for asset'
       field :submission_id, !types.ID
+      field :submissionID, types.ID, property: :submission_id # Alias for MPv2 compatability
     end
 end

--- a/app/graph/types/mutation_type.rb
+++ b/app/graph/types/mutation_type.rb
@@ -7,13 +7,13 @@ module Types
       description 'Mutation root for this schema'
 
       field :createConsignmentSubmission,
-            Mutations::CreateConsignmentSubmission::Definition.return_type do
+            Mutations::CreateSubmissionMutation::Definition.return_type do
         permit :user
         argument :input,
-                 Mutations::CreateConsignmentSubmission::Definition.input_type
+                 Mutations::CreateSubmissionMutation::Definition.input_type
 
         resolve lambda { |obj, args, context|
-                  Mutations::CreateConsignmentSubmission.resolve(
+                  Mutations::CreateSubmissionMutation.resolve(
                     obj,
                     args,
                     context
@@ -22,13 +22,13 @@ module Types
       end
 
       field :updateConsignmentSubmission,
-            Mutations::UpdateConsignmentSubmission::Definition.return_type do
+            Mutations::UpdateSubmissionMutation::Definition.return_type do
         permit :user
         argument :input,
-                 Mutations::UpdateConsignmentSubmission::Definition.input_type
+                 Mutations::UpdateSubmissionMutation::Definition.input_type
 
         resolve lambda { |obj, args, context|
-                  Mutations::UpdateConsignmentSubmission.resolve(
+                  Mutations::UpdateSubmissionMutation.resolve(
                     obj,
                     args,
                     context

--- a/app/graph/types/submission_type.rb
+++ b/app/graph/types/submission_type.rb
@@ -7,6 +7,7 @@ module Types
       description 'Consignment Submission'
 
       field :id, !types.ID, 'Uniq ID for this submission'
+      field :internalID, types.ID, property: :id # Alias for MPv2 compatability
       field :additional_info, types.String
       field :user_id, !types.String
       field :artist_id, !types.String

--- a/spec/requests/api/graphql/create_spec.rb
+++ b/spec/requests/api/graphql/create_spec.rb
@@ -15,9 +15,9 @@ describe 'Create Submission With Graphql' do
   let(:create_mutation) do
     <<-GRAPHQL
     mutation {
-      createConsignmentSubmission(input: { state: REJECTED, clientMutationId: "2", artist_id: "andy", title: "soup", category: JEWELRY, minimum_price_dollars: 50000, currency: "GBP" }){
+      createConsignmentSubmission(input: { state: REJECTED, clientMutationId: "2", artistID: "andy", title: "soup", category: JEWELRY, minimumPriceDollars: 50000, currency: "GBP" }){
         clientMutationId
-        consignment_submission {
+        consignmentSubmission {
           id
           title
           category
@@ -34,7 +34,7 @@ describe 'Create Submission With Graphql' do
     <<-GRAPHQL
     mutation {
       createConsignmentSubmission(input: { title: "soup" }){
-        consignment_submission {
+        consignmentSubmission {
           id
           title
         }
@@ -90,32 +90,32 @@ describe 'Create Submission With Graphql' do
         expect(response.status).to eq 200
         body = JSON.parse(response.body)
         expect(
-          body['data']['createConsignmentSubmission']['consignment_submission'][
+          body['data']['createConsignmentSubmission']['consignmentSubmission'][
             'id'
           ]
         ).not_to be_nil
         expect(
-          body['data']['createConsignmentSubmission']['consignment_submission'][
+          body['data']['createConsignmentSubmission']['consignmentSubmission'][
             'title'
           ]
         ).to eq 'soup'
         expect(
-          body['data']['createConsignmentSubmission']['consignment_submission'][
+          body['data']['createConsignmentSubmission']['consignmentSubmission'][
             'category'
           ]
         ).to eq 'JEWELRY'
         expect(
-          body['data']['createConsignmentSubmission']['consignment_submission'][
+          body['data']['createConsignmentSubmission']['consignmentSubmission'][
             'state'
           ]
         ).to eq 'REJECTED'
         expect(
-          body['data']['createConsignmentSubmission']['consignment_submission'][
+          body['data']['createConsignmentSubmission']['consignmentSubmission'][
             'minimum_price_dollars'
           ]
         ).to eq 50_000
         expect(
-          body['data']['createConsignmentSubmission']['consignment_submission'][
+          body['data']['createConsignmentSubmission']['consignmentSubmission'][
             'currency'
           ]
         ).to eq 'GBP'
@@ -135,9 +135,9 @@ describe 'Create Submission With Graphql' do
 
         create_asset = <<-GRAPHQL
         mutation {
-          addAssetToConsignmentSubmission(input: { clientMutationId: "test", submission_id: #{
+          addAssetToConsignmentSubmission(input: { clientMutationId: "test", submissionID: #{
           submission.id
-        }, gemini_token: "gemini-token-hash" }){
+        }, geminiToken: "gemini-token-hash" }){
             clientMutationId
             asset {
               id
@@ -150,7 +150,7 @@ describe 'Create Submission With Graphql' do
         post '/api/graphql', params: { query: create_asset }, headers: headers
         expect(response.status).to eq 200
 
-        body = JSON.parse(response.body)
+        body = JSON.parse(response.body) # byebug
         expect(
           body['data']['addAssetToConsignmentSubmission']['asset']['id']
         ).not_to be_nil

--- a/spec/requests/api/graphql/update_spec.rb
+++ b/spec/requests/api/graphql/update_spec.rb
@@ -26,9 +26,9 @@ describe 'Update Submission With Graphql' do
     mutation {
       updateConsignmentSubmission(input: { state: DRAFT, category: JEWELRY, clientMutationId: "test", id: #{
       submission.id
-    }, artist_id: "andy-warhol", title: "soup" }){
+    }, artistID: "andy-warhol", title: "soup" }){
         clientMutationId
-        consignment_submission {
+        consignmentSubmission {
           category
           state
           id
@@ -43,9 +43,9 @@ describe 'Update Submission With Graphql' do
   let(:update_mutation_random_id) do
     <<-GRAPHQL
     mutation {
-      updateConsignmentSubmission(input: { clientMutationId: "test", id: 999999, artist_id: "andy-warhol", title: "soup" }){
+      updateConsignmentSubmission(input: { clientMutationId: "test", id: 999999, artistID: "andy-warhol", title: "soup" }){
         clientMutationId
-        consignment_submission {
+        consignmentSubmission {
           id
           artist_id
           title
@@ -114,28 +114,28 @@ describe 'Update Submission With Graphql' do
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(
-        body['data']['updateConsignmentSubmission']['consignment_submission'][
+        body['data']['updateConsignmentSubmission']['consignmentSubmission'][
           'id'
         ]
           .to_i
       ).to eq submission.id
       expect(
-        body['data']['updateConsignmentSubmission']['consignment_submission'][
+        body['data']['updateConsignmentSubmission']['consignmentSubmission'][
           'title'
         ]
       ).to eq 'soup'
       expect(
-        body['data']['updateConsignmentSubmission']['consignment_submission'][
+        body['data']['updateConsignmentSubmission']['consignmentSubmission'][
           'artist_id'
         ]
       ).to eq 'andy-warhol'
       expect(
-        body['data']['updateConsignmentSubmission']['consignment_submission'][
+        body['data']['updateConsignmentSubmission']['consignmentSubmission'][
           'category'
         ]
       ).to eq 'JEWELRY'
       expect(
-        body['data']['updateConsignmentSubmission']['consignment_submission'][
+        body['data']['updateConsignmentSubmission']['consignmentSubmission'][
           'state'
         ]
       ).to eq 'DRAFT'


### PR DESCRIPTION
**Related**: https://github.com/artsy/metaphysics/pull/2221

This PR updates our GraphQL schema to match the currently _unstitched_ MPv2 schema. We had to make these changes on the convection side because to enable stitching we had to take old mobile app versions into account, and if we modified the schema on the MP side it would be a breaking change. 

There's some `camelCase` versus `snake_case` conversion that we had to do to line things up, but nothing too severe or blocking (there were only three mutations to update).

The other thing we had to change was the GraphQL type names. There were slight differences between what MP uses and what convection had defined. 

Follow-up steps will be to open an additional PR to MP that removes Convection code unrelated to stitching, including three manually defined mutations that communicate with Convection via the REST API. 