### PR TITLE
feat: add invoice number to partner consignments

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -189,6 +189,16 @@ enum ConsignmentSort {
   ID_DESC
 
   """
+  sort by invoice_number in ascending order
+  """
+  INVOICE_NUMBER_ASC
+
+  """
+  sort by invoice_number in descending order
+  """
+  INVOICE_NUMBER_DESC
+
+  """
   sort by notes in ascending order
   """
   NOTES_ASC

--- a/app/controllers/admin/consignments_controller.rb
+++ b/app/controllers/admin/consignments_controller.rb
@@ -142,6 +142,7 @@ module Admin
         :state,
         :partner_commission_percent_whole,
         :artsy_commission_percent_whole,
+        :invoice_number,
         :partner_invoiced_at,
         :partner_paid_at,
         :notes

--- a/app/views/admin/consignments/edit.html.erb
+++ b/app/views/admin/consignments/edit.html.erb
@@ -132,6 +132,31 @@
         </div>
       </div>
     </div>
+    <% if @consignment.partner_invoiced_at %>
+      <div class='row double-padding-top'>
+        <div class='col-sm-12'>
+          <div class='col-md-9'>
+            <div class='unit bordered double-padding-top'>
+              <div class='col-md-3'>
+                <h5>
+                  Partner
+                </h5>
+              </div>
+              <div class='row single-padding-top'>
+                <div class='col-sm-12'>
+                  <label class='col-sm-3 control-label'>
+                    Invoice number
+                  </label>
+                  <div class='col-sm-9'>
+                    <%= f.text_field :invoice_number, class: 'form-control' %>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
     <div class='row triple-padding-top'>
       <div class='col-md-12'>
         <%= f.submit 'Save', class: 'btn btn-primary btn-full-width' %>

--- a/app/views/admin/consignments/show.html.erb
+++ b/app/views/admin/consignments/show.html.erb
@@ -118,6 +118,16 @@
                 <% end %>
               </div>
             </div>
+            <% if @consignment.partner_invoiced_at %>
+              <div class='overview-item'>
+                <div class='overview-item-title'>
+                  Invoice number
+                </div>
+                <div class='overview-item-value'>
+                  <%= @consignment.invoice_number %>
+                </div>
+              </div>
+            <% end %>
             <div class='overview-item'>
               <div class='overview-item-title'>
                 Partner paid?

--- a/db/migrate/20210512082147_add_invoice_number_to_partner_submissions.rb
+++ b/db/migrate/20210512082147_add_invoice_number_to_partner_submissions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInvoiceNumberToPartnerSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :partner_submissions, :invoice_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,206 +10,195 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_06_185140) do
+ActiveRecord::Schema.define(version: 2021_05_12_082147) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'pg_trgm'
-  enable_extension 'plpgsql'
+  enable_extension "pg_trgm"
+  enable_extension "plpgsql"
 
-  create_table 'artist_standing_scores', force: :cascade do |t|
-    t.string 'artist_id'
-    t.float 'artist_score'
-    t.float 'auction_score'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "artist_standing_scores", force: :cascade do |t|
+    t.string "artist_id"
+    t.float "artist_score"
+    t.float "auction_score"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'assets', id: :serial, force: :cascade do |t|
-    t.string 'asset_type'
-    t.string 'gemini_token'
-    t.jsonb 'image_urls', default: {}
-    t.integer 'submission_id'
-    t.index %w[submission_id], name: 'index_assets_on_submission_id'
+  create_table "assets", id: :serial, force: :cascade do |t|
+    t.string "asset_type"
+    t.string "gemini_token"
+    t.jsonb "image_urls", default: {}
+    t.integer "submission_id"
+    t.index ["submission_id"], name: "index_assets_on_submission_id"
   end
 
-  create_table 'notes', force: :cascade do |t|
-    t.string 'gravity_user_id', null: false
-    t.text 'body', null: false
-    t.bigint 'submission_id'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[submission_id], name: 'index_notes_on_submission_id'
+  create_table "notes", force: :cascade do |t|
+    t.string "gravity_user_id", null: false
+    t.text "body", null: false
+    t.bigint "submission_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["submission_id"], name: "index_notes_on_submission_id"
   end
 
-  create_table 'offer_responses', force: :cascade do |t|
-    t.bigint 'offer_id'
-    t.string 'intended_state', null: false
-    t.string 'phone_number'
-    t.text 'comments'
-    t.string 'rejection_reason'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[offer_id], name: 'index_offer_responses_on_offer_id'
+  create_table "offer_responses", force: :cascade do |t|
+    t.bigint "offer_id"
+    t.string "intended_state", null: false
+    t.string "phone_number"
+    t.text "comments"
+    t.string "rejection_reason"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["offer_id"], name: "index_offer_responses_on_offer_id"
   end
 
