### PR TITLE
Respect horizon deploy blocks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,11 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@5.1.3
   hokusai: artsy/hokusai@0.7.4
+  horizon: artsy/release@0.0.1
   node: artsy/node@1.0.0
   slack: circleci/slack@3.4.2
+  yarn: artsy/yarn@5.1.3
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -28,6 +29,11 @@ only_release: &only_release
 workflows:
   build-deploy:
     jobs:
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: 46
+
       - hokusai/test:
           <<: *not_staging_or_release
 
@@ -49,6 +55,8 @@ workflows:
 
       - hokusai/deploy-production:
           <<: *only_release
+          requires:
+            - horizon/block
           post-steps:
             - slack/status:
                 success_message: Convection production has been deployed!


### PR DESCRIPTION
The best practice is to only enable auto deploy if the project respects deploy blocks. I failed to understand this, so this PR fixes that and get's us back in a less risky position.

Inspired by: https://github.com/artsy/horizon/pull/195.

cc @artsy/csgn-devs @joeyAghion 