### PR TITLE
[CSGN-140] add sale_location to offer type

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -200,6 +200,7 @@ type Offer {
   partnerInfo: String
   photographyInfo: String
   saleDate: String
+  saleLocation: String
   saleName: String
   shippingInfo: String
   state: String

--- a/app/graphql/types/offer_type.rb
+++ b/app/graphql/types/offer_type.rb
@@ -20,6 +20,7 @@ module Types
     field :photography_info, String, null: true
     field :sale_date, String, null: true
     field :sale_name, String, null: true
+    field :sale_location, String, null: true
     field :shipping_info, String, null: true
     field :state, String, null: true
   end

--- a/spec/requests/api/graphql/queries/submission_spec.rb
+++ b/spec/requests/api/graphql/queries/submission_spec.rb
@@ -204,6 +204,7 @@ describe 'submission query' do
             {
               'id' => offer.id.to_s,
               'state' => offer.state,
+              'saleLocation' => offer.sale_location,
               'commissionPercentWhole' => offer.commission_percent_whole
             }
           )

--- a/spec/requests/api/graphql/queries/submission_spec.rb
+++ b/spec/requests/api/graphql/queries/submission_spec.rb
@@ -137,6 +137,7 @@ describe 'submission query' do
             offers(gravityPartnerId: "#{gravity_partner_id}") {
               id
               state
+              saleLocation
               commissionPercentWhole
             }
           }


### PR DESCRIPTION
Addresses: [CSGN-140](https://artsyproduct.atlassian.net/browse/CSGN-140)

This is follow up work from the [initial PR](https://github.com/artsy/convection/pull/656) to add `sale_location` to an offer. We missed adding this property to offer_type which was causing issue when we attempted to query it from volt.