### PR TITLE
CSGN-300: Set assigned to on submission page

### DIFF
--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -60,7 +60,11 @@
             </div>
             <div class='bold-label single-padding-top'>Assigned To:</div>
             <div class='single-padding-top'>
-              <%= @submission.assigned_to || 'Unassigned' %>
+              <%= form_with model: [:admin, @submission] do |f| %>
+                <% options = [['Please select one', '']] + Convection.config.admin_names %>
+                <%= f.select :assigned_to, options %>
+                <%= f.submit 'Update' %>
+              <% end %>
             </div>
             <div class='single-padding-top'>
               <% if @submission.state == Submission::APPROVED %>

--- a/spec/system/submission_editing_spec.rb
+++ b/spec/system/submission_editing_spec.rb
@@ -46,18 +46,45 @@ describe 'Editing a submission', type: :feature do
   end
 
   context 'adding an admin to a submission' do
-    it 'displays that admin on the submission detail page' do
-      visit admin_submission_path(submission)
-      expect(page).to have_content('Unassigned')
+    context 'from the edit screen' do
+      it 'displays that admin on the submission detail page' do
+        visit admin_submission_path(submission)
+        expect(page).to_not have_select(
+                              'submission[assigned_to]',
+                              selected: 'Alice'
+                            )
 
-      click_on 'Edit'
-      expect(page).to have_content 'Assigned To:'
+        click_on 'Edit'
+        expect(page).to have_content 'Assigned To:'
 
-      select 'Alice', from: 'submission[assigned_to]'
-      click_button 'Save'
+        select 'Alice', from: 'submission[assigned_to]'
+        click_button 'Save'
 
-      expect(page).to have_current_path(admin_submission_path(submission))
-      expect(page).to have_content('Alice')
+        expect(page).to have_current_path(admin_submission_path(submission))
+        expect(page).to have_select(
+          'submission[assigned_to]',
+          selected: 'Alice'
+        )
+      end
+    end
+
+    context 'from the detail screen' do
+      it 'displays that admin on the submission detail page' do
+        visit admin_submission_path(submission)
+        expect(page).to_not have_select(
+                              'submission[assigned_to]',
+                              selected: 'Alice'
+                            )
+
+        select 'Alice', from: 'submission[assigned_to]'
+        click_button 'Update'
+
+        expect(page).to have_current_path(admin_submission_path(submission))
+        expect(page).to have_select(
+          'submission[assigned_to]',
+          selected: 'Alice'
+        )
+      end
     end
   end
 


### PR DESCRIPTION
This PR updates the submission detail screen so that an admin can assign the submission without having to go to the edit screen:

<img width="1147" alt="Screen Shot 2020-08-26 at 2 44 31 PM" src="https://user-images.githubusercontent.com/79799/91349260-ac561280-e7aa-11ea-9430-b0e222fc3f54.png">

https://artsyproduct.atlassian.net/browse/CSGN-300

/cc @artsy/csgn-devs 