### PR TITLE
chore: switch from system tzdata to tzinfo-data gem for timezone happiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN apk update && apk --no-cache --quiet add \
   nodejs \
   postgresql-dev \
   postgresql-client \
-  tzdata \
   yarn \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
   && adduser -D -g '' deploy

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'redcarpet'
 gem 'sass-rails'
 gem 'sentry-raven' # for error reporting
 gem 'sidekiq'
+gem 'tzinfo-data' # overrides system time zone data
 gem 'uglifier'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -436,6 +436,8 @@ GEM
     tilt (2.0.10)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2020.4)
+      tzinfo (>= 1.0.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
@@ -506,6 +508,7 @@ DEPENDENCIES
   sentry-raven
   sidekiq
   solargraph
+  tzinfo-data
   uglifier
   watt!
   webdrivers

--- a/spec/lib/time_zone_spec.rb
+++ b/spec/lib/time_zone_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Time zones' do
+  it 'handles daylight saving time properly' do
+    utc = '2020-12-01T00:00:00+00:00'
+    est = '2020-11-30T19:00:00-05:00'
+    expect(Time.parse(utc).in_time_zone('America/New_York').iso8601).to eq est
+  end
+end


### PR DESCRIPTION
Addresses [CX-744](https://artsyproduct.atlassian.net/browse/CX-744).

Like our other rails apps, this PR removes `tzdata` from the docker manifest, instead opting for the `tzinfo-data` gem to handle time zone data. 

See https://github.com/artsy/volt/commit/fbb846a9b95214b4b2d4cea3a6cca64a872b37da for an origin story of these changes, or something like https://github.com/artsy/diffusion/pull/347 for a similar PR. 