### PR TITLE
CSGN-191: Set created by from offer params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,7 +513,7 @@ DEPENDENCIES
   yarjuf
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4

--- a/app/graphql/resolvers/create_offer_resolver.rb
+++ b/app/graphql/resolvers/create_offer_resolver.rb
@@ -25,7 +25,8 @@ class CreateOfferResolver < BaseResolver
 
   def partner_id
     gravity_partner_id = @arguments[:gravity_partner_id]
-    Partner.find_by(gravity_partner_id: gravity_partner_id).id
+    partner = Partner.find_by(gravity_partner_id: gravity_partner_id)
+    partner.id
   end
 
   def offer_attributes

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -20,7 +20,15 @@ class Offer < ApplicationRecord
   ].freeze
 
   # FIXME: deprecate 'accepted' state
-  STATES = %w[draft sent accepted rejected lapsed review consigned].freeze
+  STATES = [
+    DRAFT = 'draft',
+    SENT = 'sent',
+    ACCEPTED = 'accepted',
+    REJECTED = 'rejected',
+    LAPSED = 'lapsed',
+    REVIEW = 'review',
+    CONSIGNED = 'consigned'
+  ].freeze
 
   REJECTION_REASONS = [
     'Low estimate',

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -35,10 +35,10 @@ class OfferService
       if partner_submission.notified_at.blank?
         partner_submission.update!(notified_at: Time.now.utc)
       end
-      offer =
-        partner_submission.offers.new(
-          offer_params.merge(state: 'draft', created_by_id: current_user)
-        )
+
+      default_offer_attrs = { state: 'draft', created_by_id: current_user }
+      offer_attrs = offer_params.merge(default_offer_attrs)
+      offer = partner_submission.offers.new(offer_attrs)
       offer.save!
       offer
     rescue ActiveRecord::RecordNotFound => e

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -37,7 +37,7 @@ class OfferService
       end
 
       default_offer_attrs = { state: 'draft', created_by_id: current_user }
-      offer_attrs = offer_params.merge(default_offer_attrs)
+      offer_attrs = default_offer_attrs.merge(offer_params)
       offer = partner_submission.offers.new(offer_attrs)
       offer.save!
       offer

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -29,12 +29,10 @@ describe OfferService do
       it 'raises an error' do
         expect {
           OfferService.create_offer(submission.id, partner.id, {}, user.id)
-        }.to raise_error do |error|
-          expect(error).to be_a OfferService::OfferError
-          expect(
-            error.message
-          ).to eq 'Invalid submission state for offer creation'
-        end
+        }.to raise_error(
+          OfferService::OfferError,
+          'Invalid submission state for offer creation'
+        )
       end
     end
 
@@ -44,12 +42,10 @@ describe OfferService do
       it 'raises an error' do
         expect {
           OfferService.create_offer(submission.id, partner.id, {}, user.id)
-        }.to raise_error do |error|
-          expect(error).to be_a OfferService::OfferError
-          expect(
-            error.message
-          ).to eq 'Invalid submission state for offer creation'
-        end
+        }.to raise_error(
+          OfferService::OfferError,
+          'Invalid submission state for offer creation'
+        )
       end
     end
 
@@ -279,12 +275,10 @@ describe OfferService do
         it 'raises an error' do
           expect {
             OfferService.update_offer(offer, 'userid', state: Offer::CONSIGNED)
-          }.to raise_error do |error|
-            expect(error).to be_a OfferService::OfferError
-            expect(
-              error.message
-            ).to eq 'Cannot complete consignment on non-approved submission'
-          end
+          }.to raise_error(
+            OfferService::OfferError,
+            'Cannot complete consignment on non-approved submission'
+          )
         end
       end
       context 'with an offer on an approved submission' do

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -52,16 +52,14 @@ describe OfferService do
     describe 'with no initial partner submission' do
       let(:submission_state) { Submission::APPROVED }
 
-      it 'creates a draft offer' do
-        expect(
+      it 'creates a draft offer and a partner submission' do
+        expect {
+          OfferService.create_offer(submission.id, partner.id)
+        }.to change {
           PartnerSubmission.where(submission: submission, partner: partner)
             .count
-        ).to eq 0
-        OfferService.create_offer(submission.id, partner.id)
-        expect(
-          PartnerSubmission.where(submission: submission, partner: partner)
-            .count
-        ).to eq 1
+        }.from(0).to(1)
+
         ps =
           PartnerSubmission.where(submission: submission, partner: partner)
             .first

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -8,8 +8,8 @@ describe OfferService do
   let(:partner) { Fabricate(:partner, name: 'Gagosian Gallery') }
   let(:submission) { Fabricate(:submission, state: submission_state) }
 
