### PR TITLE
Always enable new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -373,3 +373,6 @@ Style/SlicingWithRange:
 
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
+
+AllCops:
+  NewCops: enable


### PR DESCRIPTION
While reading the docs on RuboCop's new versioning policy, I failed to notice that there's a config option to always enable new cops:

https://docs.rubocop.org/rubocop/versioning.html

```yaml
AllCops:
  NewCops: enable
```

So this sorta gets RuboCop back to the behavior I'm used to and upgrades will fail locally when I upgrade and then I can deal with it.