### PR TITLE
Support submission query sorting

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -304,9 +304,9 @@ type Query {
     last: Int
 
     """
-    Return submissions sorted by this field
+    Return submissions sorted this way
     """
-    sort: String
+    sort: SubmissionSort
 
     """
     Get all submissions with these user IDs
@@ -397,6 +397,458 @@ type SubmissionEdge {
   The item at the end of the edge.
   """
   node: Submission
+}
+
+enum SubmissionSort {
+  """
+  sort by additional_info in ascending order
+  """
+  ADDITIONAL_INFO_ASC
+
+  """
+  sort by additional_info in descending order
+  """
+  ADDITIONAL_INFO_DESC
+
+  """
+  sort by admin_receipt_sent_at in ascending order
+  """
+  ADMIN_RECEIPT_SENT_AT_ASC
+
+  """
+  sort by admin_receipt_sent_at in descending order
+  """
+  ADMIN_RECEIPT_SENT_AT_DESC
+
+  """
+  sort by approved_at in ascending order
+  """
+  APPROVED_AT_ASC
+
+  """
+  sort by approved_at in descending order
+  """
+  APPROVED_AT_DESC
+
+  """
+  sort by approved_by in ascending order
+  """
+  APPROVED_BY_ASC
+
+  """
+  sort by approved_by in descending order
+  """
+  APPROVED_BY_DESC
+
+  """
+  sort by artist_id in ascending order
+  """
+  ARTIST_ID_ASC
+
+  """
+  sort by artist_id in descending order
+  """
+  ARTIST_ID_DESC
+
+  """
+  sort by artist_score in ascending order
+  """
+  ARTIST_SCORE_ASC
+
+  """
+  sort by artist_score in descending order
+  """
+  ARTIST_SCORE_DESC
+
+  """
+  sort by assigned_to in ascending order
+  """
+  ASSIGNED_TO_ASC
+
+  """
+  sort by assigned_to in descending order
+  """
+  ASSIGNED_TO_DESC
+
+  """
+  sort by auction_score in ascending order
+  """
+  AUCTION_SCORE_ASC
+
+  """
+  sort by auction_score in descending order
+  """
+  AUCTION_SCORE_DESC
+
+  """
+  sort by authenticity_certificate in ascending order
+  """
+  AUTHENTICITY_CERTIFICATE_ASC
+
+  """
+  sort by authenticity_certificate in descending order
+  """
+  AUTHENTICITY_CERTIFICATE_DESC
+
+  """
+  sort by category in ascending order
+  """
+  CATEGORY_ASC
+
+  """
+  sort by category in descending order
+  """
+  CATEGORY_DESC
+
+  """
+  sort by consigned_partner_submission_id in ascending order
+  """
+  CONSIGNED_PARTNER_SUBMISSION_ID_ASC
+
+  """
+  sort by consigned_partner_submission_id in descending order
+  """
+  CONSIGNED_PARTNER_SUBMISSION_ID_DESC
+
+  """
+  sort by created_at in ascending order
+  """
+  CREATED_AT_ASC
+
+  """
+  sort by created_at in descending order
+  """
+  CREATED_AT_DESC
+
+  """
+  sort by currency in ascending order
+  """
+  CURRENCY_ASC
+
+  """
+  sort by currency in descending order
+  """
+  CURRENCY_DESC
+
+  """
+  sort by deadline_to_sell in ascending order
+  """
+  DEADLINE_TO_SELL_ASC
+
+  """
+  sort by deadline_to_sell in descending order
+  """
+  DEADLINE_TO_SELL_DESC
+
+  """
+  sort by deleted_at in ascending order
+  """
+  DELETED_AT_ASC
+
+  """
+  sort by deleted_at in descending order
+  """
+  DELETED_AT_DESC
+
+  """
+  sort by depth in ascending order
+  """
+  DEPTH_ASC
+
+  """
+  sort by depth in descending order
+  """
+  DEPTH_DESC
+
+  """
+  sort by dimensions_metric in ascending order
+  """
+  DIMENSIONS_METRIC_ASC
+
+  """
+  sort by dimensions_metric in descending order
+  """
+  DIMENSIONS_METRIC_DESC
+
+  """
+  sort by edition in ascending order
+  """
+  EDITION_ASC
+
+  """
+  sort by edition in descending order
+  """
+  EDITION_DESC
+
+  """
+  sort by edition_number in ascending order
+  """
+  EDITION_NUMBER_ASC
+
+  """
+  sort by edition_number in descending order
+  """
+  EDITION_NUMBER_DESC
+
+  """
+  sort by edition_size in ascending order
+  """
+  EDITION_SIZE_ASC
+
+  """
+  sort by edition_size in descending order
+  """
+  EDITION_SIZE_DESC
+
+  """
+  sort by ext_user_id in ascending order
+  """
+  EXT_USER_ID_ASC
+
+  """
+  sort by ext_user_id in descending order
+  """
+  EXT_USER_ID_DESC
+
+  """
+  sort by height in ascending order
+  """
+  HEIGHT_ASC
+
+  """
+  sort by height in descending order
+  """
+  HEIGHT_DESC
+
+  """
+  sort by id in ascending order
+  """
+  ID_ASC
+
+  """
+  sort by id in descending order
+  """
+  ID_DESC
+
+  """
+  sort by location_city in ascending order
+  """
+  LOCATION_CITY_ASC
+
+  """
+  sort by location_city in descending order
+  """
+  LOCATION_CITY_DESC
+
+  """
+  sort by location_country in ascending order
+  """
+  LOCATION_COUNTRY_ASC
+
+  """
+  sort by location_country in descending order
+  """
+  LOCATION_COUNTRY_DESC
+
+  """
+  sort by location_state in ascending order
+  """
+  LOCATION_STATE_ASC
+
+  """
+  sort by location_state in descending order
+  """
+  LOCATION_STATE_DESC
+
+  """
+  sort by medium in ascending order
+  """
+  MEDIUM_ASC
+
+  """
+  sort by medium in descending order
+  """
+  MEDIUM_DESC
+
+  """
+  sort by minimum_price_cents in ascending order
+  """
+  MINIMUM_PRICE_CENTS_ASC
+
+  """
+  sort by minimum_price_cents in descending order
+  """
+  MINIMUM_PRICE_CENTS_DESC
+
+  """
+  sort by offers_count in ascending order
+  """
+  OFFERS_COUNT_ASC
+
+  """
+  sort by offers_count in descending order
+  """
+  OFFERS_COUNT_DESC
+
+  """
+  sort by primary_image_id in ascending order
+  """
+  PRIMARY_IMAGE_ID_ASC
+
+  """
+  sort by primary_image_id in descending order
+  """
+  PRIMARY_IMAGE_ID_DESC
+
+  """
+  sort by provenance in ascending order
+  """
+  PROVENANCE_ASC
+
+  """
+  sort by provenance in descending order
+  """
+  PROVENANCE_DESC
+
+  """
+  sort by qualified in ascending order
+  """
+  QUALIFIED_ASC
+
+  """
+  sort by qualified in descending order
+  """
+  QUALIFIED_DESC
+
+  """
+  sort by receipt_sent_at in ascending order
+  """
+  RECEIPT_SENT_AT_ASC
+
+  """
+  sort by receipt_sent_at in descending order
+  """
+  RECEIPT_SENT_AT_DESC
+
+  """
+  sort by rejected_at in ascending order
+  """
+  REJECTED_AT_ASC
+
+  """
+  sort by rejected_at in descending order
+  """
+  REJECTED_AT_DESC
+
+  """
+  sort by rejected_by in ascending order
+  """
+  REJECTED_BY_ASC
+
+  """
+  sort by rejected_by in descending order
+  """
+  REJECTED_BY_DESC
+
+  """
+  sort by reminders_sent_count in ascending order
+  """
+  REMINDERS_SENT_COUNT_ASC
+
+  """
+  sort by reminders_sent_count in descending order
+  """
+  REMINDERS_SENT_COUNT_DESC
+
+  """
+  sort by signature in ascending order
+  """
+  SIGNATURE_ASC
+
+  """
+  sort by signature in descending order
+  """
+  SIGNATURE_DESC
+
+  """
+  sort by state in ascending order
+  """
+  STATE_ASC
+
+  """
+  sort by state in descending order
+  """
+  STATE_DESC
+
+  """
+  sort by title in ascending order
+  """
+  TITLE_ASC
+
+  """
+  sort by title in descending order
+  """
+  TITLE_DESC
+
+  """
+  sort by updated_at in ascending order
+  """
+  UPDATED_AT_ASC
+
+  """
+  sort by updated_at in descending order
+  """
+  UPDATED_AT_DESC
+
+  """
+  sort by user_agent in ascending order
+  """
+  USER_AGENT_ASC
+
+  """
+  sort by user_agent in descending order
+  """
+  USER_AGENT_DESC
+
+  """
+  sort by user_email in ascending order
+  """
+  USER_EMAIL_ASC
+
+  """
+  sort by user_email in descending order
+  """
+  USER_EMAIL_DESC
+
+  """
+  sort by user_id in ascending order
+  """
+  USER_ID_ASC
+
+  """
+  sort by user_id in descending order
+  """
+  USER_ID_DESC
+
+  """
+  sort by width in ascending order
+  """
+  WIDTH_ASC
+
+  """
+  sort by width in descending order
+  """
+  WIDTH_DESC
+
+  """
+  sort by year in ascending order
+  """
+  YEAR_ASC
+
+  """
+  sort by year in descending order
+  """
+  YEAR_DESC
 }
 
 """

--- a/_schema.graphql
+++ b/_schema.graphql
@@ -304,6 +304,11 @@ type Query {
     last: Int
 
     """
