### PR TITLE
Bump console_color for rails 6 fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.7)
     connection_pool (2.2.3)
-    console_color (0.0.5)
+    console_color (0.0.6)
     crack (0.4.5)
       rexml
     crass (1.0.6)


### PR DESCRIPTION
Bumps `console_color` to v0.0.6 for https://github.com/joeyAghion/console_color/commit/26de427e7d445d42c145e28b15946ac3ad0f9087.