### PR TITLE
don't blow up on empty string for artist_id

### DIFF
--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -27,7 +27,7 @@ module GraphqlHelper
     artist_details_response =
       Gravql::Schema.execute(
         query: artist_query_builder(fields: [:name]),
-        variables: { ids: artist_ids.compact.uniq }
+        variables: { ids: artist_ids.uniq.select(&:present?) }
       )
     if artist_details_response[:errors].present?
       flash.now[:error] = 'Error fetching artist details.'


### PR DESCRIPTION
Somehow a submission ended up with an `artist_id` that was a blank string, which caused the whole query to blow up.

In a rails console:

```ruby
artist_ids = ["1", "", nil, "2", "3", "3"]

artist_ids.compact.uniq # => ["1", "", "2", "3"]

artist_ids.uniq.select(&:present?) # => ["1", "2", "3"]
