### PR TITLE
feat: add source_artwork_id to submission schema and creation mutation

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -439,6 +439,11 @@ input CreateSubmissionMutationInput {
   minimumPriceDollars: Int
   provenance: String
   signature: Boolean
+
+  """
+  If this artwork exists in Gravity, its ID
+  """
+  sourceArtworkID: String
   state: State
   title: String
   userAgent: String
@@ -1175,6 +1180,11 @@ type Submission {
   provenance: String
   publishedAt: ISO8601DateTime
   signature: Boolean
+
+  """
+  If this artwork exists in Gravity, its ID
+  """
+  sourceArtworkID: String
   state: State
   title: String
   userAgent: String
@@ -1601,6 +1611,16 @@ enum SubmissionSort {
   sort by signature in descending order
   """
   SIGNATURE_DESC
+
+  """
+  sort by source_artwork_id in ascending order
+  """
+  SOURCE_ARTWORK_ID_ASC
+
+  """
+  sort by source_artwork_id in descending order
+  """
+  SOURCE_ARTWORK_ID_DESC
 
   """
   sort by state in ascending order

--- a/app/graphql/mutations/create_submission_mutation.rb
+++ b/app/graphql/mutations/create_submission_mutation.rb
@@ -23,6 +23,10 @@ module Mutations
     argument :minimum_price_dollars, Integer, required: false
     argument :provenance, String, required: false
     argument :signature, Boolean, required: false
+    argument :sourceArtworkID,
+             String,
+             required: false,
+             description: 'If this artwork exists in Gravity, its ID'
     argument :state, Types::StateType, required: false
     argument :title, String, required: false
     argument :user_agent, String, required: false

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -28,6 +28,9 @@ module Types
     field :provenance, String, null: true
     field :published_at, GraphQL::Types::ISO8601DateTime, null: true
     field :signature, Boolean, null: true
+    field :sourceArtworkID,
+          String,
+          null: true, description: 'If this artwork exists in Gravity, its ID'
     field :state, Types::StateType, null: true
     field :title, String, null: true
     field :user_agent, String, null: true

--- a/db/migrate/20201120231224_add_source_id_to_submissions.rb
+++ b/db/migrate/20201120231224_add_source_id_to_submissions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSourceIdToSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :submissions, :source_artwork_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_001511) do
+ActiveRecord::Schema.define(version: 2020_11_20_231224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pg_trgm'
   enable_extension 'plpgsql'
@@ -177,6 +177,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_001511) do
     t.float 'auction_score'
     t.string 'assigned_to'
     t.datetime 'published_at'
+    t.string 'source_artwork_id'
     t.index %w[consigned_partner_submission_id],
             name: 'index_submissions_on_consigned_partner_submission_id'
     t.index %w[ext_user_id], name: 'index_submissions_on_ext_user_id'

--- a/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
@@ -12,7 +12,7 @@ describe 'createConsignmentSubmission mutation' do
   let(:headers) { { 'Authorization' => "Bearer #{token}" } }
 
   let(:mutation_inputs) do
-    '{ state: REJECTED, clientMutationId: "2", artistID: "andy", title: "soup", category: JEWELRY, minimumPriceDollars: 50000, currency: "GBP" }'
+    '{ state: REJECTED, clientMutationId: "2", artistID: "andy", title: "soup", category: JEWELRY, minimumPriceDollars: 50000, currency: "GBP", sourceArtworkID: "gravity_artwork_id" }'
   end
 
   let(:mutation) do
@@ -27,6 +27,7 @@ describe 'createConsignmentSubmission mutation' do
           state
           minimumPriceDollars
           currency
+          sourceArtworkID
         }
       }
     }
@@ -109,12 +110,25 @@ describe 'createConsignmentSubmission mutation' do
           'category' => 'Jewelry',
           'state' => 'REJECTED',
           'minimumPriceDollars' => 50_000,
-          'currency' => 'GBP'
+          'currency' => 'GBP',
+          'sourceArtworkID' => 'gravity_artwork_id'
         }
       )
 
       mutation_id = create_response['clientMutationId']
       expect(mutation_id).to eq '2'
+
+      created_submission = Submission.find(submission_response['id'])
+      expect(submission_response['title']).to eq(created_submission.title)
+      expect(submission_response['category']).to eq(created_submission.category)
+      expect(created_submission.rejected?).to be true
+      expect(submission_response['minimumPriceDollars']).to eq(
+        created_submission.minimum_price_dollars
+      )
+      expect(submission_response['currency']).to eq(created_submission.currency)
+      expect(submission_response['sourceArtworkID']).to eq(
+        created_submission.source_artwork_id
+      )
     end
 
     context 'with a user agent string' do


### PR DESCRIPTION
@sweir27 made an excellent point about https://github.com/artsy/volt/pull/4745: we should start keeping _some_ kind of track of whether an artwork in Convection is associated with a Gravity artwork, especially as we do more and more syncing of existing artworks from partners to Convection.

This PR takes a step in that direction by adding a source ID field to submissions in Convection. After this is merged and deployed, I'll update the Volt PR to pass artwork IDs before we merge.

@sweir27 you think it's worth adding specs for CreateSubmissionMutation? ~~None exist at present, but it wouldn't be terribly hard to copy a different mutation spec and update the details.~~ I was wrong! The file was just named something sliiightly different from what I expected 😅 

Screenshot of me executing locally and creating a Convection submission with the id:
![Screen Shot 2020-11-20 at 6 29 55 PM](https://user-images.githubusercontent.com/5361806/99859758-09b9ef80-2b5f-11eb-945a-932af918a216.png)