### PR TITLE
fix:handle nil value for Submission.dimensions_metric

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -39,6 +39,8 @@ module SubmissionsHelper
         #{values.join(' x ')}\ in
         #{values.map{ |dimension| convert_inch_to_cm(dimension) }.join(' x ')}\ cm
       ]
+    else
+      []
     end
   end
 

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -69,9 +69,14 @@ describe SubmissionsHelper, type: :helper do
       )
     end
 
-    it 'returns empty string when dimension values are nil' do
+    it 'returns empty array when dimension values are nil' do
       submission = Fabricate(:submission, width: nil, height: nil, depth: nil)
-      expect(helper.formatted_dimensions_inch_cm(submission)).to be_blank
+      expect(helper.formatted_dimensions_inch_cm(submission)).to eq([])
+    end
+    
+    it 'returns empty array when dimension metric is nil' do
+      submission = Fabricate(:submission, width: 10, height: 10, depth: 1, dimensions_metric: nil)
+      expect(helper.formatted_dimensions_inch_cm(submission)).to eq([])
     end
 
     it 'returns array of formatted dimensions for both metrics' do


### PR DESCRIPTION
We have a lot of places where we have to be careful about nil values. I just fixed one that was blowing up the submissions page.

https://artsyproduct.atlassian.net/browse/CX-1359