### PR TITLE
Remove stale config

### DIFF
--- a/config/puma.config
+++ b/config/puma.config
@@ -2,7 +2,6 @@
 
 directory "/app"
 environment ENV.fetch("RAILS_ENV") { "development" }
-daemonize false
 pidfile  "/shared/pids/puma.pid"
 state_path "/shared/pids/puma.state"
 threads ENV.fetch("PUMA_THREAD_MIN") { 0 }.to_i, ENV.fetch("PUMA_THREAD_MAX") { 16 }.to_i


### PR DESCRIPTION
The daemonize mode of running Puma was removed in version 5:

> tcp mode and daemonization have been removed without replacement. For daemonization, please use a modern process management solution, such as systemd or monit.

https://github.com/puma/puma/blob/master/5.0-Upgrade.md

So this just removes the stale config.

I believe this will get master back to green and a deployable state, but it was tricky to reproduce this locally. 🤷 

/cc @artsy/csgn-devs 