### PR TITLE
Be more defensive when returning partner offers

### DIFF
--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -39,7 +39,12 @@ module Types
 
     def offers(gravity_partner_id:)
       partner = Partner.find_by(gravity_partner_id: gravity_partner_id)
-      object.partner_submissions.find_by(partner: partner).offers
+      return [] unless partner
+
+      partner_submission = object.partner_submissions.find_by(partner: partner)
+      return [] unless partner_submission
+
+      partner_submission.offers
     end
   end
 end


### PR DESCRIPTION
Prior to this PR it was quite possible to request offers for a partner and get an error back rather than an empty array. What I've done here is check for nils and then guard against them and ensure we return those empty arrays instead. I think this is pretty un-controversial so I'm going to `merge on green` so that I can keep going on QAing our "unblock direct listings" line of work, hope that's ok!! ❤️ 