### PR TITLE
CSGN-129: Allow partners to query for submission

### DIFF
--- a/app/graphql/resolvers/submission_resolver.rb
+++ b/app/graphql/resolvers/submission_resolver.rb
@@ -8,7 +8,7 @@ class SubmissionResolver < BaseResolver
       @error = bad_argument_error
     end
 
-    admin?
+    admin? || partner?
   end
 
   def run

--- a/spec/requests/api/graphql/queries/submission_spec.rb
+++ b/spec/requests/api/graphql/queries/submission_spec.rb
@@ -103,6 +103,29 @@ describe 'submission query' do
       end
     end
 
+    context 'with a valid submission id from a partner' do
+      let(:token) do
+        payload = { aud: 'gravity', sub: 'userid', roles: 'partner' }
+        JWT.encode(payload, Convection.config.jwt_secret)
+      end
+
+      it 'returns that submission' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        submission_response = body['data']['submission']
+        expect(submission_response).to match(
+          {
+            'id' => submission.id.to_s,
+            'artistId' => submission.artist_id,
+            'title' => submission.title
+          }
+        )
+      end
+    end
+
     context 'including offers' do
       let(:partner) { Fabricate :partner }
       let(:partner_submission) do


### PR DESCRIPTION
When I was fixing the list page I should have clicked on one of them to ensure that the detail page wasn't broken but I was going too fast and didn't do it. This PR fixes that mistake by allowing partners to query for individual submissions too.

Once I had that working, I made sure that the other flows of viewing an offer or making one both worked too, so hopefully this means that we're done with the bugs of not checking with a regular user!

https://artsyproduct.atlassian.net/browse/CSGN-129