### PR TITLE
Add Guard Groups

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,18 +1,22 @@
 # frozen_string_literal: true
 
-guard 'livereload', port: '5003', grace_period: 0.5 do
-  watch(%r{app/assets/.+})
-  watch(%r{app/controllers/.+})
-  watch(%r{app/helpers/.+})
-  watch(%r{app/views/.+})
+group :livereload do
+  guard 'livereload', port: '5003', grace_period: 0.5 do
+    watch(%r{app/assets/.+})
+    watch(%r{app/controllers/.+})
+    watch(%r{app/helpers/.+})
+    watch(%r{app/views/.+})
+  end
 end
 
-guard :rspec, cmd: 'bundle exec rspec' do
-  watch('spec/spec_helper.rb')                        { "spec" }
-  watch('app/controllers/application_controller.rb')  { "spec/controllers" }
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
-  watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
-  watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
-  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+group :rspec do
+  guard :rspec, cmd: 'bundle exec rspec' do
+    watch('spec/spec_helper.rb')                        { "spec" }
+    watch('app/controllers/application_controller.rb')  { "spec/controllers" }
+    watch(%r{^spec/.+_spec\.rb$})
+    watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+    watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$})          { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+    watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
+    watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+  end
 end


### PR DESCRIPTION
By wrapping our guard blocks in groups, one can specify which groups they'd like to invoke. For example, I only want the live reloading behavior of guard, so I can run this:

```
$ bundle exec guard --group livereload
```

And that process will ignore the rspec stuff. When run without the group flag, guard will pick up all groups, so for those that want them all, no change is required!