### PR TITLE
chore: add an empty storage.yml file to prevent crash on startup

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,1 @@
+# Empty file to satisfy ActiveStorage


### PR DESCRIPTION
Co-authored-by: @jonallured 

#923 got us past one startup issue, but we were left with another -- ActiveStorage is looking for a file that doesn't exist.

We considered disabling ActiveStorage but for the sake of fixing this deployment faster chose to add an empty file.

Tested the fix by booting rails locally with `RAILS_ENV=production ./bin/server`. 