### PR TITLE
Feature: Adds OfferResponse model

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -41,6 +41,7 @@ class Offer < ApplicationRecord
   belongs_to :partner_submission
   belongs_to :submission, counter_cache: true
   has_one :partner, through: :partner_submission
+  has_many :offer_responses, dependent: :destroy
 
   validates :state, inclusion: { in: STATES }
   validates :offer_type, inclusion: { in: OFFER_TYPES }, allow_nil: true

--- a/app/models/offer_response.rb
+++ b/app/models/offer_response.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class OfferResponse < ApplicationRecord
+  INTENDED_STATES = [Offer::ACCEPTED, Offer::REJECTED, Offer::REVIEW].freeze
+
+  belongs_to :offer
+
+  validates :intended_state, inclusion: { in: INTENDED_STATES }
+  validates :rejection_reason,
+            inclusion: { in: Offer::REJECTION_REASONS }, allow_nil: true
+end

--- a/db/migrate/20201111212135_add_offers_response_model.rb
+++ b/db/migrate/20201111212135_add_offers_response_model.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddOffersResponseModel < ActiveRecord::Migration[6.0]
+  def change
+    create_table :offer_responses do |t|
+      t.references :offer, foreign_key: true, index: true
+      t.string :intended_state, null: false
+      t.string :phone_number
+      t.text :comments
+      t.string :rejection_reason
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_26_154051) do
+ActiveRecord::Schema.define(version: 2020_11_11_212135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pg_trgm'
   enable_extension 'plpgsql'
@@ -39,6 +39,17 @@ ActiveRecord::Schema.define(version: 2020_08_26_154051) do
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
     t.index %w[submission_id], name: 'index_notes_on_submission_id'
+  end
+
+  create_table 'offer_responses', force: :cascade do |t|
+    t.bigint 'offer_id'
+    t.string 'intended_state', null: false
+    t.string 'phone_number'
+    t.text 'comments'
+    t.string 'rejection_reason'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index %w[offer_id], name: 'index_offer_responses_on_offer_id'
   end
 
   create_table 'offers', id: :serial, force: :cascade do |t|
@@ -183,6 +194,7 @@ ActiveRecord::Schema.define(version: 2020_08_26_154051) do
 
   add_foreign_key 'assets', 'submissions'
   add_foreign_key 'notes', 'submissions'
+  add_foreign_key 'offer_responses', 'offers'
   add_foreign_key 'offers', 'partner_submissions', on_delete: :cascade
   add_foreign_key 'offers', 'submissions', on_delete: :cascade
   add_foreign_key 'partner_submissions',

--- a/spec/models/offer_responses_spec.rb
+++ b/spec/models/offer_responses_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/gravity_helper'
+
+describe OfferResponse do
+  context 'intended_state' do
+    it 'allows only certain intended_states' do
+      expect(OfferResponse.new(intended_state: 'blah')).not_to be_valid
+      expect(OfferResponse.new(intended_state: Offer::ACCEPTED)).to be_valid
+      expect(OfferResponse.new(intended_state: Offer::SENT)).not_to be_valid
+    end
+
+    it 'is required' do
+      expect(OfferResponse.new).not_to be_valid
+    end
+  end
+
+  context 'rejection_reason' do
+    it 'allows only certain rejection_reasons' do
+      expect(
+        OfferResponse.new(
+          intended_state: Offer::REJECTED, rejection_reason: 'Low estimate'
+        )
+      ).to be_valid
+      expect(
+        OfferResponse.new(
+          intended_state: Offer::REJECTED, rejection_reason: 'meow'
+        )
+      ).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
Currently, there is no way for consignors to formally respond to offers. After receiving an offer via email, they can indicate their intent through a Google form, which Artsy admins must then copy over into convection's admin UI.

This PR is the first step toward allowing us to capture and display consignor's "offer responses" within convection.

**Intent of this PR**: Model out a basic `OfferResponse` to capture the data we want to collect from consignors.

**Out of scope**: API work, admin UI, etc. Those will come in subsequent PRs.

**Important bits of context**:
- Our admins do not want the consignor's response to actually change the state of the offer itself. Often the consignor has questions or would benefit from speaking with an Artsy admin before making a final call. This is the main reason to even have a separate `OfferResponse` data model!
- It doesn't seem bad to allow multiple responses to a single offer (and we don't intend to invest much in the UI-side, so this will likely be possible from clients). Therefore, an offer `has_many :offer_responses`. 

**Data model definition**:
```ruby
class AddOffersResponseModel < ActiveRecord::Migration[6.0]
  def change
    create_table :offer_responses do |t|
      ## Offer responses belong to offers, as consignors will be responding to offers directly.
      t.references :offer, foreign_key: true, index: true

      ## Right now, offer responses do not change the state of the offer, but in the future they could. This
      ## field captures the potential state of the offer after this response, but is not binding.
      t.string :intended_state, null: false

      ## In most cases, an Artsy admin will want to reach out to the consignor directly after receiving the response.
      t.string :phone_number

      ## This field is a catch-all for questions/comments/etc. that the consignor may have in response to the offer.
      t.text :comments

      ## This field matches the accepted rejection reasons on the Offer model so that we can easily "graduate" them.
      t.string :rejection_reason

      ## Standard!
      t.timestamps
    end
  end
end

```