### PR TITLE
feat: allow submission user to be edited

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -53,7 +53,7 @@ module Admin
       @submission =
         SubmissionService.create_submission(
           submission_params.merge(state: 'submitted'),
-          params[:submission][:user_id]
+          submission_params[:user_id]
         )
       redirect_to admin_submission_path(@submission)
     rescue SubmissionService::SubmissionError => e
@@ -159,6 +159,7 @@ module Admin
         signature
         state
         title
+        user_id
         width
         year
       ]

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -5,8 +5,8 @@ class SubmissionService
   class SubmissionError < StandardError; end
 
   class << self
-    def create_submission(submission_params, current_user)
-      user = User.find_or_create_by!(gravity_user_id: current_user)
+    def create_submission(submission_params, gravity_user_id)
+      user = User.find_or_create_by!(gravity_user_id: gravity_user_id)
       create_params = submission_params.merge(user_id: user.id)
       submission = Submission.create!(create_params)
       UserService.delay.update_email(user.id)
@@ -16,7 +16,9 @@ class SubmissionService
     end
 
     def update_submission(submission, params, current_user: nil)
-      submission.assign_attributes(params)
+      user = User.find_or_create_by!(gravity_user_id: params[:user_id])
+      create_params = params.merge(user_id: user.id)
+      submission.assign_attributes(create_params)
       if submission.state_changed?
         update_submission_state(submission, current_user)
       end
@@ -184,7 +186,8 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      ).deliver_now
+      )
+        .deliver_now
     end
 
     def deliver_submission_notification(submission_id)
@@ -200,7 +203,8 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      ).deliver_now
+      )
+        .deliver_now
     end
 
     def deliver_approval_notification(submission_id)
@@ -214,7 +218,8 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      ).deliver_now
+      )
+        .deliver_now
     end
 
     def deliver_rejection_notification(submission_id)
@@ -228,7 +233,8 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      ).deliver_now
+      )
+        .deliver_now
     end
   end
 end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -16,9 +16,14 @@ class SubmissionService
     end
 
     def update_submission(submission, params, current_user: nil)
-      user = User.find_or_create_by!(gravity_user_id: params[:user_id])
-      create_params = params.merge(user_id: user.id)
-      submission.assign_attributes(create_params)
+      if params[:user_id]
+        user = User.find_or_create_by!(gravity_user_id: params[:user_id])
+        create_params = params.merge(user_id: user.id)
+        submission.assign_attributes(create_params)
+      else
+        submission.assign_attributes(params)
+      end
+
       if submission.state_changed?
         update_submission_state(submission, current_user)
       end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -186,8 +186,7 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      )
-        .deliver_now
+      ).deliver_now
     end
 
     def deliver_submission_notification(submission_id)
@@ -203,8 +202,7 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      )
-        .deliver_now
+      ).deliver_now
     end
 
     def deliver_approval_notification(submission_id)
@@ -218,8 +216,7 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      )
-        .deliver_now
+      ).deliver_now
     end
 
     def deliver_rejection_notification(submission_id)
@@ -233,8 +230,7 @@ class SubmissionService
         user: user,
         user_detail: user_detail,
         artist: artist
-      )
-        .deliver_now
+      ).deliver_now
     end
   end
 end

--- a/app/views/admin/submissions/_form.html.erb
+++ b/app/views/admin/submissions/_form.html.erb
@@ -22,7 +22,7 @@
               </label>
               <div class='col-sm-10' id='user_selections_form'>
                 <%= f.text_field :user, class: 'form-control', id: 'user_search' %>
-                <%= f.hidden_field :user_id %>
+                <%= f.hidden_field :user_id, :value => @submission&.user&.gravity_user_id %>
               </div>
             </div>
           </div>

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -223,6 +223,29 @@ describe SubmissionService do
       expect(submission.approved_at).to be_nil
       expect(submission.published_at).to be_nil
     end
+
+    it 'updates the user associated with the submission if a user ID is passed' do
+      new_user =
+        Fabricate(
+          :user,
+          gravity_user_id: 'new_gravity_user_id', email: 'cool.cat@fatcat.com'
+        )
+
+      SubmissionService.update_submission(
+        submission,
+        { user_id: 'new_gravity_user_id' }
+      )
+
+      expect(submission.user_id).to eq new_user.id
+    end
+
+    it 'does not update the user associated with the submission if no ID is passed' do
+      SubmissionService.update_submission(
+        submission,
+        { title: 'Excellent Artwork' }
+      )
+      expect(submission.user_id).to eq user.id
+    end
   end
 
   context 'undo' do


### PR DESCRIPTION
Currently, when editing a submission, admins can search for & select a user, but after submission the user associated with the submission is not actually updated.

This PR adds that behavior, so that the user associated with a submission can be changed.

We also took the opportunity to clean up some naming :) 