### PR TITLE
Don't update prior approval info

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -100,7 +100,10 @@ class SubmissionService
     end
 
     def publish!(submission, current_user)
-      submission.update!(approved_by: current_user, approved_at: Time.now.utc)
+      unless submission.approved_at
+        submission.update!(approved_by: current_user, approved_at: Time.now.utc)
+      end
+
       NotificationService.delay.post_submission_event(
         submission.id,
         SubmissionEvent::PUBLISHED

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -171,6 +171,19 @@ describe SubmissionService do
       expect(partner2.partner_submissions.first.notified_at).to be_nil
     end
 
+    it 'does not update already approved submissions on publish' do
+      allow(NotificationService).to receive(:post_submission_event)
+      approved_at = 1.day.ago.beginning_of_day
+      submission.update!(state: 'approved', approved_at: approved_at)
+      SubmissionService.update_submission(
+        submission,
+        { state: 'published' },
+        current_user: 'userid'
+      )
+
+      expect(submission.reload.approved_at).to eq approved_at
+    end
+
     it 'sends a rejection notification if the submission state is changed to rejected' do
       SubmissionService.update_submission(
         submission,


### PR DESCRIPTION
While working on adding publishing to convection I made a mistake and did not guard that prior approval info should be maintained. This PR fixes that mistake by adding a test that asserts that the prior info stays put and then the addition of a guard to that update.