### PR TITLE
[CX-1342]: feature(submission): show both metrics for dimension

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module SubmissionsHelper
+  INCH_TO_CM = 2.54
+
   def formatted_score(score)
     (score || 0) * 100
   end
@@ -19,6 +21,33 @@ module SubmissionsHelper
     return if values.empty?
 
     "#{values.join('x')}#{submission.dimensions_metric.try(:downcase)}"
+  end
+
+  def formatted_dimensions_inch_cm(submission)
+    values = [submission.height, submission.width, submission.depth].select(&:present?)
+
+    return [] if values.empty?
+
+    case submission.dimensions_metric.try(:downcase)
+    when 'cm'
+      %W[
+        #{values.join(' x ')}\ cm
+        #{values.map{ |dimension| convert_cm_to_inch(dimension) }.join(' x ')}\ in
+      ]
+    when 'in'
+      %W[
+        #{values.join(' x ')}\ in
+        #{values.map{ |dimension| convert_inch_to_cm(dimension) }.join(' x ')}\ cm
+      ]
+    end
+  end
+
+  def convert_inch_to_cm(num)
+    (num.to_f * INCH_TO_CM).round(2)
+  end
+
+  def convert_cm_to_inch(num)
+    (num.to_f / INCH_TO_CM).round(2)
   end
 
   def formatted_category(submission)

--- a/app/views/admin/submissions/_submission_details.html.erb
+++ b/app/views/admin/submissions/_submission_details.html.erb
@@ -66,7 +66,9 @@
     Dimensions
   </div>
   <div class='overview-item-value'>
-    <%= formatted_dimensions(@submission) %>
+    <% formatted_dimensions_inch_cm(@submission).map do |formatted_dimension| %>
+      <div><%= formatted_dimension %></div>
+    <% end %>
   </div>
 </div>
 

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -55,6 +55,37 @@ describe SubmissionsHelper, type: :helper do
     end
   end
 
+  context 'formatted_dimensions_inch_cm' do
+    let(:submission_with_inch) do
+      Fabricate(
+        :submission,
+        width: '10', height: '12', depth: '1.75', dimensions_metric: 'in'
+      )
+      end
+    let(:submission_with_cm) do
+      Fabricate(
+        :submission,
+        width: '30', height: '40', depth: '2.54', dimensions_metric: 'cm'
+      )
+    end
+
+    it 'returns empty string when dimension values are nil' do
+      submission = Fabricate(:submission, width: nil, height: nil, depth: nil)
+      expect(helper.formatted_dimensions_inch_cm(submission)).to be_blank
+    end
+
+    it 'returns array of formatted dimensions for both metrics' do
+      expect(helper.formatted_dimensions_inch_cm(submission_with_inch)).to match_array [
+        '12 x 10 x 1.75 in',
+        '30.48 x 25.4 x 4.45 cm'
+      ]
+      expect(helper.formatted_dimensions_inch_cm(submission_with_cm)).to match_array [
+        '15.75 x 11.81 x 1.0 in',
+        '40 x 30 x 2.54 cm'
+      ]
+    end
+  end
+
   context 'formatted_editions' do
     it 'it correctly formats the editions fields' do
       submission =


### PR DESCRIPTION
Refs CX-1342

<img width="823" alt="Submission_with_cm_metrics" src="https://user-images.githubusercontent.com/3873525/115638636-d228bc80-a323-11eb-8728-6987b122dc21.png">
<img width="806" alt="Submission_with_inch_metrics" src="https://user-images.githubusercontent.com/3873525/115638642-d48b1680-a323-11eb-8e12-5a0244984291.png">
