### PR TITLE
chore: pin omniauth to <2 due to breaking change in login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'jquery-rails'
 gem 'kaminari' # for pagination
 gem 'money' # for currency/money formatting
 gem 'neat', '1.7.2' # required for watt
+gem 'omniauth', '< 2' # pinned to avoid breaking change with login in v2
 gem 'pg_search' # for searching within convection's database
 gem 'premailer-rails' # generate text parts from HTML automatically
 gem 'rack-cors' # to allow cross-origin requests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,10 +270,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (2.0.2)
+    omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-      rack-protection
     omniauth-artsy (0.2.3)
       omniauth-oauth2 (>= 1.1.2)
     omniauth-oauth2 (1.7.1)
@@ -307,8 +306,6 @@ GEM
     rack-cors (1.1.1)
       rack (>= 2.0.0)
     rack-livereload (0.3.17)
-      rack
-    rack-protection (2.1.0)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -506,6 +503,7 @@ DEPENDENCIES
   kaminari
   money
   neat (= 1.7.2)
+  omniauth (< 2)
   pg
   pg_search
   premailer-rails


### PR DESCRIPTION
v2 of omniauth includes changes that break our login flow. This PR pins the dependency to `<2`. 

Issue was originally found [in volt](https://github.com/artsy/volt/pull/4893), thanks to @starsirius for bringing it to our attention that it login was broken here too. 