### PR TITLE
fix: Don't pass null artist_ids to artist query

### DIFF
--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -26,7 +26,8 @@ module GraphqlHelper
   def artists_query(artist_ids)
     artist_details_response =
       Gravql::Schema.execute(
-        query: ARTISTS_DETAILS_QUERY, variables: { ids: artist_ids.uniq }
+        query: ARTISTS_DETAILS_QUERY,
+        variables: { ids: artist_ids.compact.uniq }
       )
     if artist_details_response[:errors].present?
       flash.now[:error] = 'Error fetching artist details.'


### PR DESCRIPTION
If a submission is missing an artist, we'll see an error about fetching artist details if we pass in a null `artist_id`.


