### PR TITLE
CSGN-303: Add user submission count

### DIFF
--- a/app/views/admin/submissions/_collector_info.html.erb
+++ b/app/views/admin/submissions/_collector_info.html.erb
@@ -5,6 +5,9 @@
       <%= submission.user&.name %>
     </div>
     <div>
+      <%= submission.user&.submissions&.count || 0 %> submissions made
+    </div>
+    <div>
       <%= submission.user&.user_detail&.email %>
     </div>
     <div>


### PR DESCRIPTION
This PR just added a bit to the submission detail page for showing the count of submissions a user has made:

<img width="1179" alt="Screen Shot 2020-08-26 at 4 40 50 PM" src="https://user-images.githubusercontent.com/79799/91359876-fe069900-e7ba-11ea-9dbb-e7fb332b5ea4.png">

https://artsyproduct.atlassian.net/browse/CSGN-303

/cc @artsy/csgn-devs 