### PR TITLE
pin artsy/pg-data-sync image to v9.6

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -298,7 +298,7 @@ spec:
         spec:
           containers:
             - name: convection-data-export
-              image: artsy/pg-data-sync
+              image: artsy/pg-data-sync:9.6
               imagePullPolicy: Always
               env:
                 - name: APP_NAME

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -236,7 +236,7 @@ spec:
         spec:
           containers:
             - name: convection-data-import
-              image: artsy/pg-data-sync
+              image: artsy/pg-data-sync:9.6
               imagePullPolicy: Always
               env:
                 - name: APP_NAME


### PR DESCRIPTION
… to correspond with our shared Postgres deployments

Follow-up to https://github.com/artsy/docker-images/pull/67