### PR TITLE
CSGN-332: Fully deprecate the consigned offer state

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -19,15 +19,13 @@ class Offer < ApplicationRecord
     PURCHASE = 'purchase'
   ].freeze
 
-  # FIXME: deprecate 'consigned' state
   STATES = [
     DRAFT = 'draft',
     SENT = 'sent',
     ACCEPTED = 'accepted',
     REJECTED = 'rejected',
     LAPSED = 'lapsed',
-    REVIEW = 'review',
-    CONSIGNED = 'consigned'
+    REVIEW = 'review'
   ].freeze
 
   REJECTION_REASONS = [

--- a/spec/requests/api/graphql/queries/offers_spec.rb
+++ b/spec/requests/api/graphql/queries/offers_spec.rb
@@ -89,10 +89,10 @@ describe 'offers query' do
       let(:consigned_partner_submission) do
         Fabricate :partner_submission, partner: partner
       end
-      let!(:consigned_offer) do
+      let!(:accepted_offer) do
         Fabricate :offer,
                   partner_submission: consigned_partner_submission,
-                  state: 'consigned'
+                  state: 'accepted'
       end
 
       let(:query_inputs) do


### PR DESCRIPTION
This is the fifth and final step of the plan outlined here: https://github.com/artsy/convection/pull/764 to deprecate the consigned offer state and replace it with accepted to more closely match reality.

https://artsyproduct.atlassian.net/browse/CSGN-332

/cc @artsy/csgn-devs @ashleyjelks 