### PR TITLE
CSGN-114: Switch Category to String on Queries

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -291,7 +291,7 @@ type Submission {
   artistId: String!
   assets: [Asset]
   authenticityCertificate: Boolean
-  category: Category
+  category: String
   createdAt: ISO8601DateTime
   currency: String
   depth: String

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -8,7 +8,7 @@ module Types
     field :artist_id, String, null: false
     field :assets, [Types::AssetType, null: true], null: true
     field :authenticity_certificate, Boolean, null: true
-    field :category, Types::CategoryType, null: true
+    field :category, String, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: true
     field :currency, String, null: true
     field :depth, String, null: true

--- a/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
@@ -106,7 +106,7 @@ describe 'createConsignmentSubmission mutation' do
           'id' => be,
           # this ensures it's not nil
           'title' => 'soup',
-          'category' => 'JEWELRY',
+          'category' => 'Jewelry',
           'state' => 'REJECTED',
           'minimumPriceDollars' => 50_000,
           'currency' => 'GBP'

--- a/spec/requests/api/graphql/mutations/update_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/update_consignment_submission_spec.rb
@@ -137,7 +137,7 @@ describe 'updateConsignmentSubmission mutation' do
             'id' => submission.id.to_s,
             'title' => 'soup',
             'artistId' => 'andy-warhol',
-            'category' => 'JEWELRY',
+            'category' => 'Jewelry',
             'state' => 'DRAFT'
           }
         )


### PR DESCRIPTION
We ran into this situation where we were querying for submission information in Volt but rather than getting a simple string for category, we instead were getting an enum. My solution to this problem is to continue to accept the value as an enum in the mutation but to return it as a simple string in the submission type. This approach would require us to ensure that Eigen doesn't need the value of its mutation return, something that I would like to test locally.

https://artsyproduct.atlassian.net/browse/CSGN-114