### PR TITLE
CSGN-332: Consignment offers are accepted

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -19,7 +19,7 @@ class Offer < ApplicationRecord
     PURCHASE = 'purchase'
   ].freeze
 
-  # FIXME: deprecate 'accepted' state
+  # FIXME: deprecate 'consigned' state
   STATES = [
     DRAFT = 'draft',
     SENT = 'sent',

--- a/app/services/offer_service.rb
+++ b/app/services/offer_service.rb
@@ -47,13 +47,13 @@ class OfferService
 
     def update_offer_state(offer, current_user)
       case offer.state
-      when 'sent'
+      when Offer::SENT
         send_offer!(offer, current_user)
-      when 'review'
+      when Offer::REVIEW
         review!(offer)
-      when 'consigned'
+      when Offer::ACCEPTED
         consign!(offer)
-      when 'rejected'
+      when Offer::REJECTED
         reject!(offer, current_user)
       end
     end

--- a/app/views/admin/offers/_state_actions.html.erb
+++ b/app/views/admin/offers/_state_actions.html.erb
@@ -1,4 +1,4 @@
-<% unless @offer.rejected? || @offer.lapsed? || @offer.consigned? %>
+<% unless @offer.rejected? || @offer.lapsed? || @offer.accepted? %>
   <% if @offer.draft? %>
     <div class='overview-section offer-draft-actions'>
       <div class='single-padding-top'>
@@ -14,8 +14,8 @@
                 data: { confirm: 'This action will delete the offer. This action cannot be undone.' }) %>
         </div>
         <div class='single-padding-top mark-as-consigned-link-wrapper'>
-          <%= link_to('Mark as Consigned',
-                admin_offer_path(@offer, offer: { state: 'consigned' }),
+          <%= link_to('Accept Offer',
+                admin_offer_path(@offer, offer: { state: 'accepted' }),
                 method: :put,
                 class: 'mark-as-consigned-link',
                 data: { confirm: 'This action will complete the consignment. This action cannot be undone.' }) %>
@@ -46,14 +46,14 @@
             <%= check_box_tag 'terms_signed' %>
             <span class='purple-label'>Required:</span> Terms signed.
             <div class='single-padding-top'>
-              <%= link_to('Complete Consignment',
-                    admin_offer_path(@offer, offer: { state: 'consigned' }),
+              <%= link_to('Accept Offer',
+                    admin_offer_path(@offer, offer: { state: 'accepted' }),
                     method: :put,
                     class: 'btn btn-primary btn-small btn-full-width offer-consign-button disabled-button',
                     data: { confirm: 'This action will complete the consignment. This action cannot be undone.' }) %>
             </div>
             <div class='single-padding-top'>
-              <i>When offer is consigned, all other competing offers will lock.</i>
+              <i>When offer is accepted, all other competing offers will lock.</i>
             </div>
           </div>
         <% end %>

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -287,11 +287,7 @@ describe OfferService do
         context 'with an offer on a non-approved submission' do
           it 'raises an error' do
             expect {
-              OfferService.update_offer(
-                offer,
-                'userid',
-                state: Offer::CONSIGNED
-              )
+              OfferService.update_offer(offer, 'userid', state: Offer::ACCEPTED)
             }.to raise_error(
               OfferService::OfferError,
               'Cannot complete consignment on non-approved submission'
@@ -307,7 +303,7 @@ describe OfferService do
             OfferService.update_offer(
               consignable_offer,
               'userid',
-              state: Offer::CONSIGNED
+              state: Offer::ACCEPTED
             )
             expect(ActionMailer::Base.deliveries.count).to eq 0
             expect(ps.state).to eq 'open'

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -202,8 +202,8 @@ describe 'admin/offers/show.html.erb', type: :feature do
         page.visit "/admin/offers/#{offer.id}"
       end
 
-      it 'shows the complete consignment button' do
-        expect(page).to have_content('Complete Consignment')
+      it 'shows the accept offer button' do
+        expect(page).to have_content('Accept Offer')
         expect(page).to_not have_selector('.offer-draft-actions')
         expect(page).to have_selector('.offer-actions')
       end
@@ -218,7 +218,7 @@ describe 'admin/offers/show.html.erb', type: :feature do
         find('.offer-consign-button').click
         page.driver.browser.switch_to.alert.accept
         expect(page).to have_content("Offer ##{offer.reference_id}")
-        expect(page).to_not have_content('Complete Consignment')
+        expect(page).to_not have_content('Accept Offer')
         expect(page).to have_selector('.list-item--consignment')
 
         # FIXME: Why do these two lines cause test to fail


### PR DESCRIPTION
This PR continues the five-step process of deprecating the consigned offer state.

## Step 1

Add `accepted` as a "consigned" state in Volt. This means that there would be two offer states considered consigned for some amount of time. This gives us the room to do our work without breaking anything for our CMS users. I've got a PR for this here: https://github.com/artsy/volt/pull/4572.

## Step 2

Next we promote `Offer::ACCEPTED` as the canonical state for an offer that has been accepted. This was previously the `Offer::CONSIGNED` state, but that was confusing. More on this in a bit but this PR does this step in the process.

## Step 3

Once this change has made its way to production, I will open a Rails console and update all existing offers that are currently set as `consigned` over to `accepted`:

```ruby
Offer.where(state: Offer::CONSIGNED).update_all(state: Offer::ACCEPTED)
```

I will then wait a couple days and check back. What I would expect is that the count of offers with a consigned state would still be zero. If so, onto Step 4.

## Step 4

Now we can go back to CMS and remove consigned as an offer state over there.

## Step 5

Once I'm sure that the data is updated and there are no codepaths to set an offer to `consigned` anymore, then I can do a PR to properly drop it as an option altogether. I'll probably do a grep on the project and delete things as I find them and then run the tests. 

## Why do this - what was confusing?

There's a long Slack thread here:

https://artsy.slack.com/archives/CS3H1K4BD/p1597166066433800

But what we figured out along the way was that we had a problem where a canceled consignment would still have it's offer set as consigned. This lead to lots of conversation but I ended up pitching that an Offer that's been accepted should have that state and not change. If the consignment is canceled, that doesn't change the fact that the offer had been accepted originally.

So with this insight, we were able to get some related reports updated:

https://artsy.slack.com/archives/CS3H1K4BD/p1597345629059100

And now I'm coming back to this topic to clean things up. This work has the added benefit of putting the `PartnerSubmission` record as the source of truth about the outcome of the negotiation between the consignor and the partner. Having one source of truth is awesome!!

https://artsyproduct.atlassian.net/browse/CSGN-332