### PR TITLE
CSGN-321: Filter submissions by assigned to

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -24,6 +24,7 @@ module Admin
 
     expose(:filters) do
       {
+        assigned_to: params[:assigned_to],
         state: params[:state],
         user: params[:user],
         sort: params[:sort],

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -16,29 +16,7 @@ module Admin
                   ]
 
     expose(:submissions) do
-      matching_submissions = Submission.not_deleted
-      if params[:term].present?
-        matching_submissions = matching_submissions.search(params[:term])
-      end
-      if params[:state].present?
-        matching_submissions = matching_submissions.where(state: params[:state])
-      end
-      if params[:user].present?
-        matching_submissions =
-          matching_submissions.where(user_id: params[:user])
-      end
-
-      sort = params[:sort].presence || 'id'
-      direction = params[:direction].presence || 'desc'
-
-      matching_submissions =
-        if sort.include?('users')
-          matching_submissions.includes(:user).reorder(
-            "#{sort} #{direction}, submissions.id desc"
-          )
-        else
-          matching_submissions.reorder("#{sort} #{direction}")
-        end
+      matching_submissions = SubmissionMatch.find_all(params)
       matching_submissions.page(page).per(size)
     end
 

--- a/app/models/submission_match.rb
+++ b/app/models/submission_match.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class SubmissionMatch
+  def self.find_all(params)
+    matching_submissions = Submission.not_deleted
+
+    if params[:term].present?
+      matching_submissions = matching_submissions.search(params[:term])
+    end
+
+    if params[:state].present?
+      matching_submissions = matching_submissions.where(state: params[:state])
+    end
+
+    if params[:user].present?
+      matching_submissions = matching_submissions.where(user_id: params[:user])
+    end
+
+    sort = params[:sort].presence || 'id'
+    direction = params[:direction].presence || 'desc'
+
+    if sort.include?('users')
+      matching_submissions.includes(:user).reorder(
+        "#{sort} #{direction}, submissions.id desc"
+      )
+    else
+      matching_submissions.reorder("#{sort} #{direction}")
+    end
+  end
+end

--- a/app/models/submission_match.rb
+++ b/app/models/submission_match.rb
@@ -25,7 +25,16 @@ class SubmissionMatch
   end
 
   def query
-    { state: params[:state].presence, user_id: params[:user].presence }.compact
+    attributes = {
+      state: params[:state].presence, user_id: params[:user].presence
+    }.compact
+    attributes.merge!(assigned_to: assigned_to) if filtering_by_assigned_to?
+    attributes
+  end
+
+  def filtering_by_assigned_to?
+    params.keys.map(&:to_sym).include?(:assigned_to) &&
+      params[:assigned_to] != 'all'
   end
 
   def sorting_by_users?
@@ -46,5 +55,9 @@ class SubmissionMatch
 
   def direction
     params[:direction].presence || 'desc'
+  end
+
+  def assigned_to
+    params[:assigned_to].presence
   end
 end

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -1,4 +1,5 @@
 <div class='page-title'>
+  <%= link_to 'Create New', new_admin_submission_path, class: 'btn btn-small btn-primary pull-right' %>
   <h2>
     Submissions
   </h2>
@@ -7,27 +8,31 @@
 <div class='container double-padding-top'>
   <div class='row'>
     <div class='row col-md-12'>
+      <%= text_field_tag 'term', '', class: 'form-control', placeholder: 'Search by ID, title, or user email', id: 'submission-search-form' %>
+    </div>
+    <div class='row col-md-12' style="padding: 25px 15px 25px 0;">
       <%= form_tag admin_submissions_url, method: 'get', id: 'submission-filter-form' do %>
