### PR TITLE
Expose an offer query

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -677,6 +677,17 @@ type PageInfo {
 
 type Query {
   """
+  Get an Offer
+  """
+  offer(
+    """
+    Return offers for the given partner
+    """
+    gravityPartnerId: ID!
+    id: ID!
+  ): Offer
+
+  """
   List offers
   """
   offers(

--- a/app/graphql/resolvers/offer_resolver.rb
+++ b/app/graphql/resolvers/offer_resolver.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class OfferResolver < BaseResolver
+  BadArgumentError = GraphQL::ExecutionError.new("Can't access offer")
+
+  def valid?
+    @error = compute_error
+    @error.nil?
+  end
+
+  def run
+    partner.offers.find(@arguments[:id])
+  rescue ActiveRecord::RecordNotFound
+    raise GraphQL::ExecutionError, 'Offer not found'
+  end
+
+  private
+
+  def compute_error
+    return BadArgumentError unless admin? || partner?
+  end
+
+  def partner
+    Partner.find_by(gravity_partner_id: @arguments[:gravity_partner_id])
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -2,6 +2,24 @@
 
 module Types
   class QueryType < GraphQL::Schema::Object
+    field :offer, OfferType, null: true do
+      description 'Get an Offer'
+
+      argument :id, ID, required: true
+
+      argument :gravity_partner_id, ID, required: true do
+        description 'Return offers for the given partner'
+      end
+    end
+
+    def offer(arguments = {})
+      query_options = { arguments: arguments, context: context, object: object }
+      resolver = OfferResolver.new(query_options)
+      raise resolver.error unless resolver.valid?
+
+      resolver.run
+    end
+
     field :offers, OfferConnectionType, null: true, connection: true do
       description 'List offers'
 

--- a/spec/requests/api/graphql/queries/offer_spec.rb
+++ b/spec/requests/api/graphql/queries/offer_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'offer query' do
+  let(:partner) { Fabricate :partner }
+  let(:partner_submission) { Fabricate :partner_submission, partner: partner }
+  let!(:offer) { Fabricate :offer, partner_submission: partner_submission }
+
+  let(:token) do
+    JWT.encode(
+      { aud: 'gravity', sub: 'userid', roles: 'admin' },
+      Convection.config.jwt_secret
+    )
+  end
+
+  let(:headers) { { 'Authorization' => "Bearer #{token}" } }
+
+  let(:query_inputs) do
+    "id: \"#{offer.id}\", gravityPartnerId: \"#{partner.gravity_partner_id}\""
+  end
+
+  let(:query) do
+    <<-GRAPHQL
+    query {
+      offer(#{query_inputs}) {
+        id
+        commissionPercentWhole
+      }
+    }
+    GRAPHQL
+  end
+
+  describe 'invalid requests' do
+    context 'with an unauthorized request' do
+      let(:token) { 'foo.bar.baz' }
+
+      it 'returns an error for that request' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        offer_response = body.dig('data', 'offer')
+        expect(offer_response).to eq nil
+
+        error_message = body['errors'][0]['message']
+        expect(error_message).to eq "Can't access offer"
+      end
+    end
+
+    context 'with a request from a regular user' do
+      let(:token) do
+        payload = { aud: 'gravity', sub: 'userid', roles: 'user' }
+        JWT.encode(payload, Convection.config.jwt_secret)
+      end
+
+      it 'returns an error for that request' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        offer_response = body.dig('data', 'offer')
+        expect(offer_response).to eq nil
+
+        error_message = body['errors'][0]['message']
+        expect(error_message).to eq "Can't access offer"
+      end
+    end
+  end
+
+  describe 'valid requests' do
+    context 'with an invalid offer id' do
+      let(:query_inputs) do
+        "id: 999999999, gravityPartnerId: \"#{partner.gravity_partner_id}\""
+      end
+
+      it 'returns an error for that request' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        offer_response = body.dig('data', 'offer')
+        expect(offer_response).to eq nil
+
+        error_message = body['errors'][0]['message']
+        expect(error_message).to eq 'Offer not found'
+      end
+    end
+
+    context 'with an existing offer id' do
+      it 'returns that offer' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        offer_response = body.dig('data', 'offer')
+        expect(offer_response).to match(
+          {
+            'id' => offer.id.to_s,
+            'commissionPercentWhole' => offer.commission_percent_whole
+          }
+        )
+      end
+    end
+
+    context 'with a valid offer id from a partner' do
+      let(:token) do
+        payload = { aud: 'gravity', sub: 'userid', roles: 'partner' }
+        JWT.encode(payload, Convection.config.jwt_secret)
+      end
+
+      it 'returns that offer' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        offer_response = body.dig('data', 'offer')
+        expect(offer_response).to match(
+          {
+            'id' => offer.id.to_s,
+            'commissionPercentWhole' => offer.commission_percent_whole
+          }
+        )
+      end
+    end
+
+    context 'with an offer id from another partner' do
+      let(:token) do
+        payload = { aud: 'gravity', sub: 'userid', roles: 'partner' }
+        JWT.encode(payload, Convection.config.jwt_secret)
+      end
+
+      let(:another_partner) { Fabricate :partner }
+      let(:query_inputs) do
+        "id: \"#{offer.id}\", gravityPartnerId: \"#{
+          another_partner.gravity_partner_id
+        }\""
+      end
+
+      it 'returns an error for that request' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        offer_response = body.dig('data', 'offer')
+        expect(offer_response).to eq nil
+
+        error_message = body['errors'][0]['message']
+        expect(error_message).to eq 'Offer not found'
+      end
+    end
+  end
+end


### PR DESCRIPTION
It didn't occur to me until getting things ready for a demo tomorrow that I didn't have a way to query for an individual offer yet! So this PR adds that top-level query at `offer`. It requires a gravity partner id and an offer id. It will use that partner id to scope the offer find so that by definition one can not see the offers of another partner.

For tests I copy/pasted from the `submission` query and adjusted from there.