### PR TITLE
Add console color gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'bootsnap', require: false # Speed up boot time by caching expensive operati
 gem 'bootstrap-sass' # required for watt
 gem 'bourbon', '4.2.3' # required for watt
 gem 'coffee-rails' # required for watt
+gem 'console_color'
 gem 'ddtrace'
 gem 'decent_exposure' # for safely referencing variables in views
 gem 'gemini_upload-rails' # for admins to upload images

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
+    console_color (0.0.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -468,6 +469,7 @@ DEPENDENCIES
   bourbon (= 4.2.3)
   capybara
   coffee-rails
+  console_color
   database_cleaner
   ddtrace
   decent_exposure


### PR DESCRIPTION
This PR just adds a gem that will color and give context to your Rails console prompt:

<img width="844" alt="Screen Shot 2020-04-03 at 9 56 47 AM" src="https://user-images.githubusercontent.com/79799/78374503-7ca33580-7591-11ea-8732-402f39b36fce.png">

Inspired by https://github.com/artsy/diffusion/pull/225 and @jpotts244. 🙌 