### PR TITLE
Feature: Updates admin interface to handle offer responses

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -685,6 +685,16 @@ enum OfferSort {
   NOTES_DESC
 
   """
+  sort by offer_responses_count in ascending order
+  """
+  OFFER_RESPONSES_COUNT_ASC
+
+  """
+  sort by offer_responses_count in descending order
+  """
+  OFFER_RESPONSES_COUNT_DESC
+
+  """
   sort by offer_type in ascending order
   """
   OFFER_TYPE_ASC

--- a/app/assets/javascripts/match_offer.js.coffee
+++ b/app/assets/javascripts/match_offer.js.coffee
@@ -5,7 +5,7 @@ $ ->
       source: (request, response) ->
         compiledData = []
         currentStateFilter = $('#state :selected').val()
-        baseURL = "/admin/offers?state=#{currentStateFilter}"
+        baseURL = encodeURI("/admin/offers?state=#{currentStateFilter}")
         respond = _.after 3, ->
           response compiledData
         $.getJSON '/admin/offers', { term: request.term, size: 5, format: 'json' }, (data) ->

--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -12,12 +12,24 @@ $green: #0eda83;
   text-transform: uppercase;
 }
 
+.bold {
+  font-weight: bold;
+}
+
 .gray-label {
   color: #999999;
 }
 
 .purple-label {
   color: $purple;
+}
+
+.red {
+  color: $red;
+}
+
+.green {
+  color: $green;
 }
 
 .flex-label {

--- a/app/controllers/admin/offers_controller.rb
+++ b/app/controllers/admin/offers_controller.rb
@@ -25,7 +25,15 @@ module Admin
       end
 
       if params[:state].present?
-        matching_offers = matching_offers.where(state: params[:state])
+        matching_offers =
+          if params[:state] == 'sent with response'
+            matching_offers.where(state: Offer::SENT).where(
+              'offer_responses_count > ?',
+              0
+            )
+          else
+            matching_offers.where(state: params[:state])
+          end
       end
 
       sort = params[:sort].presence || 'id'

--- a/app/models/offer_response.rb
+++ b/app/models/offer_response.rb
@@ -3,7 +3,7 @@
 class OfferResponse < ApplicationRecord
   INTENDED_STATES = [Offer::ACCEPTED, Offer::REJECTED, Offer::REVIEW].freeze
 
-  belongs_to :offer
+  belongs_to :offer, counter_cache: true
 
   validates :intended_state, inclusion: { in: INTENDED_STATES }
   validates :rejection_reason,

--- a/app/views/admin/offer_responses/_offer_response_section.html.erb
+++ b/app/views/admin/offer_responses/_offer_response_section.html.erb
@@ -1,0 +1,40 @@
+<% truncated = false if local_assigns[:truncated].nil? %>
+
+<div class='double-padding-top'>
+  <% if offer_response.intended_state == Offer::ACCEPTED %>
+    <div class="green">
+      Accept offer
+    </div>
+  <% elsif offer_response.intended_state == Offer::REVIEW %>
+    <div class="purple-label">
+      Interested in offer
+    </div>
+  <% else %>
+    <div class="red">
+      Reject offer
+    </div>
+    <% if offer_response.rejection_reason.present? %>
+      <div>
+        <span class="bold">Reason: </span><%= offer_response.rejection_reason %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% unless truncated %>
+    <% if offer_response.comments.present? %>
+      <div>
+        <span class="bold">Comments: </span><%= offer_response.comments %>
+      </div>
+    <% end %>
+
+    <% if offer_response.phone_number.present? %>
+      <div>
+        <span class="bold">Phone number: </span><%= offer_response.phone_number %>
+      </div>
+    <% end %>
+
+    <div>
+      <span class="bold">Date: </span><%= offer_response.created_at.strftime('%b %-d %Y') %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/offer_responses/_offer_responses_section.html.erb
+++ b/app/views/admin/offer_responses/_offer_responses_section.html.erb
@@ -1,0 +1,10 @@
+<% if offer_responses.present? && offer_responses.any? %>
+  <div class='overview-section'>
+    <div class='overview-section-title--inline'>
+      Offer responses
+    </div>
+    <% offer_responses.order(created_at: :desc).each do |offer_response| %>
+      <%= render 'admin/offer_responses/offer_response_section', offer_response: offer_response %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/offers/_offer.html.erb
+++ b/app/views/admin/offers/_offer.html.erb
@@ -12,10 +12,24 @@
     <% end %>
   </span>
   <div class='list-group-item-info'>
-    <%= offer.state %>
-  </div>
-  <div class='list-group-item-info'>
-    #<%= offer.reference_id %>
+    <% if offer.state != Offer::SENT || offer.offer_responses.empty? %>
+      <%= offer.state %>
+    <% else %>
+      <% offer_response = offer.offer_responses.order(created_at: :desc).first %>
+      <% if offer_response.intended_state == Offer::ACCEPTED %>
+        <div class='green'>
+          Response: Accept
+        </div>
+      <% elsif offer_response.intended_state == Offer::REJECTED %>
+        <div class='red'>
+          Response: Reject
+        </div>
+      <% else %>
+        <div class='purple-label'>
+          Response: Interested
+        </div>
+      <% end %>
+    <% end %>
   </div>
   <div class='list-group-item-info'>
     <%= offer.created_at.strftime('%m/%d/%Y') %>

--- a/app/views/admin/offers/index.html.erb
+++ b/app/views/admin/offers/index.html.erb
@@ -37,9 +37,6 @@
           State
         </div>
         <div class='list-group-item-info bold-label'>
-          ID
-        </div>
-        <div class='list-group-item-info bold-label'>
           <%= render 'admin/shared/sort_label', filters: filters, sort_field: 'offers.created_at', label: 'Date' %>
         </div>
         <div class='list-group-item-info bold-label'>

--- a/app/views/admin/offers/index.html.erb
+++ b/app/views/admin/offers/index.html.erb
@@ -12,7 +12,7 @@
           <div class='form-group'>
             <%= select_tag 'state',
                           options_for_select(
-                            Offer::STATES.map{ |state| [state, state] }.unshift(['all', nil]),
+                            Offer::STATES.map{ |state| [state, state] }.unshift(['all', nil], ['sent with response', 'sent with response']),
                             filters[:state]
                           ),
                           class: 'form-control',

--- a/app/views/admin/offers/show.html.erb
+++ b/app/views/admin/offers/show.html.erb
@@ -20,6 +20,7 @@
           </div>
           <%= render 'admin/consignments/consignment_section', consignment: offer.submission.consigned_partner_submission, artist: artist %>
           <%= render 'admin/submissions/submission_section', submission: offer.submission, artist: artist %>
+          <%= render 'admin/offer_responses/offer_responses_section', offer_responses: offer.offer_responses %>
         </div>
       </div>
     </div>
@@ -38,6 +39,14 @@
             </div>
           </div>
           <%= render 'state_actions' %>
+          <% if offer.offer_responses&.any? %>
+            <div class='overview-section'>
+              <div class='bold-label'>
+                Most recent offer response
+              </div>
+              <%= render 'admin/offer_responses/offer_response_section', truncated: true, offer_response: offer.offer_responses.order(created_at: :desc).first %>
+            </div>
+          <% end %>
           <div class='overview-section'>
             <div class='bold-label'>State</div>
             <div class='single-padding-top'>

--- a/db/migrate/20201113001511_add_offer_responses_count_to_offers.rb
+++ b/db/migrate/20201113001511_add_offer_responses_count_to_offers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOfferResponsesCountToOffers < ActiveRecord::Migration[6.0]
   def change
     add_column :offers, :offer_responses_count, :integer

--- a/db/migrate/20201113001511_add_offer_responses_count_to_offers.rb
+++ b/db/migrate/20201113001511_add_offer_responses_count_to_offers.rb
@@ -1,0 +1,5 @@
+class AddOfferResponsesCountToOffers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :offers, :offer_responses_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_11_212135) do
+ActiveRecord::Schema.define(version: 2020_11_13_001511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pg_trgm'
   enable_extension 'plpgsql'
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2020_11_11_212135) do
     t.text 'partner_info'
     t.string 'deadline_to_consign'
     t.string 'sale_location'
