### PR TITLE
Add support for showing only available submissions

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -173,14 +173,14 @@ type Query {
     after: String
 
     """
+    If true return only available submissions
+    """
+    available: Boolean
+
+    """
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-
-    """
-    If present return either completed or not completed submissions
-    """
-    completed: Boolean
 
     """
     Returns the first _n_ elements from the list.

--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -44,9 +44,7 @@ class SubmissionsResolver < BaseResolver
   private
 
   def base_submissions
-    return Submission.all unless @arguments.key?(:completed)
-
-    @arguments[:completed] ? Submission.completed : Submission.draft
+    @arguments[:available] ? Submission.available : Submission.all
   end
 
   def conditions

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -26,8 +26,8 @@ module Types
         description 'Get all submissions with these user IDs'
       end
 
-      argument :completed, Boolean, required: false do
-        description 'If present return either completed or not completed submissions'
+      argument :available, Boolean, required: false do
+        description 'If true return only available submissions'
       end
     end
 

--- a/spec/requests/api/graphql/queries/submissions_spec.rb
+++ b/spec/requests/api/graphql/queries/submissions_spec.rb
@@ -118,31 +118,21 @@ describe 'submissions query' do
       end
     end
 
-    context 'when asking for completed submissions' do
-      let!(:submission2) { Fabricate :submission, state: 'submitted' }
+    context 'when asking for only available submissions' do
+      let!(:submitted_submission) { Fabricate :submission, state: 'submitted' }
+      let!(:approved_submission) { Fabricate :submission, state: 'approved' }
 
-      let(:query_inputs) { 'completed: true' }
+      let(:partner_submission) { Fabricate :partner_submission }
 
-      it 'returns only the completed submissions' do
-        post '/api/graphql', params: { query: query }, headers: headers
-
-        expect(response.status).to eq 200
-        body = JSON.parse(response.body)
-
-        submissions_response = body['data']['submissions']
-        expect(submissions_response['edges'].count).to eq 1
-
-        ids = submissions_response['edges'].map { |edge| edge['node']['id'] }
-        expect(ids).to eq [submission2.id.to_s]
+      let!(:consigned_submission) do
+        Fabricate :submission,
+                  state: 'approved',
+                  consigned_partner_submission_id: partner_submission.id
       end
-    end
 
-    context 'when asking for incomplete submissions' do
-      let!(:submission2) { Fabricate :submission, state: 'submitted' }
+      let(:query_inputs) { 'available: true' }
 
-      let(:query_inputs) { 'completed: false' }
-
-      it 'returns only the incomplete submissions' do
+      it 'returns only the available submissions' do
         post '/api/graphql', params: { query: query }, headers: headers
 
         expect(response.status).to eq 200
@@ -152,7 +142,7 @@ describe 'submissions query' do
         expect(submissions_response['edges'].count).to eq 1
 
         ids = submissions_response['edges'].map { |edge| edge['node']['id'] }
-        expect(ids).to eq [submission.id.to_s]
+        expect(ids).to eq [approved_submission.id.to_s]
       end
     end
 


### PR DESCRIPTION
This PR adds support to the submissions query for an available flag. This flag maps to the Submission scope by the same name. What it will do is filter out submissions that are not approved but also remove those that have been consigned. That way we can show a list to partners in CMS of submission that they could make offers on.

Note that this PR also drops support for the complete flag on this same query. Unless I'm missing something, this flag was not being used and also didn't make a ton of sense. It's possible this is not the last time we'll be discussing how to filter this query, but this does get us closer to releasing our work on adding submissions to CMS, so I'm good with it, but totally open to feedback!