-  context 'create_offer' do
-    describe 'with a submission in submitted state' do
+  describe 'create_offer' do
+    context 'with a submission in submitted state' do
       let(:submission_state) { Submission::SUBMITTED }
 
       it 'updates the submission state to approved' do
@@ -23,7 +23,7 @@ describe OfferService do
       end
     end
 
-    describe 'with a submission in a draft state' do
+    context 'with a submission in a draft state' do
       let(:submission_state) { Submission::DRAFT }
 
       it 'raises an error' do
@@ -36,7 +36,7 @@ describe OfferService do
       end
     end
 
-    describe 'with a submission in a rejected state' do
+    context 'with a submission in a rejected state' do
       let(:submission_state) { Submission::REJECTED }
 
       it 'raises an error' do
@@ -49,7 +49,7 @@ describe OfferService do
       end
     end
 
-    describe 'with no initial partner submission' do
+    context 'with no initial partner submission' do
       let(:submission_state) { Submission::APPROVED }
 
       it 'creates a draft offer and a partner submission' do
@@ -69,7 +69,7 @@ describe OfferService do
       end
     end
 
-    describe 'with an initial partner submission' do
+    context 'with an initial partner submission' do
       let!(:partner_submission) do
         Fabricate(:partner_submission, partner: partner, submission: submission)
       end
@@ -111,7 +111,7 @@ describe OfferService do
     end
   end
 
