### PR TITLE
CSGN-141: Support publishing of submissions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,11 +21,13 @@ Metrics/AbcSize:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 411
+  Exclude:
+    - 'spec/**/*'
 
 # Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 172
+  Max: 100000
 
 # Offense count: 1
 Metrics/CyclomaticComplexity:

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -16,6 +16,7 @@ class StateActions
     actions << approve_action if submission.submitted?
     actions << publish_action if submission.submitted? || submission.approved?
     actions << reject_action if submission.submitted?
+    actions << close_action if submission.submitted?
     actions
   end
 
@@ -54,6 +55,15 @@ class StateActions
       text: 'Reject'
     }
   end
+
+  def close_action
+    {
+      class: default_classes << 'btn-delete',
+      confirm: 'No email will be sent.',
+      state: 'closed',
+      text: 'Close'
+    }
+  end
 end
 
 module Admin
@@ -68,6 +78,7 @@ module Admin
                     undo_approval
                     undo_publish
                     undo_rejection
+                    undo_close
                   ]
 
     expose(:submissions) do
@@ -182,6 +193,11 @@ module Admin
 
     def undo_rejection
       SubmissionService.undo_rejection(@submission)
+      redirect_to admin_submission_path(@submission)
+    end
+
+    def undo_close
+      SubmissionService.undo_close(@submission)
       redirect_to admin_submission_path(@submission)
     end
 

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -1,5 +1,61 @@
 # frozen_string_literal: true
 
+class StateActions
+  def self.for(submission)
+    new(submission).run
+  end
+
+  attr_reader :submission
+
+  def initialize(submission)
+    @submission = submission
+  end
+
+  def run
+    actions = []
+    actions << approve_action if submission.submitted?
+    actions << publish_action if submission.submitted? || submission.approved?
+    actions << reject_action if submission.submitted?
+    actions
+  end
+
+  private
+
+  def default_classes
+    ['btn btn-secondary btn-small btn-full-width']
+  end
+
+  def approve_action
+    {
+      class: default_classes << 'btn-approve',
+      confirm:
+        'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.',
+      state: 'approved',
+      text: 'Approve (convection only)'
+    }
+  end
+
+  def publish_action
+    {
+      class: default_classes << 'btn-approve',
+      confirm:
+        'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.',
+      state: 'published',
+      text: 'Publish (CMS + digest)'
+    }
+  end
+
+  def reject_action
+    {
+      class: default_classes << 'btn-delete',
+      confirm:
+        'An email will be sent to the consignor, letting them know that we are not accepting their submission. This action cannot be undone.',
+      state: 'rejected',
+      text: 'Reject'
+    }
+  end
+end
+
 module Admin
   class SubmissionsController < ApplicationController
     include GraphqlHelper
@@ -88,6 +144,7 @@ module Admin
       @partner_submissions_count =
         notified_partner_submissions.group_by_day.count
       @offers = @submission.offers
+      @actions = StateActions.for(@submission)
     end
 
     def edit; end

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -1,71 +1,5 @@
 # frozen_string_literal: true
 
-class StateActions
-  def self.for(submission)
-    new(submission).run
-  end
-
-  attr_reader :submission
-
-  def initialize(submission)
-    @submission = submission
-  end
-
-  def run
-    actions = []
-    actions << approve_action if submission.submitted?
-    actions << publish_action if submission.submitted? || submission.approved?
-    actions << reject_action if submission.submitted?
-    actions << close_action if submission.submitted?
-    actions
-  end
-
-  private
-
-  def default_classes
-    ['btn btn-secondary btn-small btn-full-width']
-  end
-
-  def approve_action
-    {
-      class: default_classes << 'btn-approve',
-      confirm:
-        'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.',
-      state: 'approved',
-      text: 'Approve (convection only)'
-    }
-  end
-
-  def publish_action
-    {
-      class: default_classes << 'btn-approve',
-      confirm:
-        'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.',
-      state: 'published',
-      text: 'Publish (CMS + digest)'
-    }
-  end
-
-  def reject_action
-    {
-      class: default_classes << 'btn-delete',
-      confirm:
-        'An email will be sent to the consignor, letting them know that we are not accepting their submission. This action cannot be undone.',
-      state: 'rejected',
-      text: 'Reject'
-    }
-  end
-
-  def close_action
-    {
-      class: default_classes << 'btn-delete',
-      confirm: 'No email will be sent.',
-      state: 'closed',
-      text: 'Close'
-    }
-  end
-end
-
 module Admin
   class SubmissionsController < ApplicationController
     include GraphqlHelper
