### PR TITLE
Run all checks using the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,8 @@ if Rails.env.development? || Rails.env.test?
 
   desc 'check for schema drift'
   task schema_check: :environment do
-    system 'rake graphql:schema:idl'
-    abort 'schema export failed' unless $CHILD_STATUS.exitstatus.zero?
-    system 'git status --porcelain | grep -q "_schema.graphql"'
-    abort 'schema-check failed' if $CHILD_STATUS.exitstatus.zero?
+    system './bin/schema_check'
+    abort 'schema-check failed' unless $CHILD_STATUS.exitstatus.zero?
   end
 
   Rake::Task[:default].clear

--- a/bin/schema_check
+++ b/bin/schema_check
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+mv _schema.graphql _schema.graphql.bak
+rake graphql:schema:idl
+
+trap "mv _schema.graphql.bak _schema.graphql" ERR
+diff -q _schema.graphql _schema.graphql.bak

--- a/hokusai/ci.sh
+++ b/hokusai/ci.sh
@@ -21,12 +21,9 @@ retry() {
     sleep ${retry_delay_seconds}
   done
 
-  # set up test database
   bundle exec rake db:setup
-
-  yarn prettier-check
-  bundle exec rake rubocop
-  bundle exec rake spec
 }
 
 retry 1>&2 ${MAX_ATTEMPTS:-5} ${RETRY_DELAY_SECONDS:-1} psql ${DATABASE_URL} -c '\l'
+
+bundle exec rake

--- a/hokusai/ci.sh
+++ b/hokusai/ci.sh
@@ -21,7 +21,7 @@ retry() {
     sleep ${retry_delay_seconds}
   done
 
-  bundle exec rake db:setup
+  bundle exec rake db:schema:load
 }
 
 retry 1>&2 ${MAX_ATTEMPTS:-5} ${RETRY_DELAY_SECONDS:-1} psql ${DATABASE_URL} -c '\l'


### PR DESCRIPTION
I suspect that this will fail on Circle because we actually have an issue that @xtina-starr fixes with https://github.com/artsy/convection/pull/658 so this should be red, then I can merge hers and then rebase and this should be green and prevent any further PRs from passing when the schema file is out of sync.