### PR TITLE
Add the new published at timestamp to schema

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1164,6 +1164,16 @@ enum SubmissionSort {
   PROVENANCE_DESC
 
   """
+  sort by published_at in ascending order
+  """
+  PUBLISHED_AT_ASC
+
+  """
+  sort by published_at in descending order
+  """
+  PUBLISHED_AT_DESC
+
+  """
   sort by qualified in ascending order
   """
   QUALIFIED_ASC


### PR DESCRIPTION
For some reason the builds over on #678 were green even though they should not have been because the schema was out of sync. I suspect this is because the PR itself was the source of the schema drift. I can't really prove this though and I don't have a fix for the CI script just yet. I will think on this!

Anyway, all I did here was run `be rake graphql:schema:idl` and then commit the results.