@@ -155,7 +89,7 @@ module Admin
       @partner_submissions_count =
         notified_partner_submissions.group_by_day.count
       @offers = @submission.offers
-      @actions = StateActions.for(@submission)
+      @actions = SubmissionStateActions.for(@submission)
     end
 
     def edit; end

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -5,7 +5,14 @@ module Admin
     include GraphqlHelper
 
     before_action :set_submission,
-                  only: %i[show edit update undo_approval undo_rejection]
+                  only: %i[
+                    show
+                    edit
+                    update
+                    undo_approval
+                    undo_publish
+                    undo_rejection
+                  ]
 
     expose(:submissions) do
       matching_submissions = Submission.not_deleted
@@ -86,12 +93,11 @@ module Admin
     def edit; end
 
     def update
-      hide_from_partners = params[:hide_from_partners] == 'true'
       result =
         SubmissionService.update_submission(
           @submission,
           submission_params,
-          current_user: @current_user, hide_from_partners: hide_from_partners
+          current_user: @current_user
         )
 
       if result
@@ -103,6 +109,14 @@ module Admin
 
     def undo_approval
       SubmissionService.undo_approval(@submission)
+      redirect_to admin_submission_path(@submission)
+    rescue SubmissionService::SubmissionError => e
+      flash[:error] = e.message
+      redirect_to admin_submission_path(@submission)
+    end
+
+    def undo_publish
+      SubmissionService.undo_publish(@submission)
       redirect_to admin_submission_path(@submission)
     rescue SubmissionService::SubmissionError => e
       flash[:error] = e.message

--- a/app/events/submission_event.rb
+++ b/app/events/submission_event.rb
@@ -2,7 +2,12 @@
 
 class SubmissionEvent < Events::BaseEvent
   TOPIC = 'consignments'
-  ACTIONS = [SUBMITTED = 'submitted', APPROVED = 'approved'].freeze
+
+  ACTIONS = [
+    APPROVED = 'approved',
+    PUBLISHED = 'published',
+    SUBMITTED = 'submitted'
+  ].freeze
 
   def object
     { id: @object.id, display: "#{@object.id} (#{@object.state})" }

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -44,7 +44,7 @@ module SubmissionsHelper
   end
 
   def reviewer_byline(submission)
-    if submission.approved?
+    if submission.approved? || submission.published?
       "Approved by #{submission.reviewed_by_user.try(:name)}"
     elsif submission.rejected?
       "Rejected by #{submission.reviewed_by_user.try(:name)}"

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -17,6 +17,7 @@ class Submission < ApplicationRecord
     DRAFT = 'draft',
     SUBMITTED = 'submitted',
     APPROVED = 'approved',
+    PUBLISHED = 'published',
     REJECTED = 'rejected'
   ].freeze
 
@@ -71,7 +72,7 @@ class Submission < ApplicationRecord
   scope :draft, -> { where(state: 'draft') }
   scope :submitted, -> { where(state: 'submitted') }
   scope :available,
-        -> { where(state: APPROVED, consigned_partner_submission_id: nil) }
+        -> { where(state: PUBLISHED, consigned_partner_submission_id: nil) }
 
   dollarize :minimum_price_cents
 
@@ -110,7 +111,7 @@ class Submission < ApplicationRecord
   end
 
   def reviewed?
-    approved? || rejected?
+    approved? || published? || rejected?
   end
 
   def ready?

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -18,7 +18,8 @@ class Submission < ApplicationRecord
     SUBMITTED = 'submitted',
     APPROVED = 'approved',
     PUBLISHED = 'published',
