### PR TITLE
[CreateSubmissionMutation] Add support for userAgent

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -138,6 +138,7 @@ input CreateSubmissionMutationInput {
   signature: Boolean
   state: State
   title: String
+  userAgent: String
   width: String
   year: String
 }

--- a/app/graphql/mutations/create_submission_mutation.rb
+++ b/app/graphql/mutations/create_submission_mutation.rb
@@ -25,6 +25,7 @@ module Mutations
     argument :signature, Boolean, required: false
     argument :state, Types::StateType, required: false
     argument :title, String, required: false
+    argument :user_agent, String, required: false
     argument :width, String, required: false
     argument :year, String, required: false
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "prettier": "prettier --write '**/*.rb'",
-    "prettier-check": "prettier --check '**/*.rb'"
+    "prettier-check": "prettier --check '**/*.rb'",
+    "sync-schema": "rake graphql:schema:idl && cp _schema.graphql ../metaphysics/src/data/convection.graphql"
   },
   "devDependencies": {
     "@prettier/plugin-ruby": "0.18.2",
@@ -17,7 +18,7 @@
     }
   },
   "lint-staged": {
-    "{app,test}/**/*.rb": "bundle exec rubocop -a",
+    "{app,spec}/**/*.rb": "bundle exec rubocop -a",
     "*.{rb,js,jsx,ts,tsx,css,md}": "prettier --write"
   }
 }

--- a/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
@@ -103,8 +103,8 @@ describe 'createConsignmentSubmission mutation' do
       submission_response = create_response['consignmentSubmission']
       expect(submission_response).to include(
         {
-          'id' => be,
           # this ensures it's not nil
+          'id' => be,
           'title' => 'soup',
           'category' => 'Jewelry',
           'state' => 'REJECTED',
@@ -115,6 +115,25 @@ describe 'createConsignmentSubmission mutation' do
 
       mutation_id = create_response['clientMutationId']
       expect(mutation_id).to eq '2'
+    end
+
+    context 'with a user agent string' do
+      let(:mutation_inputs) do
+        '{ artistID: "andy", userAgent: "something, something" }'
+      end
+
+      it 'sets that UA on the submission' do
+        stub_gravity_root
+        stub_gravity_user
+        stub_gravity_user_detail(email: 'michael@bluth.com')
+
+        post '/api/graphql', params: { query: mutation }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+        submission = Submission.first
+        expect(submission.user_agent).to eq 'something, something'
+      end
     end
   end
 end

--- a/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
@@ -130,7 +130,6 @@ describe 'createConsignmentSubmission mutation' do
         post '/api/graphql', params: { query: mutation }, headers: headers
 
         expect(response.status).to eq 200
-        body = JSON.parse(response.body)
         submission = Submission.first
         expect(submission.user_agent).to eq 'something, something'
       end


### PR DESCRIPTION
Once this is merged, then 
- https://github.com/artsy/metaphysics/pull/2450
- https://github.com/artsy/eigen/pull/3409

Adds a new `userAgent` mutation input on the `CreateSubmissionMutationInput` type.

```graphql
mutation createConsignmentSubmissionMutation($input: CreateSubmissionMutationInput!) {
  createConsignmentSubmission(input: $input) {
    consignmentSubmission {
      id 
      userAgent
    }
  }
}
```
```json
{
  "input": {
    "artistID": "andy-warhol",
    "userAgent":"foo"
  }
}
```
```json
{
  "data": {
    "createConsignmentSubmission": {
      "consignmentSubmission": {
        "id": "35609",
        "userAgent": "foo"
      }
    }
  }
}
```
