### PR TITLE
fix: fetch user email from Gravity when updating submission user

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -18,6 +18,7 @@ class SubmissionService
     def update_submission(submission, params, current_user: nil)
       if params[:user_id]
         user = User.find_or_create_by!(gravity_user_id: params[:user_id])
+        UserService.delay.update_email(user.id)
         create_params = params.merge(user_id: user.id)
         submission.assign_attributes(create_params)
       else

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -226,10 +226,10 @@ describe SubmissionService do
 
     it 'updates the user associated with the submission if a user ID is passed' do
       new_user =
-        Fabricate(
-          :user,
-          gravity_user_id: 'new_gravity_user_id', email: 'cool.cat@fatcat.com'
-        )
+        Fabricate(:user, gravity_user_id: 'new_gravity_user_id', email: nil)
+      stub_gravity_user_detail(
+        id: new_user.gravity_user_id, email: 'cool.cat@fatcat.com'
+      )
 
       SubmissionService.update_submission(
         submission,
@@ -237,6 +237,7 @@ describe SubmissionService do
       )
 
       expect(submission.user_id).to eq new_user.id
+      expect(submission.user.email).to eq 'cool.cat@fatcat.com'
     end
 
     it 'does not update the user associated with the submission if no ID is passed' do


### PR DESCRIPTION
After we enabled the user associated with a submission to be updated in https://github.com/artsy/convection/pull/852, Wendy noticed that submissions whose user had been changed lacked an email and those submissions had not been turning up in Looker reporting.

Turns out I missed a crucial line here: we need to explicitly fetch the user's email from Gravity using `UserService`. This PR adds that functionality and a test.

I'm not positive about the Looker reporting, but I assume that the issue is that some submissions don't have emails associated and we have a baked-in assumption that 1 submission = 1 email. I figure we can try this fix, and if reporting isn't fixed I can touch base with Data.

We should also backfill any emails:

```ruby
users_without_email = User.where(email: nil)
users_without_email.count
users_without_email.each {|u| UserService.delay.update_email(u.id)}
users_without_email.count
```