-    REJECTED = 'rejected'
+    REJECTED = 'rejected',
+    CLOSED = 'closed'
   ].freeze
 
   DIMENSION_METRICS = %w[in cm].freeze
@@ -111,7 +112,7 @@ class Submission < ApplicationRecord
   end
 
   def reviewed?
-    approved? || published? || rejected?
+    approved? || published? || rejected? || closed?
   end
 
   def ready?

--- a/app/models/submission_state_actions.rb
+++ b/app/models/submission_state_actions.rb
@@ -30,7 +30,7 @@ class SubmissionStateActions
     {
       class: default_classes << 'btn-approve',
       confirm:
-        'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.',
+        'No email will be sent to the consignor and this submission will be excluded from the digests.',
       state: 'approved',
       text: 'Approve (convection only)'
     }
@@ -65,4 +65,3 @@ class SubmissionStateActions
     }
   end
 end
-

--- a/app/models/submission_state_actions.rb
+++ b/app/models/submission_state_actions.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class SubmissionStateActions
+  def self.for(submission)
+    new(submission).run
+  end
+
+  attr_reader :submission
+
+  def initialize(submission)
+    @submission = submission
+  end
+
+  def run
+    actions = []
+    actions << approve_action if submission.submitted?
+    actions << publish_action if submission.submitted? || submission.approved?
+    actions << reject_action if submission.submitted?
+    actions << close_action if submission.submitted?
+    actions
+  end
+
+  private
+
+  def default_classes
+    ['btn btn-secondary btn-small btn-full-width']
+  end
+
+  def approve_action
+    {
+      class: default_classes << 'btn-approve',
+      confirm:
+        'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.',
+      state: 'approved',
+      text: 'Approve (convection only)'
+    }
+  end
+
+  def publish_action
+    {
+      class: default_classes << 'btn-approve',
+      confirm:
+        'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.',
+      state: 'published',
+      text: 'Publish (CMS + digest)'
+    }
+  end
+
+  def reject_action
+    {
+      class: default_classes << 'btn-delete',
+      confirm:
+        'An email will be sent to the consignor, letting them know that we are not accepting their submission. This action cannot be undone.',
+      state: 'rejected',
+      text: 'Reject'
+    }
+  end
+
+  def close_action
+    {
+      class: default_classes << 'btn-delete',
+      confirm: 'No email will be sent.',
+      state: 'closed',
+      text: 'Close'
+    }
+  end
+end
+

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -63,7 +63,8 @@ class OfferService
     end
 
     def consign!(offer)
-      unless offer.submission.state == Submission::APPROVED
+      consignable_states = [Submission::APPROVED, Submission::PUBLISHED]
+      unless consignable_states.include?(offer.submission.state)
         raise OfferError,
               'Cannot complete consignment on non-approved submission'
       end

--- a/app/services/partner_submission_service.rb
+++ b/app/services/partner_submission_service.rb
@@ -11,7 +11,9 @@ class PartnerSubmissionService
     def deliver_digest(partner_id)
       partner = Partner.find(partner_id)
       partner_submissions = partner.partner_submissions.where(notified_at: nil)
-      submissions = Submission.find(partner_submissions.pluck(:submission_id))
+      ids = partner_submissions.pluck(:submission_id)
+      submissions = Submission.where(state: Submission::PUBLISHED, id: ids)
+
       if submissions.empty?
         Rails.logger.info "Skipping digest for #{partner_id}... no submissions."
         return
@@ -81,7 +83,7 @@ class PartnerSubmissionService
     end
 
     def generate_for_new_partner(partner)
-      Submission.where(state: 'approved').each do |submission|
+      Submission.where(state: 'published').each do |submission|
         partner.partner_submissions.find_or_create_by!(
           submission_id: submission.id
         )

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -33,6 +33,8 @@ class SubmissionService
         publish!(submission, current_user)
       when 'rejected'
         reject!(submission, current_user)
+      when 'closed'
+        close!(submission)
       end
     end
 
