### PR TITLE
CSGN-160: Add hold state to submission

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -19,6 +19,7 @@ class Submission < ApplicationRecord
     APPROVED = 'approved',
     PUBLISHED = 'published',
     REJECTED = 'rejected',
+    HOLD = 'hold',
     CLOSED = 'closed'
   ].freeze
 

--- a/app/models/submission_state_actions.rb
+++ b/app/models/submission_state_actions.rb
@@ -14,11 +14,13 @@ class SubmissionStateActions
   def run
     case submission.state
     when Submission::SUBMITTED
-      [approve_action, publish_action, reject_action, close_action]
+      [approve_action, publish_action, hold_action, reject_action, close_action]
     when Submission::APPROVED
-      [publish_action, close_action]
+      [publish_action, hold_action, close_action]
     when Submission::PUBLISHED
       [close_action]
+    when Submission::HOLD
+      [approve_action, publish_action, reject_action, close_action]
     else
       []
     end
@@ -66,6 +68,15 @@ class SubmissionStateActions
       confirm: 'No email will be sent.',
       state: 'closed',
       text: 'Close'
+    }
+  end
+
+  def hold_action
+    {
+      class: default_classes << 'btn-delete',
+      confirm: 'No email will be sent to the consignor.',
+      state: 'hold',
+      text: 'Hold'
     }
   end
 end

--- a/spec/models/submission_state_actions_spec.rb
+++ b/spec/models/submission_state_actions_spec.rb
@@ -17,20 +17,20 @@ describe SubmissionStateActions do
   context 'with a submitted submission' do
     let(:state) { 'submitted' }
 
-    it 'returns approve, publish, reject and close actions' do
+    it 'returns approve, publish, hold, reject and close actions' do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
-      expect(states).to eq %w[approved published rejected closed]
+      expect(states).to eq %w[approved published hold rejected closed]
     end
   end
 
   context 'with an approved submission' do
     let(:state) { 'approved' }
 
-    it 'returns the publish and close actions' do
+    it 'returns the publish, hold and close actions' do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
-      expect(states).to eq %w[published closed]
+      expect(states).to eq %w[published hold closed]
     end
   end
 
@@ -41,6 +41,16 @@ describe SubmissionStateActions do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
       expect(states).to eq %w[closed]
+    end
+  end
+
+  context 'with an on hold submission' do
+    let(:state) { 'hold' }
+
+    it 'returns approve, publish, reject and close actions' do
+      actions = SubmissionStateActions.for(submission)
+      states = actions.pluck(:state)
+      expect(states).to eq %w[approved published rejected closed]
     end
   end
 


### PR DESCRIPTION
This PR add a new state of a submission called `hold` that represents when a submission is temporarily not available. It looks like this:

<img width="1212" alt="Screen Shot 2020-08-28 at 10 12 00 AM" src="https://user-images.githubusercontent.com/79799/91583609-14c20280-e917-11ea-9d4d-06317a6059c8.png">

And then once set to hold, this can be altered like so:

<img width="1212" alt="Screen Shot 2020-08-28 at 10 11 48 AM" src="https://user-images.githubusercontent.com/79799/91583655-24d9e200-e917-11ea-8872-8ce49e47a981.png">

So that gives admins a lot of control about how they want to manage their submissions.

In terms of code, this was a pretty cheap change - I had previously extracted a class to represent the logic around which actions are appropriate for a given submission called `SubmissionStateActions` with unit tests and everything! So, I added a new item to the valid states on the Submission model and then came to that file and added the hold action. I updated a couple specs and this was done!

https://artsyproduct.atlassian.net/browse/CSGN-160

/cc @artsy/csgn-devs @louislecluse 