### PR TITLE
[Graphql] Update connection totalCount to return only published

### DIFF
--- a/app/graphql/types/pagination/pageable_connection.rb
+++ b/app/graphql/types/pagination/pageable_connection.rb
@@ -28,7 +28,9 @@ module Types
       end
 
       def total_count
-        object.items.size
+        published_items =
+          object.items.filter { |item| item.state == 'published' }
+        published_items.count
       end
 
       private

--- a/spec/requests/api/graphql/queries/submissions_spec.rb
+++ b/spec/requests/api/graphql/queries/submissions_spec.rb
@@ -20,6 +20,7 @@ describe 'submissions query' do
     <<-GRAPHQL
     query {
       submissions(#{query_inputs}) {
+        totalCount
         edges {
           node {
             id,
@@ -99,6 +100,20 @@ describe 'submissions query' do
 
         submissions_response = body['data']['submissions']
         expect(submissions_response['edges'].count).to eq 2
+      end
+    end
+
+    context 'with totalCount' do
+      let!(:submission) { Fabricate :submission, state: 'submitted' }
+
+      it 'returns the number of published submissions' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        submissions_response = body['data']['submissions']
+        expect(submissions_response['totalCount']).to eq 0
       end
     end
 


### PR DESCRIPTION
Right now we return everything, for every state. This narrows the scope a bit and will further narrow depending on which arguments are passed to the connection. 

<img width="494" alt="Screen Shot 2020-08-07 at 4 54 29 PM" src="https://user-images.githubusercontent.com/236943/89696929-bf25a780-d8ce-11ea-8e05-a0033309c783.png">

<img width="594" alt="Screen Shot 2020-08-07 at 4 54 38 PM" src="https://user-images.githubusercontent.com/236943/89696924-ba60f380-d8ce-11ea-9452-885483036127.png">