@@ -57,6 +59,10 @@ class SubmissionService
     end
 
     def undo_rejection(submission)
+      return_to_submitted_state(submission)
+    end
+
+    def undo_close(submission)
       return_to_submitted_state(submission)
     end
 
@@ -107,6 +113,10 @@ class SubmissionService
     def reject!(submission, current_user)
       submission.update!(rejected_by: current_user, rejected_at: Time.now.utc)
       delay.deliver_rejection_notification(submission.id)
+    end
+
+    def close!(submission)
+      # noop
     end
 
     def notify_admin(submission_id)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -15,22 +15,22 @@ class SubmissionService
       raise SubmissionError, e.message
     end
 
-    def update_submission(
-      submission, params, current_user: nil, hide_from_partners: false
-    )
+    def update_submission(submission, params, current_user: nil)
       submission.assign_attributes(params)
       if submission.state_changed?
-        update_submission_state(submission, current_user, hide_from_partners)
+        update_submission_state(submission, current_user)
       end
       submission.save!
     end
 
-    def update_submission_state(submission, current_user, hide_from_partners)
+    def update_submission_state(submission, current_user)
       case submission.state
       when 'submitted'
         submit!(submission)
       when 'approved'
-        approve!(submission, current_user, hide_from_partners)
+        approve!(submission, current_user)
+      when 'published'
+        publish!(submission, current_user)
       when 'rejected'
         reject!(submission, current_user)
       end
@@ -40,6 +40,16 @@ class SubmissionService
       if submission.offers.count.positive?
         raise SubmissionError,
               'Undoing approval of a submission with offers is not allowed!'
+      end
+
+      return_to_submitted_state(submission)
+      submission.partner_submissions.each(&:destroy)
+    end
+
+    def undo_publish(submission)
+      if submission.offers.count.positive?
+        raise SubmissionError,
+              'Undoing publish of a submission with offers is not allowed!'
       end
 
       return_to_submitted_state(submission)
@@ -75,17 +85,23 @@ class SubmissionService
         .notify_user(submission.id)
     end
 
-    def approve!(submission, current_user, hide_from_partners)
+    def approve!(submission, current_user)
       submission.update!(approved_by: current_user, approved_at: Time.now.utc)
       NotificationService.delay.post_submission_event(
         submission.id,
         SubmissionEvent::APPROVED
       )
+    end
 
-      unless hide_from_partners
-        delay.deliver_approval_notification(submission.id)
-        PartnerSubmissionService.delay.generate_for_all_partners(submission.id)
-      end
+    def publish!(submission, current_user)
+      submission.update!(approved_by: current_user, approved_at: Time.now.utc)
+      NotificationService.delay.post_submission_event(
+        submission.id,
+        SubmissionEvent::PUBLISHED
+      )
+
+      delay.deliver_approval_notification(submission.id)
+      PartnerSubmissionService.delay.generate_for_all_partners(submission.id)
     end
 
     def reject!(submission, current_user)

--- a/app/views/admin/submissions/_state_actions.html.erb
+++ b/app/views/admin/submissions/_state_actions.html.erb
@@ -1,6 +1,19 @@
 <% if @submission.approved? %>
   <div class='overview-section'>
-      <%= link_to 'Create Offer', new_step_0_admin_offers_path(submission_id: @submission.id), class: 'btn btn-primary btn-small btn-full-width' %>
+    <%= link_to 'Create Offer', new_step_0_admin_offers_path(submission_id: @submission.id), class: 'btn btn-primary btn-small btn-full-width' %>
+    <div class='single-padding-top'>
+      <%= link_to('Publish (CMS + digest)',
+                  admin_submission_path(@submission, submission: { state: 'published' }),
+                  method: :put,
+                  class: 'btn btn-secondary btn-approve btn-small btn-full-width',
+                  data: { confirm: 'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.' }) %>
+    </div>
+  </div>
+<% end %>
+
+<% if @submission.published? %>
+  <div class='overview-section'>
+    <%= link_to 'Create Offer', new_step_0_admin_offers_path(submission_id: @submission.id), class: 'btn btn-primary btn-small btn-full-width' %>
   </div>
 <% end %>
 
