### PR TITLE
Set up ingress resources (for migration from ELB)

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -155,6 +155,46 @@ spec:
     component: web
   sessionAffinity: None
   type: LoadBalancer
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: convection
+    component: web
+    layer: application
+  name: convection-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: convection
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: convection
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+spec:
+  rules:
+    - host: convection.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: convection-web-internal
+              servicePort: http
+
 ---
 apiVersion: batch/v1beta1
 kind: CronJob

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -157,6 +157,45 @@ spec:
   type: LoadBalancer
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: convection
+    component: web
+    layer: application
+  name: convection-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: convection
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: convection
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ cloudflareIpSourceRanges|join(',') }}"
+spec:
+  rules:
+    - host: convection-staging.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: convection-web-internal
+              servicePort: http
+
+---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:


### PR DESCRIPTION
Set up ingress resources in both staging and production, as per doc:

https://www.notion.so/artsy/Nginx-Ingress-Controllers-4b5d937f0acd480f938c34ef1509d3c4

I already enabled Cloudflare proxying on both staging and production, since that's a worthwhile improvement anyway and we can combine those settings with this change.

Traffic won't actually use the new ingress handling until DNS is updated to point to the shared "network" load balancer. A follow-up PR and migration will remove the unnecessary ELB service.