+    t.integer 'offer_responses_count'
     t.index %w[partner_submission_id],
             name: 'index_offers_on_partner_submission_id'
     t.index %w[reference_id], name: 'index_offers_on_reference_id'

--- a/spec/controllers/admin/offers_controller_spec.rb
+++ b/spec/controllers/admin/offers_controller_spec.rb
@@ -205,6 +205,31 @@ describe Admin::OffersController, type: :controller do
                @offer1.id
              ]
         end
+
+        describe 'sent with response' do
+          it 'allows you to filter by state = sent with response' do
+            Fabricate(:offer_response, offer: @offer1)
+
+            get :index, params: { state: 'sent with response' }
+
+            expect(controller.offers.pluck(:id)).to eq [@offer1.id]
+          end
+
+          it 'allows you to filter by state = sent with response, search for partner, and sort by date' do
+            Fabricate(:offer_response, offer: @offer1)
+            Fabricate(:offer_response, offer: @offer2)
+            Fabricate(:offer_response, offer: @offer4)
+
+            get :index,
+                params: {
+                  state: 'sent with response',
+                  direction: 'desc',
+                  partner: @partner1.id
+                }
+
+            expect(controller.offers.pluck(:id)).to eq [@offer2.id, @offer1.id]
+          end
+        end
       end
     end
 

