### PR TITLE
CSGN-104: Add offers to submission query

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -181,10 +181,27 @@ type Mutation {
 Consignment Offer
 """
 type Offer {
+  commissionPercent: Int
+  createdById: ID
+  currency: String
+  deadlineToConsign: String
+  highEstimateCents: Int
+
   """
   Uniq ID for this submission
   """
   id: ID!
+  insuranceInfo: String
+  lowEstimateCents: Int
+  notes: String
+  offerType: String
+  otherFeesInfo: String
+  partnerInfo: String
+  photographyInfo: String
+  saleDate: String
+  saleName: String
+  shippingInfo: String
+  state: String
 }
 
 """

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -294,6 +294,7 @@ type Submission {
   locationState: String
   medium: String
   minimumPriceDollars: Int
+  offers(gravityPartnerId: ID!): [Offer!]!
   provenance: String
   signature: Boolean
   state: State

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -181,7 +181,7 @@ type Mutation {
 Consignment Offer
 """
 type Offer {
-  commissionPercent: Int
+  commissionPercentWhole: Int
   createdById: ID
   currency: String
   deadlineToConsign: String

--- a/app/graphql/types/offer_type.rb
+++ b/app/graphql/types/offer_type.rb
@@ -6,7 +6,7 @@ module Types
 
     field :id, ID, 'Uniq ID for this submission', null: false
 
-    field :commission_percent, Integer, null: true
+    field :commission_percent_whole, Integer, null: true
     field :created_by_id, ID, null: true
     field :currency, String, null: true
     field :deadline_to_consign, String, null: true

--- a/app/graphql/types/offer_type.rb
+++ b/app/graphql/types/offer_type.rb
@@ -5,5 +5,22 @@ module Types
     description 'Consignment Offer'
 
     field :id, ID, 'Uniq ID for this submission', null: false
+
+    field :commission_percent, Integer, null: true
+    field :created_by_id, ID, null: true
+    field :currency, String, null: true
+    field :deadline_to_consign, String, null: true
+    field :high_estimate_cents, Integer, null: true
+    field :insurance_info, String, null: true
+    field :low_estimate_cents, Integer, null: true
+    field :notes, String, null: true
+    field :offer_type, String, null: true
+    field :other_fees_info, String, null: true
+    field :partner_info, String, null: true
+    field :photography_info, String, null: true
+    field :sale_date, String, null: true
+    field :sale_name, String, null: true
+    field :shipping_info, String, null: true
+    field :state, String, null: true
   end
 end

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -31,5 +31,14 @@ module Types
     field :user_id, String, null: false
     field :width, String, null: true
     field :year, String, null: true
+
+    field :offers, [Types::OfferType], null: false do
+      argument :gravity_partner_id, ID, required: true
+    end
+
+    def offers(gravity_partner_id:)
+      partner = Partner.find_by(gravity_partner_id: gravity_partner_id)
+      object.partner_submissions.find_by(partner: partner).offers
+    end
   end
 end

--- a/spec/requests/api/graphql/queries/submission_spec.rb
+++ b/spec/requests/api/graphql/queries/submission_spec.rb
@@ -120,13 +120,10 @@ describe 'submission query' do
         <<-GRAPHQL
         query {
           submission(#{query_inputs}) {
-            id,
-            artistId,
-            title
             offers(gravityPartnerId: "#{partner.gravity_partner_id}") {
               id
               state
-              commissionPercent
+              commissionPercentWhole
             }
           }
         }
@@ -142,8 +139,15 @@ describe 'submission query' do
         submission_response = body['data']['submission']
         offers_response = submission_response['offers']
         expect(offers_response.count).to eq 1
-        offer_response_id = offers_response.first['id']
-        expect(offer_response_id).to eq offer.id.to_s
+
+        offer_response = offers_response.first
+        expect(offer_response).to match(
+          {
+            'id' => offer.id.to_s,
+            'state' => offer.state,
+            'commissionPercentWhole' => offer.commission_percent_whole
+          }
+        )
       end
     end
   end

--- a/spec/requests/api/graphql/queries/submission_spec.rb
+++ b/spec/requests/api/graphql/queries/submission_spec.rb
@@ -125,6 +125,8 @@ describe 'submission query' do
             title
             offers(gravityPartnerId: "#{partner.gravity_partner_id}") {
               id
+              state
+              commissionPercent
             }
           }
         }


### PR DESCRIPTION
This PR adds the offers for a given partner to the submission query. I've also added a bunch of fields to the offer type so that I can properly consume it over on Volt.

This was an interesting exercise because I didn't know one could pass an argument to a field in a query. It seems obvious now in hindsight, but I assumed I'd have to pass that argument to the top-level query like I do the submission id and then use it some other way.

But nope, just have to pass it right where we're requesting the offers.

Note: I did add a spec that ensures one can not see the offers for another partner.

https://artsyproduct.atlassian.net/browse/CSGN-104