-  create_table 'offers', id: :serial, force: :cascade do |t|
-    t.integer 'partner_submission_id'
-    t.string 'offer_type'
-    t.datetime 'sale_period_start'
-    t.datetime 'sale_period_end'
-    t.datetime 'sale_date'
-    t.string 'sale_name'
-    t.bigint 'low_estimate_cents'
-    t.bigint 'high_estimate_cents'
-    t.string 'currency'
-    t.text 'notes'
-    t.float 'commission_percent'
-    t.bigint 'price_cents'
-    t.string 'shipping_info'
-    t.string 'photography_info'
-    t.string 'other_fees_info'
-    t.string 'insurance_info'
-    t.string 'state'
-    t.string 'created_by_id'
-    t.string 'reference_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'submission_id'
-    t.datetime 'sent_at'
-    t.string 'sent_by'
-    t.string 'rejection_reason'
-    t.text 'rejection_note'
-    t.string 'rejected_by'
-    t.datetime 'rejected_at'
-    t.datetime 'review_started_at'
-    t.datetime 'consigned_at'
-    t.string 'override_email'
-    t.text 'partner_info'
-    t.string 'deadline_to_consign'
-    t.string 'sale_location'
-    t.integer 'offer_responses_count'
-    t.bigint 'starting_bid_cents'
-    t.index %w[partner_submission_id],
-            name: 'index_offers_on_partner_submission_id'
-    t.index %w[reference_id], name: 'index_offers_on_reference_id'
-    t.index %w[submission_id], name: 'index_offers_on_submission_id'
+  create_table "offers", id: :serial, force: :cascade do |t|
+    t.integer "partner_submission_id"
+    t.string "offer_type"
+    t.datetime "sale_period_start"
+    t.datetime "sale_period_end"
+    t.datetime "sale_date"
+    t.string "sale_name"
+    t.bigint "low_estimate_cents"
+    t.bigint "high_estimate_cents"
+    t.string "currency"
+    t.text "notes"
+    t.float "commission_percent"
+    t.bigint "price_cents"
+    t.string "shipping_info"
+    t.string "photography_info"
+    t.string "other_fees_info"
+    t.string "insurance_info"
+    t.string "state"
+    t.string "created_by_id"
+    t.string "reference_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "submission_id"
+    t.datetime "sent_at"
+    t.string "sent_by"
+    t.string "rejection_reason"
+    t.text "rejection_note"
+    t.string "rejected_by"
+    t.datetime "rejected_at"
+    t.datetime "review_started_at"
+    t.datetime "consigned_at"
+    t.string "override_email"
+    t.text "partner_info"
+    t.string "deadline_to_consign"
+    t.string "sale_location"
+    t.integer "offer_responses_count"
+    t.bigint "starting_bid_cents"
+    t.index ["partner_submission_id"], name: "index_offers_on_partner_submission_id"
+    t.index ["reference_id"], name: "index_offers_on_reference_id"
+    t.index ["submission_id"], name: "index_offers_on_submission_id"
   end
 
-  create_table 'partner_submissions', id: :serial, force: :cascade do |t|
-    t.integer 'submission_id'
-    t.integer 'partner_id'
-    t.datetime 'notified_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'accepted_offer_id'
-    t.float 'partner_commission_percent'
-    t.float 'artsy_commission_percent'
-    t.string 'sale_name'
-    t.string 'sale_location'
-    t.string 'sale_lot_number'
-    t.datetime 'sale_date'
-    t.bigint 'sale_price_cents'
-    t.string 'currency'
-    t.datetime 'partner_invoiced_at'
-    t.datetime 'partner_paid_at'
-    t.text 'notes'
-    t.string 'state'
-    t.string 'reference_id'
-    t.text 'canceled_reason'
-    t.index %w[accepted_offer_id],
-            name: 'index_partner_submissions_on_accepted_offer_id'
-    t.index %w[partner_id], name: 'index_partner_submissions_on_partner_id'
-    t.index %w[submission_id],
-            name: 'index_partner_submissions_on_submission_id'
+  create_table "partner_submissions", id: :serial, force: :cascade do |t|
+    t.integer "submission_id"
+    t.integer "partner_id"
+    t.datetime "notified_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "accepted_offer_id"
+    t.float "partner_commission_percent"
+    t.float "artsy_commission_percent"
+    t.string "sale_name"
+    t.string "sale_location"
+    t.string "sale_lot_number"
+    t.datetime "sale_date"
+    t.bigint "sale_price_cents"
+    t.string "currency"
+    t.datetime "partner_invoiced_at"
+    t.datetime "partner_paid_at"
+    t.text "notes"
+    t.string "state"
+    t.string "reference_id"
+    t.text "canceled_reason"
+    t.string "invoice_number"
+    t.index ["accepted_offer_id"], name: "index_partner_submissions_on_accepted_offer_id"
+    t.index ["partner_id"], name: "index_partner_submissions_on_partner_id"
+    t.index ["submission_id"], name: "index_partner_submissions_on_submission_id"
   end
 