-        <div class='col-md-3'>
-          <div class='form-group'>
-            <%= select_tag 'state',
-                          options_for_select(
-                            Submission::STATES.map{ |state| [state, state] }.unshift(['all', nil]),
-                            filters[:state]
-                          ),
-                          class: 'form-control',
-                          onchange: ("$('#submission-filter-form').submit()") %>
-          </div>
+        <div class='col-md-6'>
+          <label>State</label>
+          <%= select_tag 'state',
+                        options_for_select(
+                          Submission::STATES.map{ |state| [state, state] }.unshift(['all', nil]),
+                          filters[:state]
+                        ),
+                        class: 'form-control',
+                        onchange: ("$('#submission-filter-form').submit()") %>
+        </div>
+        <div class='col-md-6' style="padding: 0;">
+          <label>Assigned to</label>
+          <%= select_tag 'assigned_to',
+                        options_for_select(
+                          Convection.config.admin_names.map { |name| [name, name] }.unshift(['all', 'all'], ['none', nil]),
+                          filters[:assigned_to]
+                        ),
+                        class: 'form-control',
+                        onchange: ("$('#submission-filter-form').submit()") %>
         </div>
       <% end %>
-      <div class='col-md-7'>
-        <div class='form-group'>
-          <%= text_field_tag 'term', '', class: 'form-control', placeholder: 'Search by ID, title, or user email', id: 'submission-search-form' %>
-        </div>
-      </div>
-      <div class='col-md-2'>
-        <%= link_to 'Create New', new_admin_submission_path, class: 'btn btn-small btn-primary btn-full-width' %>
-      </div>
     </div>
     <div class='row col-md-12'>
       <div class='list-group-item list-item--submission'>

--- a/spec/models/submission_match_spec.rb
+++ b/spec/models/submission_match_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SubmissionMatch do
+  describe '.find_all' do
+    context 'with an otherwise matching deleted submission' do
+      let!(:submission) { Fabricate :submission, deleted_at: Time.zone.now }
+
+      it 'excludes that submission' do
+        params = {}
+        matching = SubmissionMatch.find_all(params).to_a
+        expect(matching).to eq []
+      end
+    end
+
+    context 'filtering by state' do
+      let(:state) { 'submitted' }
+      let!(:submitted_submission) { Fabricate :submission, state: state }
+      let!(:draft_submission) { Fabricate :submission, state: 'draft' }
+
+      it 'returns only matching submissions' do
+        params = { state: state }
+        matching = SubmissionMatch.find_all(params).to_a
+        expect(matching).to eq [submitted_submission]
+      end
+    end
+
+    context 'filtering by user' do
+      let(:user) { Fabricate :user }
+      let(:another_user) { Fabricate :user }
+      let!(:submission) { Fabricate :submission, user: user }
+      let!(:another_submission) { Fabricate :submission, user: another_user }
+
+      it 'returns only matching submissions' do
+        params = { user: user.id }
+        matching = SubmissionMatch.find_all(params).to_a
+        expect(matching).to eq [submission]
+      end
+    end
+
+    context 'searching with term' do
+      let(:query) { 'mushroom' }
+      let!(:submission) do
+        Fabricate :submission, title: "Contains the #{query} term!!"
+      end
+      let!(:another_submission) do
+        Fabricate :submission, title: 'Does not match.'
+      end
+
+      it 'returns only matching submissions' do
+        params = { term: query }
+        matching = SubmissionMatch.find_all(params).to_a
+        expect(matching).to eq [submission]
+      end
+    end
+
+    context 'ordering matches' do
+      let(:first_user) { Fabricate :user, email: 'c@example.com' }
+      let(:second_user) { Fabricate :user, email: 'b@example.com' }
+      let(:third_user) { Fabricate :user, email: 'a@example.com' }
+
+      let!(:first_submission) do
+        Fabricate :submission, id: 1, user: first_user, offers_count: 20
+      end
+      let!(:second_submission) do
+        Fabricate :submission, id: 2, user: second_user, offers_count: 10
+      end
+      let!(:third_submission) do
+        Fabricate :submission, id: 3, user: third_user, offers_count: 30
+      end
+
+      context 'with nothing specified' do
+        it 'falls back to defaults' do
+          params = {}
+          matching = SubmissionMatch.find_all(params).to_a
+          expected = [third_submission, second_submission, first_submission]
+          expect(matching).to eq expected
+        end
+      end
+
+      context 'with a sort and direction specified' do
+        it 'orders by that sort and direction' do
+          params = { sort: 'offers_count', direction: 'asc' }
+          matching = SubmissionMatch.find_all(params).to_a
+          expected = [second_submission, first_submission, third_submission]
+          expect(matching).to eq expected
+        end
+      end
+
+      context 'when sorting by users.email' do
+        let!(:fourth_submission) do
+          Fabricate :submission, id: 4, user: first_user
+        end
+
+        it 'breaks ties with submission id' do
+          params = { sort: 'users.email', direction: 'asc' }
+          matching = SubmissionMatch.find_all(params).to_a
+          expected = [
+            third_submission,
+            second_submission,
+            fourth_submission,
+            first_submission
+          ]
+          expect(matching).to eq expected
+        end
+      end
+    end
+  end
+end

