### PR TITLE
Tune resource assignment based on observed use.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -43,8 +43,8 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 300m
-              memory: 256Mi
+              cpu: 200m
+              memory: 512Mi
             limits:
               memory: 1Gi
           readinessProbe:
@@ -229,8 +229,8 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: convection-sidekiq
-  minReplicas: 1
-  maxReplicas: 2
+  minReplicas: 2
+  maxReplicas: 3
   targetCPUUtilizationPercentage: 80
 
 ---
@@ -278,7 +278,10 @@ spec:
             periodSeconds: 30
           resources:
             requests:
-              cpu: "1"
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -44,9 +44,9 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               port: convection-http
@@ -229,8 +229,8 @@ spec:
     apiVersion: extensions/v1beta1
     kind: Deployment
     name: convection-sidekiq
-  minReplicas: 2
-  maxReplicas: 3
+  minReplicas: 1
+  maxReplicas: 2
   targetCPUUtilizationPercentage: 80
 
 ---
@@ -279,9 +279,9 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -43,7 +43,7 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 256Mi
             limits:
               memory: 512Mi
@@ -216,7 +216,7 @@ spec:
             periodSeconds: 30
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 512Mi
             limits:
               memory: 1Gi

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -217,9 +217,9 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 256Mi
             limits:
-              memory: 1Gi
+              memory: 512Mi
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/PLATFORM-2657

Prod
---
For Web:
- Reduce CPU request due to lower usage.
- Reduce memory limit due to lower usage.

For Sidekiq:
- Reduce CPU request due to lower usage.
- Memory request/limit has not been specified. Here we are going to specify 256M/512M.

Staging
---
Similar changes.

Resources
---
Tuning guideline:
https://www.notion.so/artsy/Guidelines-on-tuning-an-app-s-CPU-and-memory-consumption-in-a-Kubernetes-cluster-797977be895643af84015a7d4b60a5dc
Prod Web usage dashboard (please change filters to see other prod deployments or staging deployments).
https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-cpumemory-usage-by-deployment?from_ts=1594840342055&live=true&to_ts=1595013142055&tpl_var_container=convection-web&tpl_var_deployment=convection-web&tpl_var_env=production&tpl_var_hpa=convection-web&tv_mode=false