### PR TITLE
CSGN-307: Allow more submissions to be returned in queries

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -61,7 +61,7 @@ module Types
 
     field :submissions,
           SubmissionConnectionType,
-          null: true, connection: true do
+          null: true, connection: true, max_page_size: 100 do
       description 'Filter all submission'
 
       argument :ids, [ID], required: false do

--- a/spec/requests/api/graphql/queries/submissions_spec.rb
+++ b/spec/requests/api/graphql/queries/submissions_spec.rb
@@ -482,5 +482,91 @@ describe 'submissions query' do
         end
       end
     end
+
+    describe 'max page size' do
+      before do
+        Fabricate.times 100, :submission
+        expect(Submission.count).to eq 101
+      end
+
+      context 'with no page size specified' do
+        let(:query) do
+          <<-GRAPHQL
+          query {
+            submissions {
+              edges {
+                node {
+                  id,
+                  artistId,
+                  title
+                }
+              }
+            }
+          }
+          GRAPHQL
+        end
+
+        it 'returns 100 submissions' do
+          post '/api/graphql', params: { query: query }, headers: headers
+
+          body = JSON.parse(response.body)
+          edges = body['data']['submissions']['edges']
+
+          expect(edges.count).to eq 100
+        end
+      end
+
+      context 'with the default max page size' do
+        let(:query_inputs) { 'first: 20' }
+
+        it 'returns 20 submissions' do
+          post '/api/graphql', params: { query: query }, headers: headers
+
+          body = JSON.parse(response.body)
+          edges = body['data']['submissions']['edges']
+
+          expect(edges.count).to eq 20
+        end
+      end
+
+      context 'with an in-between page size' do
+        let(:query_inputs) { 'first: 77' }
+
+        it 'returns 77 submissions' do
+          post '/api/graphql', params: { query: query }, headers: headers
+
+          body = JSON.parse(response.body)
+          edges = body['data']['submissions']['edges']
+
+          expect(edges.count).to eq 77
+        end
+      end
+
+      context 'with the max page size for submissions' do
+        let(:query_inputs) { 'first: 100' }
+
+        it 'returns 100 submissions' do
+          post '/api/graphql', params: { query: query }, headers: headers
+
+          body = JSON.parse(response.body)
+          edges = body['data']['submissions']['edges']
+
+          expect(edges.count).to eq 100
+        end
+      end
+
+      context 'with 1 more than the max page size for submissions' do
+        let(:query_inputs) { 'first: 101' }
+
+        it 'returns only 100 submissions' do
+          post '/api/graphql', params: { query: query }, headers: headers
+
+          body = JSON.parse(response.body)
+          edges = body['data']['submissions']['edges']
+
+          expect(edges.count).to eq 100
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR cranks up the maximum number of submissions allowed to be returned all the way to 100. We have long been asking for more than 20 submissions using the `first` parameter to the query but it has not been supported because we have a default max of 20:

https://github.com/artsy/convection/blob/559a47b18a91189ce41c07f24edcc0a6054f1c0b/app/graphql/convection_schema.rb#L6

So then I looked up [the docs](https://graphql-ruby.org/pagination/using_connections.html#max-page-size) and read them more closely than I have before and allowing more submissions to be returned was as easy as passing the `max_page_size` option with a value of 100.

That's all this PR does and then I wrapped some tests around so that it was more clear how this property behaves at different values.

https://artsyproduct.atlassian.net/browse/CSGN-307

/cc @artsy/csgn-devs 