### PR TITLE
WIP: userAgent is invalid on input type

### DIFF
--- a/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
@@ -103,8 +103,8 @@ describe 'createConsignmentSubmission mutation' do
       submission_response = create_response['consignmentSubmission']
       expect(submission_response).to include(
         {
-          'id' => be,
           # this ensures it's not nil
+          'id' => be,
           'title' => 'soup',
           'category' => 'Jewelry',
           'state' => 'REJECTED',
@@ -115,6 +115,29 @@ describe 'createConsignmentSubmission mutation' do
 
       mutation_id = create_response['clientMutationId']
       expect(mutation_id).to eq '2'
+    end
+
+    context 'with a user agent string' do
+      let(:mutation_inputs) do
+        '{ artistID: "andy", userAgent: "something, something" }'
+      end
+
+      it 'sets that UA on the submission' do
+        stub_gravity_root
+        stub_gravity_user
+        stub_gravity_user_detail(email: 'michael@bluth.com')
+
+        post '/api/graphql', params: { query: mutation }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+        puts '*'*80
+        puts body["errors"][0]["message"]
+        puts '*'*80
+
+        submission = Submission.first
+        expect(submission.user_agent).to eq 'something, something'
+      end
     end
   end
 end


### PR DESCRIPTION
@damassi this test will fail like so:

```
jon@juggernaut:~/code/convection(support-user-agent-string-in-submission-mutations*)% be rspec spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb:120
Run options: include {:focus=>true, :locations=>{"./spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb"=>[120]}}

Randomized with seed 57197
********************************************************************************
InputObject 'CreateSubmissionMutationInput' doesn't accept argument 'userAgent'
********************************************************************************
F

Failures:

  1) createConsignmentSubmission mutation valid requests with a user agent string sets that UA on the submission
     Failure/Error: expect(submission.user_agent).to eq 'something, something'

     NoMethodError:
       undefined method `user_agent' for nil:NilClass
     # ./spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb:139:in `block (4 levels) in <top (required)>'
     # ./spec/rails_helper.rb:29:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:29:in `block (2 levels) in <top (required)>'

Finished in 0.18863 seconds (files took 2.25 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb:125 # createConsignmentSubmission mutation valid requests with a user agent string sets that UA on the submission

Randomized with seed 57197
```

The output includes this:

```
InputObject 'CreateSubmissionMutationInput' doesn't accept argument 'userAgent'
```

So I think the next step here is to add this argument to the input type and probably also the update mutation too?