--- a/spec/models/submission_match_spec.rb
+++ b/spec/models/submission_match_spec.rb
@@ -39,6 +39,40 @@ describe SubmissionMatch do
       end
     end
 
+    context 'filtering by assigned_to' do
+      let!(:unassigned) { Fabricate :submission, id: 1, assigned_to: nil }
+      let!(:alice_assigned) do
+        Fabricate :submission, id: 2, assigned_to: 'Alice'
+      end
+      let!(:betty_assigned) do
+        Fabricate :submission, id: 3, assigned_to: 'Betty'
+      end
+
+      context 'with a valid assigned username' do
+        it 'returns only matching submissions' do
+          params = { assigned_to: 'Alice' }
+          matching = SubmissionMatch.find_all(params).to_a
+          expect(matching).to eq [alice_assigned]
+        end
+      end
+
+      context "with 'all' for assigned to" do
+        it 'returns all submissions' do
+          params = { assigned_to: 'all' }
+          matching = SubmissionMatch.find_all(params).to_a
+          expect(matching).to eq [betty_assigned, alice_assigned, unassigned]
+        end
+      end
+
+      context 'with nil for assigned to' do
+        it 'returns unassigned submisisons' do
+          params = { assigned_to: nil }
+          matching = SubmissionMatch.find_all(params).to_a
+          expect(matching).to eq [unassigned]
+        end
+      end
+    end
+
     context 'searching with term' do
       let(:query) { 'mushroom' }
       let!(:submission) do


### PR DESCRIPTION
This PR adds support for a second sort on the submissions list page:

<img width="1258" alt="Screen Shot 2020-08-18 at 11 54 28 AM" src="https://user-images.githubusercontent.com/79799/90542564-edff1180-e149-11ea-8e33-fc2fe66326b6.png">

The values for that dropdown match up with our list of possible assignees and then includes two more:

* all => include all submissions, assigned and unassigned
* none => include only submissions without an assignee
* [name] => include only submissions for that assignee

## Extract class

My first move was to realize that the code to return the list of submissions had grown too big for the controller. I extracted a class called `SubmissionMatch` to encapsulate this logic. It takes the params as an input and returns an ActiveRecord relation that can be chained with pagination calls. I first did the extraction as a straight copy/paste but then I added unit tests and refactored it so that it would be easier to add the support for filtering by assignee.

Note: I'm def interested in naming input! Do you have a better name for the `SubmissionMatch` class? I'm all ears!! 👂 👂 👂 

## Add behavior, update UI

So with my refactored class, I then was able to add the support for the second filtering and then update the UI. I asked for some design direction and got this as a comp:

https://www.figma.com/file/hk8hC98BhKuWTdxQpBiDoY/Convection?node-id=0%3A1

I had to do a little faffing to get the watt-based layout to behave, but it wasn't too bad.

/cc @artsy/csgn-devs 

https://artsyproduct.atlassian.net/browse/CSGN-321