+    Return submissions sorted by this field
+    """
+    sort: String
+
+    """
     Get all submissions with these user IDs
     """
     userId: [ID!]

--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -80,7 +80,7 @@ class SubmissionsResolver < BaseResolver
   def invalid_sort?
     return false if @arguments[:sort].blank?
 
-    column_name = @arguments[:sort].tr('-', '')
+    column_name = @arguments[:sort].keys.first
     !Submission.column_names.include?(column_name)
   end
 
@@ -88,9 +88,6 @@ class SubmissionsResolver < BaseResolver
     default_sort = { id: :desc }
     return default_sort unless @arguments[:sort]
 
-    direction = @arguments[:sort].first == '-' ? :desc : :asc
-    column = @arguments[:sort].tr('-', '')
-
-    { column => direction }
+    @arguments[:sort]
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -31,6 +31,10 @@ module Types
       argument :available, Boolean, required: false do
         description 'If true return only available submissions'
       end
+
+      argument :sort, String, required: false do
+        description 'Return submissions sorted by this field'
+      end
     end
 
     def submissions(arguments = {})

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -32,8 +32,10 @@ module Types
         description 'If true return only available submissions'
       end
 
-      argument :sort, String, required: false do
-        description 'Return submissions sorted by this field'
+      argument :sort,
+               SubmissionSortType,
+               required: false, prepare: SubmissionSortType.prepare do
+        description 'Return submissions sorted this way'
       end
     end
 

--- a/app/graphql/types/sort_type.rb
+++ b/app/graphql/types/sort_type.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Types
+  class SortType < Types::BaseEnum
+    DIRECTIONS = %w[asc desc].freeze
+
+    def self.generate_values(columns)
+      columns.each do |column_name|
+        asc_value, desc_value =
+          DIRECTIONS.map do |direction|
+            [column_name, direction].join('_').upcase
+          end
+
+        value asc_value, "sort by #{column_name} in ascending order"
+        value desc_value, "sort by #{column_name} in descending order"
+      end
+    end
+
+    def self.prepare
+      lambda do |sort, _context|
+        return unless sort
+
+        match_data = sort.downcase.match(/(.*)_(asc|desc)/)
+        column_name, direction = match_data.captures
+        { column_name => direction }
+      end
+    end
+  end
+end

--- a/app/graphql/types/submission_sort_type.rb
+++ b/app/graphql/types/submission_sort_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Types
+  class SubmissionSortType < SortType
+    generate_values(Submission.column_names)
+  end
+end

--- a/spec/requests/api/graphql/queries/submissions_spec.rb
+++ b/spec/requests/api/graphql/queries/submissions_spec.rb
@@ -383,7 +383,7 @@ describe 'submissions query' do
       context 'without a sort column' do
         let(:query_inputs) { 'sort: null' }
 
-        it 'returns the submissions sorted ascending by the id column' do
+        it 'returns the submissions sorted descending by the id column' do
           post '/api/graphql', params: { query: query }, headers: headers
 
           expect(response.status).to eq 200

--- a/spec/requests/api/graphql/queries/submissions_spec.rb
+++ b/spec/requests/api/graphql/queries/submissions_spec.rb
@@ -396,22 +396,8 @@ describe 'submissions query' do
         end
       end
 
-      context 'with an invalid sort column' do
-        let(:query_inputs) { 'sort: "invalid"' }
-
-        it 'returns an error' do
-          post '/api/graphql', params: { query: query }, headers: headers
-
-          expect(response.status).to eq 200
-          body = JSON.parse(response.body)
-
-          error_message = body['errors'][0]['message']
-          expect(error_message).to eq 'Invalid sort column.'
-        end
-      end
-
       context 'with a valid sort column' do
-        let(:query_inputs) { 'sort: "created_at"' }
+        let(:query_inputs) { 'sort: CREATED_AT_ASC' }
 
         it 'returns the submissions sorted ascending by that column' do
           post '/api/graphql', params: { query: query }, headers: headers
@@ -427,7 +413,7 @@ describe 'submissions query' do
       end
 
       context 'with a descending direction prefix' do
-        let(:query_inputs) { 'sort: "-created_at"' }
+        let(:query_inputs) { 'sort: CREATED_AT_DESC' }
 
         it 'returns the submissions sorted descending by that column' do
           post '/api/graphql', params: { query: query }, headers: headers

--- a/spec/types/sort_type_spec.rb
+++ b/spec/types/sort_type_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Types::SortType do
+  describe 'prepare' do
+    context 'with an ascending sort' do
+      it 'returns the correct sort column and direction' do
+        prepare_callback = Types::SortType.prepare
+        sort_order = prepare_callback.call('CREATED_AT_ASC', nil)
+        expect(sort_order).to eq('created_at' => 'asc')
+      end
+    end
+
+    context 'with a descending sort' do
+      it 'returns the correct sort column and direction' do
+        prepare_callback = Types::SortType.prepare
+        sort_order = prepare_callback.call('CREATED_AT_DESC', nil)
+        expect(sort_order).to eq('created_at' => 'desc')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the ability to specify a column to sort by when quering for submissions:

```graphql
query {
  submissions(sort: "created_at") {
    edges {
      node {
        id
        created_at
      }
    }
  }
}
```

If omitted, the default sort remains DESC by `id`. Otherwise you can specify any value included in the Submission column names array:

```ruby
convection:development> Submission.column_names.sort
=> ["additional_info", "admin_receipt_sent_at", "approved_at", "approved_by", "artist_id", "artist_score", "assigned_to", "auction_score", "authenticity_certificate", "category", "consigned_partner_submission_id", "created_at", "currency", "deadline_to_sell", "deleted_at", "depth", "dimensions_metric", "edition", "edition_number", "edition_size", "ext_user_id", "height", "id", "location_city", "location_country", "location_state", "medium", "minimum_price_cents", "offers_count", "primary_image_id", "provenance", "qualified", "receipt_sent_at", "rejected_at", "rejected_by", "reminders_sent_count", "signature", "state", "title", "updated_at", "user_agent", "user_email", "user_id", "width", "year"]
```

## Should this be an ENUM?

I guess I was thinking String for this argument value because then as fields come and go, what's ultimately the source of truth about what can be sorted by is the database. I'm interested in hearing other thoughts here though! /cc @mzikherman 