### PR TITLE
CSGN-293: Expose edition info on submission detail page

### DIFF
--- a/app/views/admin/submissions/_submission_details.html.erb
+++ b/app/views/admin/submissions/_submission_details.html.erb
@@ -45,6 +45,24 @@
 
 <div class='overview-item'>
   <div class='overview-item-title'>
+    Edition Size
+  </div>
+  <div class='overview-item-value'>
+    <%= @submission.edition_size %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Edition Number
+  </div>
+  <div class='overview-item-value'>
+    <%= @submission.edition_number %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
     Dimensions
   </div>
   <div class='overview-item-value'>

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -30,7 +30,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
           title: 'my sartwork',
           artist_id: 'artistid',
           edition: true,
-          edition_size: 100,
+          edition_size: 77,
           edition_number: '23a',
           category: 'Painting',
           user: Fabricate(:user, gravity_user_id: 'userid'),
@@ -47,6 +47,8 @@ describe 'admin/submissions/show.html.erb', type: :feature do
       expect(page).to have_content('Jon Jonson')
       expect(page).to have_content('user@example.com')
       expect(page).to have_content('Painting')
+      expect(page).to have_content('77')
+      expect(page).to have_content('23a')
     end
 
     it 'displays no undo links' do


### PR DESCRIPTION
This PR adds a couple fields to the submission detail view, it looks like this:

<img width="1125" alt="Screen Shot 2020-08-28 at 10 25 06 AM" src="https://user-images.githubusercontent.com/79799/91589124-d892a000-e91e-11ea-88a7-aaa9b0118157.png">

https://artsyproduct.atlassian.net/browse/CSGN-293

/cc @artsy/csgn-devs 