### PR TITLE
CSGN-278: Allow submission edits to not affect assigned user

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -159,31 +159,35 @@ module Admin
     end
 
     def submission_params
-      params.require(:submission).permit(
-        :artist_id,
-        :assigned_to,
-        :authenticity_certificate,
-        :category,
-        :currency,
-        :deleted_at,
-        :depth,
-        :dimensions_metric,
-        :edition_number,
-        :edition_size,
-        :height,
-        :location_city,
-        :location_country,
-        :location_state,
-        :medium,
-        :minimum_price_dollars,
-        :primary_image_id,
-        :provenance,
-        :signature,
-        :state,
-        :title,
-        :width,
-        :year
-      )
+      safelist = %i[
+        artist_id
+        authenticity_certificate
+        category
+        currency
+        deleted_at
+        depth
+        dimensions_metric
+        edition_number
+        edition_size
+        height
+        location_city
+        location_country
+        location_state
+        medium
+        minimum_price_dollars
+        primary_image_id
+        provenance
+        signature
+        state
+        title
+        width
+        year
+      ]
+
+      permitted_params = params.require(:submission).permit(safelist)
+      permitted_params[:assigned_to] =
+        params.dig(:submission, :assigned_to).presence
+      permitted_params
     end
   end
 end

--- a/app/views/admin/submissions/_form.html.erb
+++ b/app/views/admin/submissions/_form.html.erb
@@ -221,7 +221,8 @@
                 Assigned To:
               </label>
               <div class='col-sm-10'>
-                <%= f.select :assigned_to, options_for_select(Convection.config.admin_names), {}, class: 'form-control' %>
+                <% options = [['Please select one', '']] + Convection.config.admin_names %>
+                <%= f.select :assigned_to, options_for_select(options), {}, class: 'form-control' %>
               </div>
             </div>
           </div>

--- a/spec/views/admin/submissions/edit.html.erb_spec.rb
+++ b/spec/views/admin/submissions/edit.html.erb_spec.rb
@@ -44,5 +44,12 @@ describe 'admin/submissions/edit.html.erb', type: :feature do
       expect(page).to have_content('Gob Bluth'.upcase)
       expect(page).to have_content('Add New')
     end
+
+    it 'lets you update the submission and not affect the assigned user' do
+      expect(@submission.assigned_to).to eq nil
+      find_button('Save').click
+      @submission.reload
+      expect(@submission.assigned_to).to eq nil
+    end
   end
 end

--- a/spec/views/admin/submissions/edit.html.erb_spec.rb
+++ b/spec/views/admin/submissions/edit.html.erb_spec.rb
@@ -47,8 +47,10 @@ describe 'admin/submissions/edit.html.erb', type: :feature do
 
     it 'lets you update the submission and not affect the assigned user' do
       expect(@submission.assigned_to).to eq nil
+      fill_in('submission_title', with: 'my new artwork title')
       find_button('Save').click
       @submission.reload
+      expect(@submission.title).to eq('my new artwork title')
       expect(@submission.assigned_to).to eq nil
     end
   end


### PR DESCRIPTION
This PR filters out the `assigned_to` param when it is an empty string. This allows one to edit a submission without affecting which user the submission is assigned to. Shout out to @ashleyjelks for hanging out while I worked on this the other day!! 🙌 

https://artsyproduct.atlassian.net/browse/CSGN-278