### PR TITLE
chore: pin husky to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@prettier/plugin-ruby": "1.5.2",
-    "husky": "4.3.8",
+    "husky": "^4.3.8",
     "lint-staged": "10.5.4",
     "prettier": "2.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,7 +301,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@4.3.8:
+husky@^4.3.8:
   version "4.3.8"
   resolved "https://registry.yarnpkg.com/husky/-/husky-4.3.8.tgz#31144060be963fd6850e5cc8f019a1dfe194296d"
   integrity sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==


### PR DESCRIPTION
I ran updates with `./bin/update` and found the only dependency update was for `husky`, which has a v5 release.

There are breaking changes in that release & some work to do for updating it; I didn't see a need to update to that release so I'm pinning us to 4 for now. 