### PR TITLE
CSGN-126: Allow partners to see all submissions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,12 @@ inherit_from: .rubocop_todo.yml
 
 require: rubocop-rails
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Layout/AccessModifierIndentation:
   Enabled: false
 
@@ -23,10 +29,6 @@ Layout/BlockEndNewline:
 Layout/CaseIndentation:
   Enabled: false
 
-# Layout/ClassStructure
-
-# Layout/ClosingHeredocIndentation
-
 Layout/ClosingParenthesisIndentation:
   Enabled: false
 
@@ -44,14 +46,6 @@ Layout/DotPosition:
 
 Layout/ElseAlignment:
   Enabled: false
-
-# Layout/EmptyComment
-
-# Layout/EmptyLineAfterGuardClause
-
-# Layout/EmptyLineAfterMagicComment
-
-# Layout/EmptyLineBetweenDefs
 
 Layout/EmptyLines:
   Enabled: false
@@ -113,12 +107,8 @@ Layout/FirstMethodParameterLineBreak:
 Layout/FirstParameterIndentation:
   Enabled: false
 
-# Layout/HeredocArgumentClosingParenthesis
-
 Layout/HashAlignment:
   Enabled: false
-
-# Layout/HeredocIndentation
 
 Layout/IndentationConsistency:
   Enabled: false
@@ -132,8 +122,6 @@ Layout/InitialIndentation:
 Layout/LeadingEmptyLines:
   Enabled: false
 
-# Layout/LeadingCommentSpace
-
 Layout/MultilineArrayBraceLayout:
   Enabled: false
 
@@ -145,7 +133,6 @@ Layout/MultilineAssignmentLayout:
 
 Layout/MultilineBlockLayout:
   Enabled: false
-
 
 Layout/MultilineHashBraceLayout:
   Enabled: false

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -28,6 +28,10 @@ class BaseResolver
     @context[:current_user_roles].include?(:user)
   end
 
+  def partner?
+    @context[:current_user_roles].include?(:partner)
+  end
+
   def admin?
     @context[:current_user_roles].include?(:admin)
   end

--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -2,7 +2,9 @@
 
 class SubmissionsResolver < BaseResolver
   AllSubmissionsError =
-    GraphQL::ExecutionError.new('Only Admins can look at all submissions.')
+    GraphQL::ExecutionError.new(
+      'Only Admins and Partners can look at all submissions.'
+    )
 
   UserMismatchError =
     GraphQL::ExecutionError.new(
@@ -27,7 +29,7 @@ class SubmissionsResolver < BaseResolver
   def compute_error
     if @arguments.key?(:ids)
       BadArgumentError
-    elsif return_all_submissions?
+    elsif return_all_submissions? && !partner?
       AllSubmissionsError
     elsif user_mismatch?
       UserMismatchError

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -31,7 +31,7 @@ module Types
       end
     end
 
-    def submissions(arguments)
+    def submissions(arguments = {})
       query_options = { arguments: arguments, context: context, object: object }
       resolver = SubmissionsResolver.new(query_options)
       raise resolver.error unless resolver.valid?

--- a/spec/requests/api/graphql/queries/submissions_spec.rb
+++ b/spec/requests/api/graphql/queries/submissions_spec.rb
@@ -118,6 +118,39 @@ describe 'submissions query' do
       end
     end
 
+    context 'with a request from a partner' do
+      let(:token) do
+        payload = { aud: 'gravity', sub: 'userid', roles: 'partner' }
+        JWT.encode(payload, Convection.config.jwt_secret)
+      end
+
+      let(:query) do
+        <<-GRAPHQL
+        query {
+          submissions {
+            edges {
+              node {
+                id,
+                artistId,
+                title
+              }
+            }
+          }
+        }
+        GRAPHQL
+      end
+
+      it 'returns all submissions' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        submissions_response = body['data']['submissions']
+        expect(submissions_response['edges'].count).to eq 1
+      end
+    end
+
     context 'when asking for only available submissions' do
       let!(:submitted_submission) { Fabricate :submission, state: 'submitted' }
       let!(:approved_submission) { Fabricate :submission, state: 'approved' }


### PR DESCRIPTION
This PR fixes a bug where only admin users were able to see all submissions as documented in this bug:

https://artsyproduct.atlassian.net/browse/CSGN-126

So my approach here is to take a look at the roles of the user and if they are a partner, allow them to see all submissions.

Note: there's some unrelated diff here where the RuboCop setup needed some tweaks that I hadn't noticed before in order to suppress some warnings.