### PR TITLE
Sort SubmissionSort in GraphiQL

### DIFF
--- a/app/graphql/types/sort_type.rb
+++ b/app/graphql/types/sort_type.rb
@@ -5,7 +5,7 @@ module Types
     DIRECTIONS = %w[asc desc].freeze
 
     def self.generate_values(columns)
-      columns.each do |column_name|
+      columns.sort.each do |column_name|
         asc_value, desc_value =
           DIRECTIONS.map do |direction|
             [column_name, direction].join('_').upcase


### PR DESCRIPTION
Adds a simple `sort` so that things are more readable in GraphiQL:

<img width="529" alt="Screen Shot 2020-07-29 at 2 48 23 PM" src="https://user-images.githubusercontent.com/236943/88857173-a0c2fc00-d1aa-11ea-9d7f-c8a1e64084d5.png">
