### PR TITLE
CSGN-229: Always allow editing an offer

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -73,11 +73,6 @@ class Offer < ApplicationRecord
     !draft? && !sent? && !review?
   end
 
-  def editable?
-    allowed_states = %w[draft sent]
-    allowed_states.include?(state)
-  end
-
   def locked?
     submission.consigned_partner_submission_id.present? &&
       submission.consigned_partner_submission.accepted_offer_id != id

--- a/app/views/admin/offers/show.html.erb
+++ b/app/views/admin/offers/show.html.erb
@@ -6,11 +6,9 @@
           <div class='overview-section'>
             <div class='overview-section-title--inline'>
               Details
-              <% if offer.editable? %>
-                <span class='overview-section-title--inline__link'>
-                  <%= link_to 'Edit', edit_admin_offer_path(offer) %>
-                </span>
-              <% end %>
+              <span class='overview-section-title--inline__link'>
+                <%= link_to 'Edit', edit_admin_offer_path(offer) %>
+              </span>
             </div>
             <%= render "#{offer.offer_type.downcase.tr(' ', '_')}", offer: offer %>
           </div>

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -54,29 +54,6 @@ describe Offer do
     end
   end
 
-  describe 'editable?' do
-    let(:allowed_states) { %w[draft sent] }
-
-    context 'when state is draft or sent' do
-      it 'returns true' do
-        allowed_states.each do |state|
-          offer = Fabricate(:offer, state: state)
-          expect(offer).to be_editable
-        end
-      end
-    end
-
-    context 'when state is any other value' do
-      it 'returns false' do
-        not_editable_states = Offer::STATES - allowed_states
-        not_editable_states.each do |state|
-          offer = Fabricate(:offer, state: state)
-          expect(offer).to_not be_editable
-        end
-      end
-    end
-  end
-
   context 'locked?' do
     it 'returns true if this offer is not the accepted_offer and the partner submission is consigned' do
       ps = Fabricate(:partner_submission, submission: approved_submission)


### PR DESCRIPTION
This PR removes the concept of only being able to edit certain offers and instead allows an offer to always be edited.

https://artsyproduct.atlassian.net/browse/CSGN-229