### PR TITLE
Add created_at field to submission

### DIFF
--- a/app/graph/types/submission_type.rb
+++ b/app/graph/types/submission_type.rb
@@ -6,20 +6,20 @@ module Types
       name 'Submission'
       description 'Consignment Submission'
 
-      field :id, !types.ID, 'Uniq ID for this submission'
-      field :internalID, types.ID, property: :id # Alias for MPv2 compatability
       field :additional_info, types.String
-      field :user_id, !types.String
       field :artist_id, !types.String
       field :authenticity_certificate, types.Boolean
       field :category, Types::CategoryType
+      field :created_at, GraphQL::Types::ISO8601DateTime
       field :currency, types.String
       field :depth, types.String
       field :dimensions_metric, types.String
-      field :edition, types.String
       field :edition_number, types.String
       field :edition_size, types.Int
+      field :edition, types.String
       field :height, types.String
+      field :id, !types.ID, 'Uniq ID for this submission'
+      field :internalID, types.ID, property: :id # Alias for MPv2 compatability
       field :location_city, types.String
       field :location_country, types.String
       field :location_state, types.String
@@ -29,6 +29,7 @@ module Types
       field :signature, types.Boolean
       field :state, Types::StateType
       field :title, types.String
+      field :user_id, !types.String
       field :width, types.String
       field :year, types.String
 


### PR DESCRIPTION
Adds a new `created_at` field to the Submission schema. 

<img width="567" alt="Screen Shot 2020-03-06 at 4 04 56 PM" src="https://user-images.githubusercontent.com/236943/76131685-4be8d400-5fc4-11ea-8dd7-d7a565c5f73d.png">