@@ -8,18 +21,18 @@
   <div class='overview-section'>
     <div class='bold-label'>Internal Approval</div>
     <div class='single-padding-top'>
-      <%= link_to('Approve without digest',
-                  admin_submission_path(@submission, submission: { state: 'approved' }, hide_from_partners: 'true'),
+      <%= link_to('Approve (convection only)',
+                  admin_submission_path(@submission, submission: { state: 'approved' }),
                   method: :put,
                   class: 'btn btn-secondary btn-approve btn-small btn-full-width',
-                  data: { confirm: 'No email will be sent to the consignor and this submission will be excluded from the digests.' }) %>
+                  data: { confirm: 'No email will be sent to the consignor and this submission will be excluded from both the digests and CMS.' }) %>
     </div>
     <div class='single-padding-top'>
-      <%= link_to('Approve',
-                  admin_submission_path(@submission, submission: { state: 'approved' }, hide_from_partners: 'false'),
+      <%= link_to('Publish (CMS + digest)',
+                  admin_submission_path(@submission, submission: { state: 'published' }),
                   method: :put,
                   class: 'btn btn-secondary btn-approve btn-small btn-full-width',
-                  data: { confirm: 'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network. This action cannot be undone.' }) %>
+                  data: { confirm: 'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.' }) %>
     </div>
     <div class='single-padding-top'>
       <%= link_to('Reject',

--- a/app/views/admin/submissions/_state_actions.html.erb
+++ b/app/views/admin/submissions/_state_actions.html.erb
@@ -1,52 +1,16 @@
-<% if @submission.approved? %>
-  <div class='overview-section'>
-    <%= link_to 'Create Offer', new_step_0_admin_offers_path(submission_id: @submission.id), class: 'btn btn-primary btn-small btn-full-width' %>
-    <div class='single-padding-top'>
-      <%= link_to('Publish (CMS + digest)',
-                  admin_submission_path(@submission, submission: { state: 'published' }),
-                  method: :put,
-                  class: 'btn btn-secondary btn-approve btn-small btn-full-width',
-                  data: { confirm: 'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.' }) %>
-    </div>
-  </div>
-<% end %>
-
-<% if @submission.published? %>
-  <div class='overview-section'>
-    <%= link_to 'Create Offer', new_step_0_admin_offers_path(submission_id: @submission.id), class: 'btn btn-primary btn-small btn-full-width' %>
-  </div>
-<% end %>
-
-<% if @submission.submitted? %>
-  <div class='overview-section'>
-    <div class='bold-label'>Internal Approval</div>
-    <div class='single-padding-top'>
-      <%= link_to('Approve (convection only)',
-                  admin_submission_path(@submission, submission: { state: 'approved' }),
-                  method: :put,
-                  class: 'btn btn-secondary btn-approve btn-small btn-full-width',
-                  data: { confirm: 'No email will be sent to the consignor and this submission will be excluded from both the digests and CMS.' }) %>
-    </div>
-    <div class='single-padding-top'>
-      <%= link_to('Publish (CMS + digest)',
-                  admin_submission_path(@submission, submission: { state: 'published' }),
-                  method: :put,
-                  class: 'btn btn-secondary btn-approve btn-small btn-full-width',
-                  data: { confirm: 'An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.' }) %>
-    </div>
-    <div class='single-padding-top'>
-      <%= link_to('Reject',
-                  admin_submission_path(@submission, submission: { state: 'rejected' }),
-                  method: :put,
-                  class: 'btn btn-secondary btn-delete btn-small btn-full-width',
-                  data: { confirm: 'An email will be sent to the consignor, letting them know that we are not accepting their submission. This action cannot be undone.' }) %>
-    </div>
-  </div>
-<% elsif @submission.reviewed? %>
-  <div class='overview-section'>
-    <div class='bold-label'>Internal Approval</div>
-    <div class='single-padding-top'>
-      <%= reviewer_byline(@submission) %>
-    </div>
-  </div>
-<% end %>
+<div class='overview-section'>
+  <div class='bold-label'>Actions</div>
+    <% if @submission.approved? || @submission.published? %>
+      <%= link_to 'Create Offer', new_step_0_admin_offers_path(submission_id: @submission.id), class: 'btn btn-primary btn-small btn-full-width' %>
+    <% end %>
+    <% @actions.each do |action| %>
+      <div class='single-padding-top'>
+        <%= link_to(action[:text], admin_submission_path(@submission, submission: { state: action[:state] }), method: :put, class: action[:class], data: { confirm: action[:confirm] }) %>
+      </div>
+    <% end %>
+    <% if @submission.reviewed? %>
+      <div class='single-padding-top'>
+          <%= reviewer_byline(@submission) %>
+      </div>
+    <% end %>
+</div>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -62,6 +62,9 @@
               <% if @submission.state == Submission::REJECTED %>
                 <%= link_to 'Undo rejection', undo_rejection_admin_submission_path(@submission), method: :put, class: 'sidebar-link' %>
               <% end %>
+              <% if @submission.state == Submission::CLOSED %>
+                <%= link_to 'Undo close', undo_close_admin_submission_path(@submission), method: :put, class: 'sidebar-link' %>
+              <% end %>
             </div>
           </div>
           <%= render 'collector_info', submission: @submission %>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -56,6 +56,9 @@
               <% if @submission.state == Submission::APPROVED %>
                 <%= link_to 'Undo approval', undo_approval_admin_submission_path(@submission), method: :put, class: 'sidebar-link' %>
               <% end %>
+              <% if @submission.state == Submission::PUBLISHED %>
+                <%= link_to 'Undo publish', undo_publish_admin_submission_path(@submission), method: :put, class: 'sidebar-link' %>
+              <% end %>
               <% if @submission.state == Submission::REJECTED %>
                 <%= link_to 'Undo rejection', undo_rejection_admin_submission_path(@submission), method: :put, class: 'sidebar-link' %>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     resources :submissions do
       member do
         put 'undo_approval'
+        put 'undo_publish'
         put 'undo_rejection'
       end
       resources :assets do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
         put 'undo_approval'
         put 'undo_publish'
         put 'undo_rejection'
+        put 'undo_close'
       end
       resources :assets do
         post :multiple, on: :collection

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -35,22 +35,23 @@ describe Submission do
     end
 
     describe 'available' do
-      it 'returns only approved submissions without an accepted offer' do
-        consigned_submission = Fabricate(:submission, state: 'approved')
+      it 'returns only published submissions without an accepted offer' do
+        consigned_submission = Fabricate(:submission, state: 'published')
         partner_submission =
           Fabricate(:partner_submission, submission: consigned_submission)
         offer = Fabricate(:offer, partner_submission: partner_submission)
 
         OfferService.consign!(offer)
 
-        approved_submission = Fabricate(:submission, state: 'approved')
+        Fabricate(:submission, state: 'approved')
+        published_submission = Fabricate(:submission, state: 'published')
         Fabricate(:submission, state: 'rejected')
         Fabricate(:submission, state: 'draft')
         Fabricate(:submission, state: 'submitted')
 
         available_submissions = Submission.available
         expect(available_submissions.count).to eq(1)
-        expect(available_submissions.first).to eq(approved_submission)
+        expect(available_submissions.first).to eq(published_submission)
       end
     end
   end

--- a/spec/models/submission_state_actions_spec.rb
+++ b/spec/models/submission_state_actions_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SubmissionStateActions do
+  let(:submission) { Fabricate :submission, state: state }
+
+  context 'with a draft submission' do
+    let(:state) { 'draft' }
+
+    it 'returns an empty array of actions' do
+      actions = SubmissionStateActions.for(submission)
+      expect(actions).to eq []
+    end
+  end
+
+  context 'with a submitted submission' do
+    let(:state) { 'submitted' }
+
+    it 'returns approve, publish, reject and close actions' do
+      actions = SubmissionStateActions.for(submission)
+      states = actions.map { |action| action[:state] }
+      expect(states).to eq %w[approved published rejected closed]
+    end
+  end
+
+  context 'with an approved submission' do
+    let(:state) { 'approved' }
+
+    it 'returns the publish action' do
+      actions = SubmissionStateActions.for(submission)
+      states = actions.map { |action| action[:state] }
+      expect(states).to eq %w[published]
+    end
+  end
+
+  context 'with a published submission' do
+    let(:state) { 'published' }
+
+    it 'returns an empty array of actions' do
+      actions = SubmissionStateActions.for(submission)
+      expect(actions).to eq []
+    end
+  end
+
+  context 'with a rejected submission' do
+    let(:state) { 'rejected' }
+
+    it 'returns an empty array of actions' do
+      actions = SubmissionStateActions.for(submission)
+      expect(actions).to eq []
+    end
+  end
+
+  context 'with a closed submission' do
+    let(:state) { 'closed' }
+
+    it 'returns an empty array of actions' do
+      actions = SubmissionStateActions.for(submission)
+      expect(actions).to eq []
+    end
+  end
+end

--- a/spec/requests/api/graphql/queries/submissions_spec.rb
+++ b/spec/requests/api/graphql/queries/submissions_spec.rb
@@ -154,12 +154,13 @@ describe 'submissions query' do
     context 'when asking for only available submissions' do
       let!(:submitted_submission) { Fabricate :submission, state: 'submitted' }
       let!(:approved_submission) { Fabricate :submission, state: 'approved' }
+      let!(:published_submission) { Fabricate :submission, state: 'published' }
 
       let(:partner_submission) { Fabricate :partner_submission }
 
       let!(:consigned_submission) do
         Fabricate :submission,
-                  state: 'approved',
+                  state: 'published',
                   consigned_partner_submission_id: partner_submission.id
       end
 
@@ -175,7 +176,7 @@ describe 'submissions query' do
         expect(submissions_response['edges'].count).to eq 1
 
         ids = submissions_response['edges'].map { |edge| edge['node']['id'] }
-        expect(ids).to eq [approved_submission.id.to_s]
+        expect(ids).to eq [published_submission.id.to_s]
       end
     end
 

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -25,7 +25,7 @@ describe PartnerSubmissionService do
 
   describe '#generate_for_new_partner' do
     it 'generates partner submissions if the partner has no existing partner submissions' do
-      submission = Fabricate(:submission, state: 'approved')
+      submission = Fabricate(:submission, state: 'published')
       Fabricate(:submission, state: 'submitted')
       partner = Fabricate(:partner)
       PartnerSubmissionService.generate_for_new_partner(partner)
@@ -44,13 +44,12 @@ describe PartnerSubmissionService do
         )
       expect(NotificationService).to receive(:post_submission_event).once.with(
         submission.id,
-        'approved'
+        'published'
       )
