### PR TITLE
Add #filterByCategory arg to submissions field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -753,6 +753,11 @@ type Query {
     before: String
 
     """
+    Get submissions filtered by category
+    """
+    filterByCategory: Category
+
+    """
     Returns the first _n_ elements from the list.
     """
     first: Int

--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -43,7 +43,11 @@ class SubmissionsResolver < BaseResolver
   end
 
   def conditions
-    { id: submission_ids.presence, user_id: user_ids.presence }.compact
+    {
+      id: submission_ids.presence,
+      user_id: user_ids.presence,
+      category: filter_by_category.presence
+    }.compact
   end
 
   def submission_ids
@@ -52,6 +56,10 @@ class SubmissionsResolver < BaseResolver
 
   def user_ids
     @arguments.fetch(:user_id, [])
+  end
+
+  def filter_by_category
+    @arguments.fetch(:filter_by_category, [])
   end
 
   def not_allowed_ids?

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -81,6 +81,10 @@ module Types
                required: false, prepare: SubmissionSortType.prepare do
         description 'Return submissions sorted this way'
       end
+
+      argument :filterByCategory, CategoryType, required: false do
+        description 'Get submissions filtered by category'
+      end
     end
 
     def submissions(arguments = {})


### PR DESCRIPTION
Related: https://github.com/artsy/volt/pull/4488/files 

Updates the submission field to accept a new argument `filterByCategory` --which, filters by category. 

I opted for this more specific name over, say, `filter`, because we might want to filter in a more sophisticated way in the future and appending + deprecating seems better than potentially breaking consumers. 

```graphql
{
  submissions(sort:CATEGORY_ASC, filterByCategory: PAINTING) {
    edges {
      node {
        category
        id 
        title
        createdAt
      }
    }
  }
}
```

```json
{
  "data": {
    "submissions": {
      "edges": [
        {
          "node": {
            "category": "Painting",
            "id": "1",
            "title": "sarah's test artwork!",
            "createdAt": "2017-06-06T21:58:00Z"
          }
        },
        {
          "node": {
            "category": "Painting",
            "id": "2",
            "title": "sarah's test 2",
            "createdAt": "2017-06-06T22:00:57Z"
          }
        },
        ...
     ]
   }
 }
```

#### Todo: 
- [x] Add tests 