### PR TITLE
[Toolchain] Add guard-rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'sidekiq', '<6' # for sending emails in the background (<6 necessary for Red
 gem 'uglifier'
 
 group :development, :test do
+  gem 'guard-rspec', require: false
   gem 'pry-byebug'
   gem 'rspec-rails', '4.0.0.beta4'
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,10 @@ GEM
       guard (~> 2.8)
       guard-compat (~> 1.0)
       multi_json (~> 1.8)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -473,6 +477,7 @@ DEPENDENCIES
   graphql
   graphql-rails_logger
   guard-livereload
+  guard-rspec
   haml-rails
   hyperclient
   jquery-rails

--- a/Guardfile
+++ b/Guardfile
@@ -6,3 +6,13 @@ guard 'livereload', port: '5003', grace_period: 0.5 do
   watch(%r{app/helpers/.+})
   watch(%r{app/views/.+})
 end
+
+guard :rspec, cmd: 'bundle exec rspec' do
+  watch('spec/spec_helper.rb')                        { "spec" }
+  watch('app/controllers/application_controller.rb')  { "spec/controllers" }
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,9 @@
 require 'yarjuf'
 
 RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
Adds some niceties to our testing toolchain by automatically running tests associated with changed files, as well as adding the ability to focus on specific tests: 

1) If a source changes (`foo.rb`), and there's an associated test file (`foo_spec.rb`), run tests.
1) If a test changes, automatically run it
1) If only wanting to run a specific test or test group, add `focus: true` to it 

```rb
it "works", focus: true do 
  ...
end
```

### Use

To start the watcher, run

```rb
$ bundle exec guard
```

![onchange](https://user-images.githubusercontent.com/236943/76018957-d3a3e500-5ed5-11ea-990a-686cf6ffc2b7.gif)