-      SubmissionService.update_submission(submission, state: 'approved')
-      expect(
-        PartnerSubmission.where(submission: submission, partner: partner).count
-      ).to eq 1
-      Fabricate(:submission, state: 'approved')
+      SubmissionService.update_submission(submission, state: 'published')
+      expect(partner.partner_submissions.count).to eq 1
+      expect(partner.partner_submissions.first.submission).to eq submission
+      Fabricate(:submission, state: 'published')
       PartnerSubmissionService.generate_for_new_partner(partner)
       expect(partner.partner_submissions.count).to eq 2
     end
@@ -108,8 +107,8 @@ describe PartnerSubmissionService do
             currency: 'USD'
           )
         expect(NotificationService).to receive(:post_submission_event).once
-          .with(@approved1.id, 'approved')
-        SubmissionService.update_submission(@approved1, state: 'approved')
+          .with(@approved1.id, 'published')
+        SubmissionService.update_submission(@approved1, state: 'published')
         PartnerSubmissionService.daily_digest
         @email = ActionMailer::Base.deliveries.last
       end
@@ -133,8 +132,8 @@ describe PartnerSubmissionService do
             year: '1992'
           )
         expect(NotificationService).to receive(:post_submission_event).once
-          .with(@approved1.id, 'approved')
-        SubmissionService.update_submission(@approved1, state: 'approved')
+          .with(@approved1.id, 'published')
+        SubmissionService.update_submission(@approved1, state: 'published')
       end
 
       it 'does not display any min price-related text' do
