### PR TITLE
Configure Event Service to determine TLS flag from ENV.

### DIFF
--- a/config/initializers/artsy_eventservice.rb
+++ b/config/initializers/artsy_eventservice.rb
@@ -4,7 +4,7 @@ Artsy::EventService.configure do |config|
   config.app_name = 'artsy-convection'
   config.event_stream_enabled = true
   config.rabbitmq_url = ENV['RABBITMQ_URL']
-  config.tls = true
+  config.tls = ENV['RABBITMQ_TLS']
   config.tls_ca_certificate = Base64.decode64(ENV['RABBITMQ_CA_CERT'] || '')
   config.tls_cert = Base64.decode64(ENV['RABBITMQ_CLIENT_CERT'] || '')
   config.tls_key = Base64.decode64(ENV['RABBITMQ_CLIENT_KEY'] || '')

--- a/config/initializers/artsy_eventservice.rb
+++ b/config/initializers/artsy_eventservice.rb
@@ -4,7 +4,7 @@ Artsy::EventService.configure do |config|
   config.app_name = 'artsy-convection'
   config.event_stream_enabled = true
   config.rabbitmq_url = ENV['RABBITMQ_URL']
-  config.tls = ENV['RABBITMQ_TLS']
+  config.tls = ENV['RABBITMQ_CLIENT_CERT'].present? # following configs are only used if tls is true
   config.tls_ca_certificate = Base64.decode64(ENV['RABBITMQ_CA_CERT'] || '')
   config.tls_cert = Base64.decode64(ENV['RABBITMQ_CLIENT_CERT'] || '')
   config.tls_key = Base64.decode64(ENV['RABBITMQ_CLIENT_KEY'] || '')


### PR DESCRIPTION
Under https://artsyproduct.atlassian.net/browse/PLATFORM-2834, we would like to switch Convection to use the  internal endpoint of RabbitMQ:

Staging: `rabbitmq.stg.artsy.systems`
Production: ` rabbitmq.prd.artsy.systems`

These endpoints, unlike the internet-facing ones currently in use, do not support TLS. Therefore, at the same time we make that switch, we will also have to tell Convection to not use TLS.

Convection is currently hardcoded to always use TLS, by `config.tls = true`. This PR is to let the flag be determined via ENV. After this PR, Convection continues to connect to RabbitMQ on its internet-facing endpoint and continues to use TLS.

Later on, we will switch Convection to Rabbit's internal endpoint, and it will be entirely done through ENV, by unsetting `RABBITMQ_CA_CERT,RABBITMQ_CLIENT_CERT,RABBITMQ_CLIENT_KEY,RABBITMQ_NO_VERIFY_PEER` and changing RABBITMQ_URL.