--- a/spec/fabricators/offer_response_fabricator.rb
+++ b/spec/fabricators/offer_response_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:offer_response) do
+  offer { Fabricate(:offer) }
+  intended_state 'accepted'
+end

--- a/spec/views/admin/offers/index.html.erb_spec.rb
+++ b/spec/views/admin/offers/index.html.erb_spec.rb
@@ -189,7 +189,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
         click_link("partner-#{@partner1.id}")
         expect(current_url).to include "&partner=#{@partner1.id}"
         expect(page).to have_selector('.list-group-item', count: 5)
-        expect(page).to have_content('sent', count: 4)
+        expect(page).to have_content('sent', count: 5) # 3 items + "sent" and "sent with response" filters
         expect(page).to have_content('draft', count: 2)
       end
 
@@ -208,7 +208,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
         click_link("partner-#{@partner1.id}")
         expect(current_url).to include "state=sent&partner=#{@partner1.id}"
         expect(page).to have_selector('.list-group-item', count: 4)
-        expect(page).to have_content('sent', count: 4)
+        expect(page).to have_content('sent', count: 5) # 3 items + "sent" and "sent with response" filters
         expect(page).to have_content('draft', count: 1)
       end
 

--- a/spec/views/admin/offers/index.html.erb_spec.rb
+++ b/spec/views/admin/offers/index.html.erb_spec.rb
@@ -44,6 +44,50 @@ describe 'admin/offers/index.html.erb', type: :feature do
       end
     end
 
+    context 'offer state' do
+      let(:offer) { Fabricate(:offer) }
+
+      it 'displays the correct state when the offer has a "reject" response' do
+        Fabricate(
+          :offer_response,
+          offer: offer, intended_state: Offer::REJECTED
+        )
+        page.visit admin_offers_path
+        expect(page).to have_content('Response: Reject')
+      end
+
+      it 'displays the correct state when the offer has an "accept" response' do
+        Fabricate(
+          :offer_response,
+          offer: offer, intended_state: Offer::ACCEPTED
+        )
+        page.visit admin_offers_path
+        expect(page).to have_content('Response: Accept')
+      end
+
+      it 'displays the correct state when the offer has an "interested" response' do
+        Fabricate(:offer_response, offer: offer, intended_state: Offer::REVIEW)
+        page.visit admin_offers_path
+        expect(page).to have_content('Response: Interested')
+      end
+
+      it 'displays the correct state when the offer is sent' do
+        offer.update!(state: Offer::SENT)
+        page.visit admin_offers_path
+        within(:css, 'a.list-group-item') do
+          expect(page).to have_content('sent')
+        end
+      end
+
+      it 'displays the correct state when the offer is accepted' do
+        offer.update!(state: Offer::ACCEPTED)
+        page.visit admin_offers_path
+        within(:css, 'a.list-group-item') do
+          expect(page).to have_content('accepted')
+        end
+      end
+    end
+
     context 'with some offers' do
       before do
         3.times { Fabricate(:offer, state: 'sent') }


### PR DESCRIPTION
This PR updates the `offer`, `offers`, and `submission` views to support offer responses.

## Migration
Because we added a `counter_cache` on `Offer#offer_responses_count` in order to easily support filtering, we'll need to reset all counters.

```
Offer.find_each do |offer|
  Offer.reset_counters(offer.id, :offer_responses_count)
end
```

## Offer view
We show the "most recent offer response" (since technically there can be multiple) in the sidebar.
<img width="349" alt="image" src="https://user-images.githubusercontent.com/2081340/99014312-7b22ee00-2520-11eb-8b14-6f2084680a9e.png">

We show the entire list of offer responses at the bottom of the page.
<img width="676" alt="image" src="https://user-images.githubusercontent.com/2081340/99014367-97268f80-2520-11eb-9067-c6c033c01dc8.png">

## Submission view
We show the list of offers with the response obvious.

Note: We only show the `Response: ` text if the offer is in the `sent` state and has a response. Once it has "advanced" to a different state, we show that state instead.
<img width="673" alt="image" src="https://user-images.githubusercontent.com/2081340/99014510-cccb7880-2520-11eb-97ae-14dfe7d685f6.png">

## Offers view
Same as in the submission view, if the offer is in the `sent` state and has a response, we show the response. Otherwise we show the state.

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/2081340/99014555-e240a280-2520-11eb-8305-55b7ec97673d.png">

We are also able to filter by offers that are `sent with response`. (i.e. in the state described above)
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/2081340/99014583-f389af00-2520-11eb-9ef3-fbd28aaada60.png">
