### PR TITLE
feature:Add consignments_manager to allowed roles

### DIFF
--- a/lib/artsy_admin_auth.rb
+++ b/lib/artsy_admin_auth.rb
@@ -13,7 +13,9 @@ class ArtsyAdminAuth
       decoded_token = decode_token(token)
       return false if decoded_token.nil?
 
-      decoded_token['roles'].include? 'admin'
+      # TODO: remove 'admin' once the connsignments team all have this new role
+      roles = decoded_token['roles']
+      roles.include?('consignments_manager') || roles.include?('admin')
     end
 
     def decode_user(token)


### PR DESCRIPTION
Ticket: https://artsyproduct.atlassian.net/browse/CX-1142

I haven't received a list of consignments admins yet, so I'm temporarily allowing both admins and consignments managers to access the application.

I verified that this works with a user on staging.