-  create_table 'partners', id: :serial, force: :cascade do |t|
-    t.string 'gravity_partner_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'name'
-    t.index %w[gravity_partner_id],
-            name: 'index_partners_on_gravity_partner_id', unique: true
+  create_table "partners", id: :serial, force: :cascade do |t|
+    t.string "gravity_partner_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "name"
+    t.index ["gravity_partner_id"], name: "index_partners_on_gravity_partner_id", unique: true
   end
 
-  create_table 'submissions', id: :serial, force: :cascade do |t|
-    t.string 'ext_user_id'
-    t.boolean 'qualified'
-    t.string 'artist_id'
-    t.string 'title'
-    t.string 'medium'
-    t.string 'year'
-    t.string 'category'
-    t.string 'height'
-    t.string 'width'
-    t.string 'depth'
-    t.string 'dimensions_metric'
-    t.boolean 'signature'
-    t.boolean 'authenticity_certificate'
-    t.text 'provenance'
-    t.string 'location_city'
-    t.string 'location_state'
-    t.string 'location_country'
-    t.date 'deadline_to_sell'
-    t.text 'additional_info'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.boolean 'edition'
-    t.string 'state'
-    t.datetime 'receipt_sent_at'
-    t.string 'edition_number'
-    t.integer 'edition_size'
-    t.integer 'reminders_sent_count', default: 0
-    t.datetime 'admin_receipt_sent_at'
-    t.string 'approved_by'
-    t.datetime 'approved_at'
-    t.string 'rejected_by'
-    t.datetime 'rejected_at'
-    t.integer 'primary_image_id'
-    t.integer 'consigned_partner_submission_id'
-    t.string 'user_email'
-    t.integer 'offers_count', default: 0
-    t.integer 'user_id'
-    t.bigint 'minimum_price_cents'
-    t.string 'currency'
-    t.string 'user_agent'
-    t.datetime 'deleted_at'
-    t.float 'artist_score'
-    t.float 'auction_score'
-    t.string 'assigned_to'
-    t.datetime 'published_at'
-    t.string 'source_artwork_id'
-    t.index %w[consigned_partner_submission_id],
-            name: 'index_submissions_on_consigned_partner_submission_id'
-    t.index %w[ext_user_id], name: 'index_submissions_on_ext_user_id'
-    t.index %w[primary_image_id], name: 'index_submissions_on_primary_image_id'
-    t.index %w[user_id], name: 'index_submissions_on_user_id'
+  create_table "submissions", id: :serial, force: :cascade do |t|
+    t.string "ext_user_id"
+    t.boolean "qualified"
+    t.string "artist_id"
+    t.string "title"
+    t.string "medium"
+    t.string "year"
+    t.string "category"
+    t.string "height"
+    t.string "width"
+    t.string "depth"
+    t.string "dimensions_metric"
+    t.boolean "signature"
+    t.boolean "authenticity_certificate"
+    t.text "provenance"
+    t.string "location_city"
+    t.string "location_state"
+    t.string "location_country"
+    t.date "deadline_to_sell"
+    t.text "additional_info"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "edition"
+    t.string "state"
+    t.datetime "receipt_sent_at"
+    t.string "edition_number"
+    t.integer "edition_size"
+    t.integer "reminders_sent_count", default: 0
+    t.datetime "admin_receipt_sent_at"
+    t.string "approved_by"
+    t.datetime "approved_at"
+    t.string "rejected_by"
+    t.datetime "rejected_at"
+    t.integer "primary_image_id"
+    t.integer "consigned_partner_submission_id"
+    t.string "user_email"
+    t.integer "offers_count", default: 0
+    t.integer "user_id"
+    t.bigint "minimum_price_cents"
+    t.string "currency"
+    t.string "user_agent"
+    t.datetime "deleted_at"
+    t.float "artist_score"
+    t.float "auction_score"
+    t.string "assigned_to"
+    t.datetime "published_at"
+    t.string "source_artwork_id"
+    t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
+    t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
+    t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"
+    t.index ["user_id"], name: "index_submissions_on_user_id"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'gravity_user_id', null: false
-    t.string 'email'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[gravity_user_id],
-            name: 'index_users_on_gravity_user_id', unique: true
+  create_table "users", force: :cascade do |t|
+    t.string "gravity_user_id", null: false
+    t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["gravity_user_id"], name: "index_users_on_gravity_user_id", unique: true
   end
 
