### PR TITLE
CSGN-163: Add primary image to GraphQL API

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -344,6 +344,7 @@ type Submission {
   medium: String
   minimumPriceDollars: Int
   offers(gravityPartnerId: ID!): [Offer!]!
+  primaryImage: Asset
   provenance: String
   signature: Boolean
   state: State

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -24,6 +24,7 @@ module Types
     field :location_state, String, null: true
     field :medium, String, null: true
     field :minimum_price_dollars, Integer, null: true
+    field :primary_image, Types::AssetType, null: true
     field :provenance, String, null: true
     field :signature, Boolean, null: true
     field :state, Types::StateType, null: true


### PR DESCRIPTION
TIL that there's a concept in Convection called primary image! This can be picked from the submission detail page and so then this PR just exposes that field in the GraphQL API. This will then bubble up to Volt where we can check for the existence of this object and run that image rather than one from the assets array.

Note: you gotta love adding almost 100 lines of tests for a single line change in the codebase, haha. 🤣 

https://artsyproduct.atlassian.net/browse/CSGN-163

Co-authored-by: @pepopowitz 