@@ -177,14 +176,14 @@ describe PartnerSubmissionService do
           )
         Fabricate(:submission, state: 'rejected')
         expect(NotificationService).to receive(:post_submission_event).once
-          .with(@approved1.id, 'approved')
+          .with(@approved1.id, 'published')
         expect(NotificationService).to receive(:post_submission_event).once
-          .with(@approved2.id, 'approved')
+          .with(@approved2.id, 'published')
         expect(NotificationService).to receive(:post_submission_event).once
-          .with(@approved3.id, 'approved')
-        SubmissionService.update_submission(@approved1, state: 'approved')
-        SubmissionService.update_submission(@approved2, state: 'approved')
-        SubmissionService.update_submission(@approved3, state: 'approved')
+          .with(@approved3.id, 'published')
+        SubmissionService.update_submission(@approved1, state: 'published')
+        SubmissionService.update_submission(@approved2, state: 'published')
+        SubmissionService.update_submission(@approved3, state: 'published')
         ActionMailer::Base.deliveries = []
         expect(@partner.partner_submissions.count).to eq 3
       end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -136,7 +136,7 @@ describe SubmissionService do
       expect(submission.rejected_at).to be_nil
     end
 
-    it 'generates partner submissions on an approval' do
+    it 'does not generate partner submissions on an approval' do
       allow(NotificationService).to receive(:post_submission_event)
       partner1 = Fabricate(:partner, gravity_partner_id: 'partner1')
       partner2 = Fabricate(:partner, gravity_partner_id: 'partner2')


