### PR TITLE
[CX-1307]: feature(mailers): replace google form with CMS link

### DIFF
--- a/app/views/partner_mailer/submission_digest.html.erb
+++ b/app/views/partner_mailer/submission_digest.html.erb
@@ -52,7 +52,7 @@
               <% if @partner_type == 'Auction' %>
                 <tr>
                   <td class='email-sub-title email-sub-title--extra-padding-bottom email-sub-title--extra-padding-top'>
-                    Please click below to send one proposal per submission and respond directly to this email if you have any questions.
+                    Please click below to submit proposals through your Artsy CMS. If you do not have access to CMS yet please contact <%= mail_to(Convection.config.admin_email_address) %>
                   </td>
                 </tr>
                 <tr>
@@ -60,7 +60,7 @@
                       <table class='full-width-button'>
                         <tr>
                             <td class='submit-proposal-button'>
-                              <%= link_to('Submit Proposal', offer_form_url) %>
+                              <%= link_to('Send Proposal', Convection.config.artsy_cms_url) %>
                             </td>
                         </tr>
                       </table>

--- a/app/views/user_mailer/offer.html.erb
+++ b/app/views/user_mailer/offer.html.erb
@@ -41,7 +41,7 @@
         </tr>
         <tr>
           <td class='email-sub-title-serif'>
-            Please review the offer and reply within 48 hours. If you accept the offer, we will introduce you to our partner to finalize an agreement. If you refuse the offer, please provide a reason. Please contact consign@artsy.net with any questions.
+            Please review the offer and reply within 48 hours. If you accept the offer, we will introduce you to our partner to finalize an agreement. If you refuse the offer, please provide a reason. Please contact <%= Convection.config.admin_email_address %> with any questions.
           </td>
         </tr>
         <tr>

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -10,6 +10,7 @@ Convection.config =
     admin_names: (ENV['ADMIN_NAMES'] || 'Alice Betty Cindy').split,
     admin_email_address: ENV['ADMIN_EMAIL_ADDRESS'] || 'consign@artsy.net',
     artsy_url: ENV['ARTSY_URL'] || 'https://staging.artsy.net',
+    artsy_cms_url: 'https://cms.artsy.net',
     auction_offer_form_url: ENV['AUCTION_OFFER_FORM_URL'] || 'https://foo.com',
     offer_response_form_url:
       ENV['OFFER_RESPONSE_FORM_URL'] || 'https://foo.com',

--- a/spec/mailers/previews/base_preview.rb
+++ b/spec/mailers/previews/base_preview.rb
@@ -46,7 +46,6 @@ class BasePreview < ActionMailer::Preview
           "\"Accomplice” characters from KAWS are appropriately branded with the artist's trademark \"X\" " \
           "to replace each of the figure's original eyes. The black example is from an edition of 500 " \
           'and the pink example is from an edition of 1000',
-      artist_name: 'Damien Hirst',
       location_city: 'New York',
       location_state: 'NY',
       location_country: 'USA',
@@ -73,5 +72,9 @@ class BasePreview < ActionMailer::Preview
     s.minimum_price_display =
       Money.new(s.minimum_price_cents, s.currency).format(no_cents: true)
     s
+  end
+
+  def submissions_artists
+    { id: 'artistid', name: 'Damien Hirst' }
   end
 end

--- a/spec/mailers/previews/partner_mailer_preview.rb
+++ b/spec/mailers/previews/partner_mailer_preview.rb
@@ -42,6 +42,6 @@ class PartnerMailerPreview < BasePreview
     users_to_submissions =
       [sub1, sub2, base_submission_with_minimum_price].group_by(&:user)
 
-    { users_to_submissions: users_to_submissions, submissions_count: 3 }
+    { users_to_submissions: users_to_submissions, submissions_artists: submissions_artists, submissions_count: 3 }
   end
 end

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -230,7 +230,7 @@ describe PartnerSubmissionService do
           expect(email.html_part.body).to include(
             '<i>Third approved artwork</i><span>, 1997</span>'
           )
-          expect(email.html_part.body).to include('https://google.com/auction')
+          expect(email.html_part.body).to include('https://cms.artsy.net')
           expect(
             @partner.partner_submissions.map(&:notified_at).compact.length
           ).to eq 3


### PR DESCRIPTION
Refs [CX-1307]

<img width="1280" alt="Screen Shot 2021-04-10 at 20 15 46" src="https://user-images.githubusercontent.com/3873525/114277373-efb07900-9a3b-11eb-9c39-124944b88b51.png">


[CX-1307]: https://artsyproduct.atlassian.net/browse/CX-1307