### PR TITLE
fix: removed mistaken named parameter in call to artists_names_query

### DIFF
--- a/app/services/partner_submission_service.rb
+++ b/app/services/partner_submission_service.rb
@@ -69,7 +69,7 @@ class PartnerSubmissionService
       submissions = Submission.find(submission_ids)
       return if submissions.empty?
 
-      submissions_artists = artists_names_query(ids: submissions.map(&:artist_id))
+      submissions_artists = artists_names_query(submissions.map(&:artist_id))
 
       users_to_submissions = submissions.group_by(&:user)
       PartnerMailer.submission_digest(


### PR DESCRIPTION
I missed this in code review, which meant all of the sidekiq jobs to send out partner digest emails have been failing since April 9.

https://artsyproduct.atlassian.net/browse/CX-1350