### PR TITLE
chore: Update graphql gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'ddtrace'
 gem 'decent_exposure' # for safely referencing variables in views
 gem 'gemini_upload-rails' # for admins to upload images
 gem 'graphiql-rails' # A lovely interface to the API
-gem 'graphql', '1.10.10' # A lovely API
+gem 'graphql'
 gem 'graphql-page_cursors'
 gem 'graphql-rails_logger' # Adds pretty-print logging support to queries
 gem 'haml-rails' # required for watt layouts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     graphiql-rails (1.7.0)
       railties
       sprockets-rails
-    graphql (1.10.10)
+    graphql (1.11.6)
     graphql-page_cursors (0.0.2)
       graphql
     graphql-rails_logger (1.2.2)
@@ -481,7 +481,7 @@ DEPENDENCIES
   foreman
   gemini_upload-rails
   graphiql-rails
-  graphql (= 1.10.10)
+  graphql
   graphql-page_cursors
   graphql-rails_logger
   guard-livereload

--- a/app/graphql/types/asset_type.rb
+++ b/app/graphql/types/asset_type.rb
@@ -9,6 +9,6 @@ module Types
     field :gemini_token, String, 'gemini token for asset', null: true
     field :image_urls, GraphQL::Types::JSON, 'known image urls', null: true
     field :submission_id, ID, null: false
-    field :submissionID, ID, null: true # Alias for MPv2 compatability
+    field :submissionID, ID, null: true, method: :submission_id # Alias for MPv2 compatability
   end
 end

--- a/app/graphql/types/consignment_type.rb
+++ b/app/graphql/types/consignment_type.rb
@@ -5,13 +5,13 @@ module Types
     description 'Consignment'
 
     field :submission_id, ID, null: false
-    field :submissionID, ID, null: true # Alias for MPv2 compatability
+    field :submissionID, ID, null: true, method: :submission_id # Alias for MPv2 compatability
     field :sale_date, String, null: true
     field :sale_name, String, null: true
     field :state, Types::ConsignmentStateType, null: true
     field :id, ID, 'Uniq ID for this consignment', null: false
     field :currency, String, null: true
-    field :internalID, ID, method: :id, null: true
+    field :internalID, ID, null: true, method: :id
     field :sale_price_cents, Integer, null: true
     field :submission, Types::SubmissionType, null: false
   end

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -18,7 +18,7 @@ module Types
     field :edition_size, Integer, null: true
     field :height, String, null: true
     field :id, ID, 'Uniq ID for this submission', null: false
-    field :internalID, ID, method: :id, null: true
+    field :internalID, ID, null: true, method: :id
     field :location_city, String, null: true
     field :location_country, String, null: true
     field :location_state, String, null: true
@@ -30,7 +30,9 @@ module Types
     field :signature, Boolean, null: true
     field :sourceArtworkID,
           String,
-          null: true, description: 'If this artwork exists in Gravity, its ID'
+          null: true,
+          method: :source_artwork_id,
+          description: 'If this artwork exists in Gravity, its ID'
     field :state, Types::StateType, null: true
     field :title, String, null: true
     field :user_agent, String, null: true


### PR DESCRIPTION
I've had this gem pinned for some time - I've sorta forgotten the exact reason, but I wanted to ensure I could upgrade to latest and still have the graphql-page_cursors gem work as expected so I took on this upgrade today. Turns out it worked great except where we were relying on some changed behavior of the gem. It's now the case that for an id field that uses camel case, we have to provide a method to map that call. IMHO this is actually better because there's less magic and now it's more clear that these non-standard fields are aliases.

Anyway, after auditing the schema for these changes we were back to green so going to mark this MOG and usher it through.