### PR TITLE
Be more defensive about artist id

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -133,7 +133,7 @@ class Submission < ApplicationRecord
   end
 
   def artist
-    Gravity.client.artist(id: artist_id)._get if artist_id
+    Gravity.client.artist(id: artist_id)._get if artist_id.present?
   rescue Faraday::ResourceNotFound
     nil
   end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -204,6 +204,14 @@ describe Submission do
       stub_gravity_artist(id: submission.artist_id, name: 'Andy Warhol')
       expect(submission.artist_name).to eq 'Andy Warhol'
     end
+
+    context 'with an empty string for artist id' do
+      let(:submission) { Fabricate :submission, artist_id: '' }
+
+      it 'returns nil' do
+        expect(submission.artist).to eq nil
+      end
+    end
   end
 
   context 'thumbnail' do


### PR DESCRIPTION
Turns out an empty string is truthy, so we weren't being defensive enough. This came up here:

https://artsy.slack.com/archives/CS3H1K4BD/p1595865362097500

And while this does not actually solve the mystery of how we got submissions with empty string for artist id, it DOES solve the problem of the UI blowing up when this case happens.