### PR DESCRIPTION
This PR addresses a few tickets by introducing a couple new states for submission:

https://artsyproduct.atlassian.net/browse/CSGN-141
https://artsyproduct.atlassian.net/browse/CSGN-142

What was discovered through QA is that we were showing all approved submissions to partners in CMS, but we don't always want to do this. Sometimes we approve a submission and then want to share it with partners in a customized way.

To support this, we've added a state called 'published' and then updated the definition of what the available scope means to only include published submissions. This means we have complete control over which submissions show to our partners.

But then the flip side of this is that we'll want to be able to take down submissions so we've also added a 'closed' state. Moving a submission to this state will exclude it from CMS.

Note: while we were at it, we clarified that approval does NOT add the work to the daily digest either.

Ok time for some screenshots!!

<details>

<img width="1170" alt="Screen Shot 2020-04-14 at 3 20 32 PM" src="https://user-images.githubusercontent.com/79799/79270428-caf2e700-7e63-11ea-9c2d-1e0855798a49.png">
<img width="1170" alt="Screen Shot 2020-04-14 at 3 20 36 PM" src="https://user-images.githubusercontent.com/79799/79270438-cdedd780-7e63-11ea-9893-38c35d481504.png">
<img width="1170" alt="Screen Shot 2020-04-14 at 3 20 40 PM" src="https://user-images.githubusercontent.com/79799/79270439-cf1f0480-7e63-11ea-947e-5d17ff0c36ae.png">
<img width="1170" alt="Screen Shot 2020-04-14 at 3 20 44 PM" src="https://user-images.githubusercontent.com/79799/79270443-cfb79b00-7e63-11ea-8feb-6988bcdc911c.png">
<img width="1170" alt="Screen Shot 2020-04-14 at 3 20 58 PM" src="https://user-images.githubusercontent.com/79799/79270444-d0e8c800-7e63-11ea-8b51-d653d86c4c62.png">
<img width="1170" alt="Screen Shot 2020-04-14 at 3 21 15 PM" src="https://user-images.githubusercontent.com/79799/79270446-d1815e80-7e63-11ea-8c1d-8e3449cbd721.png">

</details>

To QA this what I did was take a submitted submission and publish/undo then close/undo to see that it went through the right state changes.