### PR TITLE
[Bugfix] Set offer to draft if submission canceled

### DIFF
--- a/app/controllers/admin/consignments_controller.rb
+++ b/app/controllers/admin/consignments_controller.rb
@@ -80,6 +80,9 @@ module Admin
 
     def update
       if @consignment.update(consignment_params)
+        if consignment_params[:state] == 'canceled'
+          @consignment.offers.each { |offer| offer.update(state: Offer::DRAFT) }
+        end
         redirect_to admin_consignment_path(@consignment)
       else
         flash.now[:error] = @consignment.errors.full_messages

--- a/spec/controllers/admin/consignments_controller_spec.rb
+++ b/spec/controllers/admin/consignments_controller_spec.rb
@@ -190,4 +190,33 @@ describe Admin::ConsignmentsController, type: :controller do
       end
     end
   end
+
+  describe '#update' do
+    let(:consignment) do
+      Fabricate(
+        :partner_submission,
+        state: 'open',
+        submission: Fabricate(:submission, state: 'approved'),
+        partner: Fabricate(:partner, name: 'Gagosian Gallery'),
+        sale_price_cents: 100_000
+      )
+    end
+
+    let(:offer) do
+      Fabricate(
+        :offer,
+        state: 'sent', partner_submission: consignment, offer_type: 'purchase'
+      )
+    end
+
+    before { consignment.update!(accepted_offer: offer) }
+
+    it 'sets offer state to draft if consignment state is cancelled' do
+      put :update,
+          params: {
+            id: consignment.id, partner_submission: consignment, as: :json
+          }
+      expect(consignment.state).to eq 'cancelled'
+    end
+  end
 end


### PR DESCRIPTION
This fixes an issue where a submission with an offer, when cancelled, still leaves the offer state as `consigned`. 

See this [slack convo](https://artsy.slack.com/archives/CS3H1K4BD/p1597166066433800) for more info. 