-  add_foreign_key 'assets', 'submissions'
-  add_foreign_key 'notes', 'submissions'
-  add_foreign_key 'offer_responses', 'offers'
-  add_foreign_key 'offers', 'partner_submissions', on_delete: :cascade
-  add_foreign_key 'offers', 'submissions', on_delete: :cascade
-  add_foreign_key 'partner_submissions',
-                  'offers',
-                  column: 'accepted_offer_id', on_delete: :nullify
-  add_foreign_key 'partner_submissions', 'partners'
-  add_foreign_key 'partner_submissions', 'submissions'
-  add_foreign_key 'submissions',
-                  'assets',
-                  column: 'primary_image_id', on_delete: :nullify
-  add_foreign_key 'submissions',
-                  'partner_submissions',
-                  column: 'consigned_partner_submission_id', on_delete: :nullify
-  add_foreign_key 'submissions', 'users'
+  add_foreign_key "assets", "submissions"
+  add_foreign_key "notes", "submissions"
+  add_foreign_key "offer_responses", "offers"
+  add_foreign_key "offers", "partner_submissions", on_delete: :cascade
+  add_foreign_key "offers", "submissions", on_delete: :cascade
+  add_foreign_key "partner_submissions", "offers", column: "accepted_offer_id", on_delete: :nullify
+  add_foreign_key "partner_submissions", "partners"
+  add_foreign_key "partner_submissions", "submissions"
+  add_foreign_key "submissions", "assets", column: "primary_image_id", on_delete: :nullify
+  add_foreign_key "submissions", "partner_submissions", column: "consigned_partner_submission_id", on_delete: :nullify
+  add_foreign_key "submissions", "users"
 end

--- a/spec/views/admin/consignments/edit.html.erb_spec.rb
+++ b/spec/views/admin/consignments/edit.html.erb_spec.rb
@@ -109,6 +109,26 @@ describe 'admin/consignments/edit.html.erb', type: :feature do
         expect(page).to have_content('Artsy Commission (commission charged to partner) % 8.8')
       end
 
+      context 'when the consignment has a partner invoice date' do
+        before do
+          partner_submission.update!(partner_invoiced_at: Time.zone.now)
+          page.visit edit_admin_consignment_path(partner_submission)
+        end
+
+        it 'allows you to edit the invoice number' do
+          fill_in(
+            'partner_submission_invoice_number',
+            with: '424242'
+          )
+
+          click_button('Save')
+          expect(page.current_path).to eq admin_consignment_path(
+             partner_submission
+          )
+          expect(page).to have_content('Invoice number 424242')
+        end
+      end
+
       it 'shows the canceled reason box when canceled is selected', js: true do
         select('canceled', from: 'partner_submission_state')
         expect(page).to have_content 'Canceled Reason'

--- a/spec/views/admin/consignments/show.html.erb_spec.rb
+++ b/spec/views/admin/consignments/show.html.erb_spec.rb
@@ -77,6 +77,17 @@ describe 'admin/consignments/show.html.erb', type: :feature do
         expect(page).to_not have_content('Canceled Reason')
       end
 
+      context 'when the consignment has a partner invoice date' do
+        before do
+          partner_submission.update!(partner_invoiced_at: Time.zone.now, invoice_number: 424242)
+          page.visit admin_consignment_path(partner_submission)
+        end
+
+        it 'displays the invoice number' do
+          expect(page).to have_content('Invoice number 424242')
+        end
+      end
+
       it 'shows information about the offer and lets you navigate' do
         expect(page).to have_selector('.list-item--offer')
         within(:css, '.list-item--offer') do


### PR DESCRIPTION
Ticket: https://artsyproduct.atlassian.net/browse/CX-1392

Add partner section and invoice number in edit page of the partner consignments.
Decided to only show the invoice number field if the "Partner invoiced?" field is checked. The flow can be seen below:

https://user-images.githubusercontent.com/7518671/117990803-cbe39a00-b33d-11eb-8f43-29687ad4dab8.mov

Note: If the admin decides to uncheck the "Partner invoiced?" field, the invoice number will not be erased from the database, and it will not be visible from the page until "Partner invoiced?" is checked again.