-  context 'update_offer' do
+  describe 'update_offer' do
     it 'updates the offer with the new params' do
       offer =
         Fabricate(
@@ -153,186 +153,186 @@ describe OfferService do
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 0
     end
-  end
 
-  context 'with an offer' do
-    let(:partner) { Fabricate(:partner, name: 'Happy Gallery') }
-    let(:submission_state) { Submission::DRAFT }
-    let(:partner_submission) do
-      Fabricate(:partner_submission, partner: partner, submission: submission)
-    end
-    let(:offer) do
-      Fabricate(
-        :offer,
-        offer_type: 'purchase',
-        price_cents: 10_000,
-        state: Offer::DRAFT,
-        partner_submission: partner_submission
-      )
-    end
-
-    before do
-      stub_gravity_root
-      stub_gravity_user(id: offer.submission.user.gravity_user_id)
-      stub_gravity_user_detail(
-        email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id
-      )
-      stub_gravity_artist(id: submission.artist_id)
-      stub_gravity_partner(id: partner.gravity_partner_id)
-      stub_gravity_partner_communications(
-        partner_id: partner.gravity_partner_id
-      )
-      stub_gravity_partner_contacts(
-        partner_id: partner.gravity_partner_id,
-        override_body: [
-          { email: 'contact1@partner.com' },
-          { email: 'contact2@partner.com' }
-        ]
-      )
-      allow(Convection.config).to receive(:offer_response_form_url).and_return(
-        'https://google.com/response_form?entry.1=SUBMISSION_NUMBER&entry.2=PARTNER_NAME'
-      )
-      allow(Convection.config).to receive(:auction_offer_form_url).and_return(
-        'https://google.com/offer_form?entry.1=SUBMISSION_NUMBER'
-      )
-    end
-
-    describe 'sending an offer' do
-      it 'sends an email to a user with offer information' do
-        OfferService.update_offer(offer, 'userid', state: Offer::SENT)
-        emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 1
-        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
-        expect(emails.first.to).to eq(%w[michael@bluth.com])
-        expect(emails.first.from).to eq(%w[consign@artsy.net])
-        expect(emails.first.subject).to eq('Great news! You have a new offer.')
-
-        email_body = emails.first.html_part.body
-        expect(email_body).to include(
-          'Great news! A new offer has been made on your consignment.'
+    context 'with an offer' do
+      let(:partner) { Fabricate(:partner, name: 'Happy Gallery') }
+      let(:submission_state) { Submission::DRAFT }
+      let(:partner_submission) do
+        Fabricate(:partner_submission, partner: partner, submission: submission)
+      end
+      let(:offer) do
+        Fabricate(
+          :offer,
+          offer_type: 'purchase',
+          price_cents: 10_000,
+          state: Offer::DRAFT,
+          partner_submission: partner_submission
         )
-        expect(email_body).to include(
-          'The work will be purchased directly from you by the partner'
-        )
-        expect(email_body).to include('Happy Gallery')
-        expect(email_body).to include(
-          "https://google.com/response_form?entry.1=#{
-            submission.id
-          }&amp;entry.2=Happy%20Gallery"
-        )
-
-        offer.reload
-
-        expect(offer.state).to eq Offer::SENT
-        expect(offer.sent_by).to eq 'userid'
-        expect(offer.sent_at).to_not be_nil
       end
 
-      it 'does not send an email if the email has already been sent' do
-        offer.update!(sent_at: Time.now.utc)
-        OfferService.update_offer(offer, 'userid', state: Offer::SENT)
-        emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 0
+      before do
+        stub_gravity_root
+        stub_gravity_user(id: offer.submission.user.gravity_user_id)
+        stub_gravity_user_detail(
+          email: 'michael@bluth.com', id: offer.submission.user.gravity_user_id
+        )
+        stub_gravity_artist(id: submission.artist_id)
+        stub_gravity_partner(id: partner.gravity_partner_id)
+        stub_gravity_partner_communications(
+          partner_id: partner.gravity_partner_id
+        )
+        stub_gravity_partner_contacts(
+          partner_id: partner.gravity_partner_id,
+          override_body: [
+            { email: 'contact1@partner.com' },
+            { email: 'contact2@partner.com' }
+          ]
+        )
+        allow(Convection.config).to receive(:offer_response_form_url).and_return(
+          'https://google.com/response_form?entry.1=SUBMISSION_NUMBER&entry.2=PARTNER_NAME'
+        )
+        allow(Convection.config).to receive(:auction_offer_form_url).and_return(
+          'https://google.com/offer_form?entry.1=SUBMISSION_NUMBER'
+        )
       end
-    end
 
-    describe 'introducing an offer' do
-      it 'sends an email saying the user is interested in the offer' do
-        OfferService.update_offer(offer, 'userid', state: Offer::REVIEW)
-        emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 2
-        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
-        expect(emails.map(&:to).flatten).to eq(
-          %w[contact1@partner.com contact2@partner.com]
-        )
-        expect(emails.first.from).to eq(%w[consign@artsy.net])
-        expect(emails.first.subject).to eq(
-          'The consignor has expressed interest in your offer'
-        )
-        expect(emails.first.html_part.body).to include(
-          'Your offer has been reviewed, and the consignor has expressed interest your offer'
-        )
-        expect(emails.first.html_part.body).to include('Happy Gallery')
-        expect(emails.first.html_part.body).to_not include(
-                                                     'The work will be purchased directly from you by the partner'
-                                                   )
-        expect(offer.state).to eq Offer::REVIEW
-        expect(offer.review_started_at).to_not be_nil
-      end
-    end
+      context 'sending an offer' do
+        it 'sends an email to a user with offer information' do
+          OfferService.update_offer(offer, 'userid', state: Offer::SENT)
+          emails = ActionMailer::Base.deliveries
+          expect(emails.length).to eq 1
+          expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+          expect(emails.first.to).to eq(%w[michael@bluth.com])
+          expect(emails.first.from).to eq(%w[consign@artsy.net])
+          expect(emails.first.subject).to eq('Great news! You have a new offer.')
 
-    describe 'consigning an offer' do
-      context 'with an offer on a non-approved submission' do
-        it 'raises an error' do
-          expect {
-            OfferService.update_offer(offer, 'userid', state: Offer::CONSIGNED)
-          }.to raise_error(
-            OfferService::OfferError,
-            'Cannot complete consignment on non-approved submission'
+          email_body = emails.first.html_part.body
+          expect(email_body).to include(
+            'Great news! A new offer has been made on your consignment.'
           )
+          expect(email_body).to include(
+            'The work will be purchased directly from you by the partner'
+          )
+          expect(email_body).to include('Happy Gallery')
+          expect(email_body).to include(
+            "https://google.com/response_form?entry.1=#{
+              submission.id
+            }&amp;entry.2=Happy%20Gallery"
+          )
+
+          offer.reload
+
+          expect(offer.state).to eq Offer::SENT
+          expect(offer.sent_by).to eq 'userid'
+          expect(offer.sent_at).to_not be_nil
+        end
+
+        it 'does not send an email if the email has already been sent' do
+          offer.update!(sent_at: Time.now.utc)
+          OfferService.update_offer(offer, 'userid', state: Offer::SENT)
+          emails = ActionMailer::Base.deliveries
+          expect(emails.length).to eq 0
         end
       end
-      context 'with an offer on an approved submission' do
-        let(:submission_state) { Submission::APPROVED }
 
-        let(:ps) { Fabricate(:partner_submission, submission: submission) }
-        let(:consignable_offer) { Fabricate(:offer, partner_submission: ps) }
-        it 'sets fields on submission and partner submission' do
-          OfferService.update_offer(
-            consignable_offer,
-            'userid',
-            state: Offer::CONSIGNED
+      context 'introducing an offer' do
+        it 'sends an email saying the user is interested in the offer' do
+          OfferService.update_offer(offer, 'userid', state: Offer::REVIEW)
+          emails = ActionMailer::Base.deliveries
+          expect(emails.length).to eq 2
+          expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+          expect(emails.map(&:to).flatten).to eq(
+            %w[contact1@partner.com contact2@partner.com]
           )
-          expect(ActionMailer::Base.deliveries.count).to eq 0
+          expect(emails.first.from).to eq(%w[consign@artsy.net])
+          expect(emails.first.subject).to eq(
+            'The consignor has expressed interest in your offer'
+          )
+          expect(emails.first.html_part.body).to include(
+            'Your offer has been reviewed, and the consignor has expressed interest your offer'
+          )
+          expect(emails.first.html_part.body).to include('Happy Gallery')
+          expect(emails.first.html_part.body).to_not include(
+                                                       'The work will be purchased directly from you by the partner'
+                                                     )
+          expect(offer.state).to eq Offer::REVIEW
+          expect(offer.review_started_at).to_not be_nil
+        end
+      end
+
+      context 'consigning an offer' do
+        context 'with an offer on a non-approved submission' do
+          it 'raises an error' do
+            expect {
+              OfferService.update_offer(offer, 'userid', state: Offer::CONSIGNED)
+            }.to raise_error(
+              OfferService::OfferError,
+              'Cannot complete consignment on non-approved submission'
+            )
+          end
+        end
+        context 'with an offer on an approved submission' do
+          let(:submission_state) { Submission::APPROVED }
+
+          let(:ps) { Fabricate(:partner_submission, submission: submission) }
+          let(:consignable_offer) { Fabricate(:offer, partner_submission: ps) }
+          it 'sets fields on submission and partner submission' do
+            OfferService.update_offer(
+              consignable_offer,
+              'userid',
+              state: Offer::CONSIGNED
+            )
+            expect(ActionMailer::Base.deliveries.count).to eq 0
+            expect(ps.state).to eq 'open'
+            expect(ps.accepted_offer).to eq consignable_offer
+            expect(ps.partner_commission_percent).to eq consignable_offer
+                 .commission_percent
+            expect(
+              ps.submission.consigned_partner_submission
+            ).to eq consignable_offer.partner_submission
+            expect(consignable_offer.consigned_at).to_not be_nil
+          end
+        end
+      end
+
+      context 'rejecting an offer' do
+        it 'sends an email saying the offer has been rejected' do
+          OfferService.update_offer(offer, 'userid', state: Offer::REJECTED)
+          emails = ActionMailer::Base.deliveries
+          expect(emails.length).to eq 2
+          expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
+          expect(emails.map(&:to).flatten).to eq(
+            %w[contact1@partner.com contact2@partner.com]
+          )
+          expect(emails.first.from).to eq(%w[consign@artsy.net])
+          expect(emails.first.subject).to eq(
+            'A response to your consignment offer'
+          )
+
+          email_body = emails.first.html_part.body
+          expect(email_body).to include(
+            'Your offer has been reviewed, and the consignor has rejected your offer.'
+          )
+          expect(email_body).to include('Happy Gallery')
+          expect(email_body).to_not include(
+                                      'The work will be purchased directly from you by the partner'
+                                    )
+          expect(email_body).to include(
+            "https://google.com/offer_form?entry.1=#{submission.id}"
+          )
+          expect(offer.state).to eq Offer::REJECTED
+          expect(offer.rejected_by).to eq 'userid'
+          expect(offer.rejected_at).to_not be_nil
+        end
+
+        it 'does not set consignment-related fields on an offer rejecton' do
+          OfferService.update_offer(offer, 'userid', state: Offer::REJECTED)
+          ps = offer.partner_submission
           expect(ps.state).to eq 'open'
-          expect(ps.accepted_offer).to eq consignable_offer
-          expect(ps.partner_commission_percent).to eq consignable_offer
-               .commission_percent
-          expect(
-            ps.submission.consigned_partner_submission
-          ).to eq consignable_offer.partner_submission
-          expect(consignable_offer.consigned_at).to_not be_nil
+          expect(ps.accepted_offer_id).to be_nil
+          expect(ps.partner_commission_percent).to be_nil
+          expect(ps.submission.consigned_partner_submission).to be_nil
         end
-      end
-    end
-
-    describe 'rejecting an offer' do
-      it 'sends an email saying the offer has been rejected' do
-        OfferService.update_offer(offer, 'userid', state: Offer::REJECTED)
-        emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 2
-        expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
-        expect(emails.map(&:to).flatten).to eq(
-          %w[contact1@partner.com contact2@partner.com]
-        )
-        expect(emails.first.from).to eq(%w[consign@artsy.net])
-        expect(emails.first.subject).to eq(
-          'A response to your consignment offer'
-        )
-
-        email_body = emails.first.html_part.body
-        expect(email_body).to include(
-          'Your offer has been reviewed, and the consignor has rejected your offer.'
-        )
-        expect(email_body).to include('Happy Gallery')
-        expect(email_body).to_not include(
-                                    'The work will be purchased directly from you by the partner'
-                                  )
-        expect(email_body).to include(
-          "https://google.com/offer_form?entry.1=#{submission.id}"
-        )
-        expect(offer.state).to eq Offer::REJECTED
-        expect(offer.rejected_by).to eq 'userid'
-        expect(offer.rejected_at).to_not be_nil
-      end
-
-      it 'does not set consignment-related fields on an offer rejecton' do
-        OfferService.update_offer(offer, 'userid', state: Offer::REJECTED)
-        ps = offer.partner_submission
-        expect(ps.state).to eq 'open'
-        expect(ps.accepted_offer_id).to be_nil
-        expect(ps.partner_commission_percent).to be_nil
-        expect(ps.submission.consigned_partner_submission).to be_nil
       end
     end
   end

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -9,27 +9,27 @@ describe OfferService do
 
   context 'create_offer' do
     describe 'with a submission in submitted state' do
-      let(:submitted_submission) { Fabricate(:submission, state: 'submitted') }
+      let(:submission) { Fabricate(:submission, state: 'submitted') }
 
       it 'updates the submission state to approved' do
         OfferService.create_offer(
-          submitted_submission.id,
+          submission.id,
           partner.id,
           {},
           user.id
         )
-        expect(submitted_submission.reload.state).to eq 'approved'
-        expect(submitted_submission.reload.approved_by).to eq user.id.to_s
-        expect(submitted_submission.reload.approved_at).to_not be_nil
+        expect(submission.reload.state).to eq 'approved'
+        expect(submission.reload.approved_by).to eq user.id.to_s
+        expect(submission.reload.approved_at).to_not be_nil
       end
     end
     describe 'with a submission in a draft state' do
-      let(:draft_submission) { Fabricate(:submission) }
+      let(:submission) { Fabricate(:submission) }
 
       it 'raises an error' do
         expect {
           OfferService.create_offer(
-            draft_submission.id,
+            submission.id,
             partner.id,
             {},
             user.id
@@ -43,12 +43,12 @@ describe OfferService do
       end
     end
     describe 'with a submission in a rejected state' do
-      let(:rejected_submission) { Fabricate(:submission, state: 'rejected') }
+      let(:submission) { Fabricate(:submission, state: 'rejected') }
 
       it 'raises an error' do
         expect {
           OfferService.create_offer(
-            rejected_submission.id,
+            submission.id,
             partner.id,
             {},
             user.id

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -70,26 +70,19 @@ describe OfferService do
     end
 
     describe 'with an initial partner submission' do
+      let!(:partner_submission) do
+        Fabricate(:partner_submission, partner: partner, submission: submission)
+      end
       let(:submission_state) { Submission::APPROVED }
 
-      before do
-        @partner_submission =
-          Fabricate(
-            :partner_submission,
-            partner: partner, submission: submission
-          )
-      end
-
       it 'creates multiple draft offers' do
-        OfferService.create_offer(submission.id, partner.id)
-        expect(@partner_submission.offers.count).to eq 1
-        expect(@partner_submission.offers.first.state).to eq Offer::DRAFT
+        expect {
+          OfferService.create_offer(submission.id, partner.id)
+          OfferService.create_offer(submission.id, partner.id)
+        }.to change { partner_submission.offers.count }.from(0).to(2)
 
-        OfferService.create_offer(submission.id, partner.id)
-        expect(@partner_submission.offers.count).to eq 2
-        expect(@partner_submission.offers.pluck(:state).uniq).to eq [
-             Offer::DRAFT
-           ]
+        states = partner_submission.offers.pluck(:state)
+        expect(states.uniq).to eq [Offer::DRAFT]
       end
 
       it 'fails if the partner does not exist' do

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -188,7 +188,8 @@ describe OfferService do
             { email: 'contact2@partner.com' }
           ]
         )
-        allow(Convection.config).to receive(:offer_response_form_url).and_return(
+        allow(Convection.config).to receive(:offer_response_form_url)
+          .and_return(
           'https://google.com/response_form?entry.1=SUBMISSION_NUMBER&entry.2=PARTNER_NAME'
         )
         allow(Convection.config).to receive(:auction_offer_form_url).and_return(
@@ -204,7 +205,9 @@ describe OfferService do
           expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
           expect(emails.first.to).to eq(%w[michael@bluth.com])
           expect(emails.first.from).to eq(%w[consign@artsy.net])
-          expect(emails.first.subject).to eq('Great news! You have a new offer.')
+          expect(emails.first.subject).to eq(
+            'Great news! You have a new offer.'
+          )
 
           email_body = emails.first.html_part.body
           expect(email_body).to include(
@@ -264,7 +267,11 @@ describe OfferService do
         context 'with an offer on a non-approved submission' do
           it 'raises an error' do
             expect {
-              OfferService.update_offer(offer, 'userid', state: Offer::CONSIGNED)
+              OfferService.update_offer(
+                offer,
+                'userid',
+                state: Offer::CONSIGNED
+              )
             }.to raise_error(
               OfferService::OfferError,
               'Cannot complete consignment on non-approved submission'

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -15,9 +15,11 @@ describe OfferService do
       it 'updates the submission state to approved' do
         OfferService.create_offer(submission.id, partner.id, {}, user.id)
 
-        expect(submission.reload.state).to eq 'approved'
-        expect(submission.reload.approved_by).to eq user.id.to_s
-        expect(submission.reload.approved_at).to_not be_nil
+        submission.reload
+
+        expect(submission.state).to eq Submission::APPROVED
+        expect(submission.approved_by).to eq user.id.to_s
+        expect(submission.approved_at).to_not be_nil
       end
     end
 
@@ -137,8 +139,8 @@ describe OfferService do
         'userid',
         high_estimate_cents: 30_000, notes: 'New offer notes!'
       )
-      expect(offer.reload.high_estimate_cents).to eq 30_000
-      expect(offer.reload.notes).to eq 'New offer notes!'
+      expect(offer.high_estimate_cents).to eq 30_000
+      expect(offer.notes).to eq 'New offer notes!'
     end
 
     it 'raises an error if validation fails' do
@@ -231,7 +233,10 @@ describe OfferService do
             submission.id
           }&amp;entry.2=Happy%20Gallery"
         )
-        expect(offer.reload.state).to eq Offer::SENT
+
+        offer.reload
+
+        expect(offer.state).to eq Offer::SENT
         expect(offer.sent_by).to eq 'userid'
         expect(offer.sent_at).to_not be_nil
       end
@@ -264,7 +269,7 @@ describe OfferService do
         expect(emails.first.html_part.body).to_not include(
                                                      'The work will be purchased directly from you by the partner'
                                                    )
-        expect(offer.reload.state).to eq Offer::REVIEW
+        expect(offer.state).to eq Offer::REVIEW
         expect(offer.review_started_at).to_not be_nil
       end
     end
@@ -331,7 +336,7 @@ describe OfferService do
         expect(email_body).to include(
           "https://google.com/offer_form?entry.1=#{submission.id}"
         )
-        expect(offer.reload.state).to eq Offer::REJECTED
+        expect(offer.state).to eq Offer::REJECTED
         expect(offer.rejected_by).to eq 'userid'
         expect(offer.rejected_at).to_not be_nil
       end

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -6,10 +6,11 @@ require 'support/gravity_helper'
 describe OfferService do
   let!(:user) { Fabricate(:user) }
   let(:partner) { Fabricate(:partner, name: 'Gagosian Gallery') }
+  let(:submission) { Fabricate(:submission, state: submission_state) }
 
   context 'create_offer' do
     describe 'with a submission in submitted state' do
-      let(:submission) { Fabricate(:submission, state: 'submitted') }
+      let(:submission_state) { 'submitted' }
 
       it 'updates the submission state to approved' do
         OfferService.create_offer(
@@ -24,7 +25,7 @@ describe OfferService do
       end
     end
     describe 'with a submission in a draft state' do
-      let(:submission) { Fabricate(:submission) }
+      let(:submission_state) { 'draft' }
 
       it 'raises an error' do
         expect {
@@ -43,7 +44,7 @@ describe OfferService do
       end
     end
     describe 'with a submission in a rejected state' do
-      let(:submission) { Fabricate(:submission, state: 'rejected') }
+      let(:submission_state) { 'rejected' }
 
       it 'raises an error' do
         expect {
@@ -62,7 +63,7 @@ describe OfferService do
       end
     end
     describe 'with no initial partner submission' do
-      let(:submission) { Fabricate(:submission, state: 'approved') }
+      let(:submission_state) { 'approved' }
 
       it 'creates a draft offer' do
         expect(
@@ -84,7 +85,7 @@ describe OfferService do
     end
 
     describe 'with an initial partner submission' do
-      let(:submission) { Fabricate(:submission, state: 'approved') }
+      let(:submission_state) { 'approved' }
 
       before do
         @partner_submission =
@@ -176,7 +177,7 @@ describe OfferService do
 
   context 'with an offer' do
     let(:partner) { Fabricate(:partner, name: 'Happy Gallery') }
-    let(:submission) { Fabricate(:submission) }
+    let(:submission_state) { 'draft' }
     let(:partner_submission) do
       Fabricate(:partner_submission, partner: partner, submission: submission)
     end
@@ -291,11 +292,10 @@ describe OfferService do
         end
       end
       context 'with an offer on an approved submission' do
-        let(:approved_submission) do
-          Fabricate(:submission, state: Submission::APPROVED)
-        end
+        let(:submission_state) { Submission::APPROVED }
+
         let(:ps) do
-          Fabricate(:partner_submission, submission: approved_submission)
+          Fabricate(:partner_submission, submission: submission)
         end
         let(:consignable_offer) { Fabricate(:offer, partner_submission: ps) }
         it 'sets fields on submission and partner submission' do

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -5,14 +5,12 @@ require 'support/gravity_helper'
 
 describe OfferService do
   let!(:user) { Fabricate(:user) }
-  let(:submitted_submission) { Fabricate(:submission, state: 'submitted') }
-  let(:submission) { Fabricate(:submission, state: 'approved') }
-  let(:draft_submission) { Fabricate(:submission) }
   let(:partner) { Fabricate(:partner, name: 'Gagosian Gallery') }
-  let(:rejected_submission) { Fabricate(:submission, state: 'rejected') }
 
   context 'create_offer' do
     describe 'with a submission in submitted state' do
+      let(:submitted_submission) { Fabricate(:submission, state: 'submitted') }
+
       it 'updates the submission state to approved' do
         OfferService.create_offer(
           submitted_submission.id,
@@ -26,6 +24,8 @@ describe OfferService do
       end
     end
     describe 'with a submission in a draft state' do
+      let(:draft_submission) { Fabricate(:submission) }
+
       it 'raises an error' do
         expect {
           OfferService.create_offer(
@@ -43,6 +43,8 @@ describe OfferService do
       end
     end
     describe 'with a submission in a rejected state' do
+      let(:rejected_submission) { Fabricate(:submission, state: 'rejected') }
+
       it 'raises an error' do
         expect {
           OfferService.create_offer(
@@ -60,6 +62,8 @@ describe OfferService do
       end
     end
     describe 'with no initial partner submission' do
+      let(:submission) { Fabricate(:submission, state: 'approved') }
+
       it 'creates a draft offer' do
         expect(
           PartnerSubmission.where(submission: submission, partner: partner)
@@ -80,6 +84,8 @@ describe OfferService do
     end
 
     describe 'with an initial partner submission' do
+      let(:submission) { Fabricate(:submission, state: 'approved') }
+
       before do
         @partner_submission =
           Fabricate(

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -13,12 +13,8 @@ describe OfferService do
       let(:submission_state) { Submission::SUBMITTED }
 
       it 'updates the submission state to approved' do
-        OfferService.create_offer(
-          submission.id,
-          partner.id,
-          {},
-          user.id
-        )
+        OfferService.create_offer(submission.id, partner.id, {}, user.id)
+
         expect(submission.reload.state).to eq 'approved'
         expect(submission.reload.approved_by).to eq user.id.to_s
         expect(submission.reload.approved_at).to_not be_nil
@@ -30,12 +26,7 @@ describe OfferService do
 
       it 'raises an error' do
         expect {
-          OfferService.create_offer(
-            submission.id,
-            partner.id,
-            {},
-            user.id
-          )
+          OfferService.create_offer(submission.id, partner.id, {}, user.id)
         }.to raise_error do |error|
           expect(error).to be_a OfferService::OfferError
           expect(
@@ -44,17 +35,13 @@ describe OfferService do
         end
       end
     end
+
     describe 'with a submission in a rejected state' do
       let(:submission_state) { Submission::REJECTED }
 
       it 'raises an error' do
         expect {
-          OfferService.create_offer(
-            submission.id,
-            partner.id,
-            {},
-            user.id
-          )
+          OfferService.create_offer(submission.id, partner.id, {}, user.id)
         }.to raise_error do |error|
           expect(error).to be_a OfferService::OfferError
           expect(
@@ -298,9 +285,7 @@ describe OfferService do
       context 'with an offer on an approved submission' do
         let(:submission_state) { Submission::APPROVED }
 
-        let(:ps) do
-          Fabricate(:partner_submission, submission: submission)
-        end
+        let(:ps) { Fabricate(:partner_submission, submission: submission) }
         let(:consignable_offer) { Fabricate(:offer, partner_submission: ps) }
         it 'sets fields on submission and partner submission' do
           OfferService.update_offer(

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 require 'support/gravity_helper'
 
 describe OfferService do
-  let!(:user) { Fabricate(:user) }
+  let(:user) { Fabricate(:user) }
   let(:partner) { Fabricate(:partner, name: 'Gagosian Gallery') }
   let(:submission) { Fabricate(:submission, state: submission_state) }
 

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -10,7 +10,7 @@ describe OfferService do
 
   context 'create_offer' do
     describe 'with a submission in submitted state' do
-      let(:submission_state) { 'submitted' }
+      let(:submission_state) { Submission::SUBMITTED }
 
       it 'updates the submission state to approved' do
         OfferService.create_offer(
@@ -25,7 +25,7 @@ describe OfferService do
       end
     end
     describe 'with a submission in a draft state' do
-      let(:submission_state) { 'draft' }
+      let(:submission_state) { Submission::DRAFT }
 
       it 'raises an error' do
         expect {
@@ -44,7 +44,7 @@ describe OfferService do
       end
     end
     describe 'with a submission in a rejected state' do
-      let(:submission_state) { 'rejected' }
+      let(:submission_state) { Submission::REJECTED }
 
       it 'raises an error' do
         expect {
@@ -63,7 +63,7 @@ describe OfferService do
       end
     end
     describe 'with no initial partner submission' do
-      let(:submission_state) { 'approved' }
+      let(:submission_state) { Submission::APPROVED }
 
       it 'creates a draft offer' do
         expect(
@@ -85,7 +85,7 @@ describe OfferService do
     end
 
     describe 'with an initial partner submission' do
-      let(:submission_state) { 'approved' }
+      let(:submission_state) { Submission::APPROVED }
 
       before do
         @partner_submission =
@@ -177,7 +177,7 @@ describe OfferService do
 
   context 'with an offer' do
     let(:partner) { Fabricate(:partner, name: 'Happy Gallery') }
-    let(:submission_state) { 'draft' }
+    let(:submission_state) { Submission::DRAFT }
     let(:partner_submission) do
       Fabricate(:partner_submission, partner: partner, submission: submission)
     end

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -9,6 +9,24 @@ describe OfferService do
   let(:submission) { Fabricate(:submission, state: submission_state) }
 
   describe 'create_offer' do
+    context 'with an id for created by but no current user' do
+      let(:submission_state) { Submission::APPROVED }
+
+      it 'sets that id on the offer' do
+        offer_params = { created_by_id: 'just-some-user-id' }
+
+        offer =
+          OfferService.create_offer(
+            submission.id,
+            partner.id,
+            offer_params,
+            nil
+          )
+
+        expect(offer.created_by_id).to eq offer_params[:created_by_id]
+      end
+    end
+
     context 'with a submission in submitted state' do
       let(:submission_state) { Submission::SUBMITTED }
 


### PR DESCRIPTION
While researching the attached Jira ticket I discovered that the `OfferService#create_offer` method was clobbering the `offer_params` being sent in.

So, I went to go fix that but then found that the tests needed some love so I started with improvements there and then the actual fix comes in that last commit. Note that this is only half of the fix - work will have to be done on Volt to properly send this argument so there's a dependency here. Regardless, this PR can be merged and deployed to production at any time.

https://artsyproduct.atlassian.net/browse/CSGN-191