### PR TITLE
Sync Production and Stating only once a week

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -290,7 +290,7 @@ kind: CronJob
 metadata:
   name: convection-data-export
 spec:
-  schedule: "0 5 * * *"
+  schedule: "0 5 * * 0"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -228,7 +228,7 @@ kind: CronJob
 metadata:
   name: convection-data-import
 spec:
-  schedule: "0 6 * * *"
+  schedule: "0 6 * * 0"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
We've discovered that our process to sync production and staging data clobbers migrations run in staging but not yet on production. I don't have a good answer for that at the moment, but one thing that we noticed is that this sync runs every day but what's typical at Artsy is to sync just once a week, on Sunday so this PR uses that as precedent for the sync schedule.

For reference:

https://crontab.guru/#0_6_*_*_0