### PR TITLE
[CX-1313]: Reorganize Convection home to better align with admin workflow

### DIFF
--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -293,3 +293,29 @@ a.make-primary-link {
   color: $gray-dark;
   text-decoration: underline;
 }
+
+.dashboard_category_row  {
+  .section-header {
+    margin-bottom: 20px;
+
+    > div {
+      padding: 0;
+    }
+  }
+}
+
+.dashboard_subcategory_row {
+  margin-bottom: 20px;
+  padding: 10px;
+  -webkit-box-shadow: 0px 0px 6px 0px rgba(0,0,0,0.2);
+  box-shadow: 0px 0px 6px 0px rgba(0,0,0,0.2);
+  background: #F9F9F9;
+
+  > div {
+    display: inline-block;
+  }
+
+  span {
+    line-height: inherit;
+  }
+}

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -4,28 +4,15 @@ module Admin
   class DashboardController < ApplicationController
     include GraphqlHelper
 
-    expose(:submissions) do
-      Submission.not_deleted.submitted.order(id: :desc).take(4)
+    expose(:grouped_submissions) { DashboardReportingQuery::Submission.grouped_by_state }
+
+    expose(:unreviewed_submissions) do
+      DashboardReportingQuery::Submission.unreviewed_user_submissions(@current_user)
     end
 
-    expose(:offers) { Offer.sent.order(id: :desc).take(4) }
+    expose(:grouped_offers) { DashboardReportingQuery::Offer.grouped_by_state }
 
-    expose(:consignments) do
-      PartnerSubmission.consigned.order(id: :desc).take(4)
-    end
-
-    expose(:submissions_count) { Submission.not_deleted.submitted.count }
-
-    expose(:offers_count) { Offer.sent.count }
-
-    expose(:consignments_count) { PartnerSubmission.consigned.count }
-
-    expose(:artist_details) do
-      submission_artists = artists_names_query(submissions.map(&:artist_id)) || {}
-      consignment_artists =
-        artists_names_query(consignments.map(&:submission).map(&:artist_id)) || {}
-      submission_artists.merge(consignment_artists)
-    end
+    expose(:grouped_consignments) { DashboardReportingQuery::Consignment.grouped_by_state_and_partner }
 
     def index; end
   end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DashboardHelper
+  include ApplicationHelper
+
+  def sum_up_approved_submissions(approved: 0, published: 0, **)
+    approved + published
+  end
+end

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -10,7 +10,7 @@ class PartnerSubmission < ApplicationRecord
   pg_search_scope :search,
                   against: %i[id reference_id],
                   associated_against: { partner: %i[name] },
-                  using: { tsearch: { prefix: true } }
+                  using: { tsearch: { prefix: true, negation: true } }
 
   belongs_to :partner
   belongs_to :submission

--- a/app/queries/dashboard_reporting_query.rb
+++ b/app/queries/dashboard_reporting_query.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module DashboardReportingQuery
+  module Submission
+    module_function
+
+    def grouped_by_state
+      ::Submission.not_deleted.group(:state).count.symbolize_keys
+    end
+
+    def unreviewed_user_submissions(user)
+      query = <<-SQL.squish
+        SELECT COUNT(*) AS total,
+        COUNT(assigned_to IS NULL OR NULL) AS unassigned,
+        COUNT(assigned_to = '#{user}' OR NULL) AS self_assigned
+        FROM submissions
+        WHERE state = 'submitted' AND deleted_at IS NULL
+      SQL
+      ActiveRecord::Base.connection.execute(query).first.symbolize_keys
+    end
+  end
+
+  module Offer
+    module_function
+
+    def grouped_by_state
+      query = <<-SQL.squish
+        SELECT COUNT(*) AS total,
+        COUNT(state = 'sent' OR NULL) AS sent,
+        COUNT(state = 'review' OR NULL) AS review
+        FROM offers
+      SQL
+      ActiveRecord::Base.connection.execute(query).first.symbolize_keys
+    end
+  end
+
+  module Consignment
+    module_function
+
+    def grouped_by_state_and_partner
+      query = <<-SQL.squish
+        SELECT ps.state,
+        COUNT(*) AS total,
+        COUNT(p.name LIKE  '%Artsy%' OR NULL) AS artsy_curated,
+        COUNT(p.name NOT LIKE  '%Artsy%' OR NULL) AS auction_house
+        FROM partner_submissions ps JOIN partners p ON ps.partner_id=p.id
+        WHERE accepted_offer_id IS NOT NULL
+        GROUP BY ps.state;
+      SQL
+
+      ActiveRecord::Base.connection.execute(query).map do |row|
+        [
+          row['state'].to_sym,
+          {
+            total: row['total'],
+            artsy_curated: row['artsy_curated'],
+            auction_house: row['auction_house']
+          }
+        ]
+      end.to_h
+    end
+  end
+end

--- a/app/views/admin/dashboard/_row.html.erb
+++ b/app/views/admin/dashboard/_row.html.erb
@@ -1,0 +1,10 @@
+<div class='col-sm-12 dashboard_subcategory_row <%= section_name.parameterize %>' >
+  <div class="gray-label">
+    <h4>
+      <%= section_name %> : <%= items_count || 0 %>
+    </h4>
+  </div>
+  <a href=<%= filtered_path %>>
+    <span style='' class='icon-chevron-right pull-right gray-label'></span>
+  </a>
+</div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class='container'>
-  <div class='row unreviewed-submissions'>
+  <div class='row unreviewed-submissions dashboard_category_row'>
     <div class='row section-header col-sm-12'>
       <div class='col-sm-9'>
         <h3>
@@ -7,84 +7,146 @@
         </h3>
       </div>
       <div class='col-sm-3'>
-        <div class='pull-right gray-label'>
+        <div class='pull-right'>
           <h3>
-            <%= submissions_count %>
+            <%= unreviewed_submissions[:total] || 0 %>
           </h3>
         </div>
       </div>
     </div>
-    <div class='row col-sm-12'>
-      <div class='list-group'>
-        <% submissions.each do |submission| %>
-          <%= render 'admin/submissions/submission', submission: submission, artist: artist_details&.dig(submission.artist_id) %>
-        <% end %>
-      </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Unassigned Submissions',
+                 items_count: unreviewed_submissions[:unassigned],
+                 filtered_path: admin_submissions_path(state: :submitted, assigned_to: '')
+      %>
     </div>
-    <div class='row col-sm-12'>
-      <div class='section-actions'>
-        <div class='pull-right'>
-          <%= link_to 'See All', admin_submissions_path(state: 'submitted'), class: 'btn btn-secondary btn-small' %>
-        </div>
-      </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'My Submissions',
+                 items_count: unreviewed_submissions[:self_assigned],
+                 filtered_path: admin_submissions_path(state: :submitted, assigned_to: @current_user)
+      %>
     </div>
   </div>
-  <div class='row open-offers'>
+  <div class='row approved-submissions dashboard_category_row'>
     <div class='row section-header col-sm-12'>
       <div class='col-sm-9'>
         <h3>
-          Open Offers
+          Approved
         </h3>
       </div>
       <div class='col-sm-3'>
-        <div class='pull-right gray-label'>
+        <div class='pull-right'>
           <h3>
-            <%= offers_count %>
+            <%= sum_up_approved_submissions(grouped_submissions) %>
           </h3>
         </div>
       </div>
     </div>
-    <div class='row col-sm-12'>
-      <div class='list-group'>
-        <%= render offers %>
-      </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Approved without CMS',
+                 items_count: grouped_submissions[:approved],
+                 filtered_path: admin_submissions_path(state: :approved)
+      %>
     </div>
-    <div class='row col-sm-12'>
-      <div class='section-actions'>
-        <div class='pull-right'>
-          <%= link_to 'See All', admin_offers_path(state: 'sent'), class: 'btn btn-secondary btn-small' %>
-        </div>
-      </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Published to CMS',
+                 items_count: grouped_submissions[:published],
+                 filtered_path: admin_submissions_path(state: :published)
+      %>
     </div>
   </div>
-  <div class='row active-consignments'>
+  <div class='row offers dashboard_category_row'>
     <div class='row section-header col-sm-12'>
       <div class='col-sm-9'>
         <h3>
-          Active Consignments
+          Offers
         </h3>
       </div>
       <div class='col-sm-3'>
-        <div class='pull-right gray-label'>
+        <div class='pull-right'>
           <h3>
-            <%= consignments_count %>
+            <%= grouped_offers[:total] || 0 %>
           </h3>
         </div>
       </div>
     </div>
-    <div class='row col-sm-12'>
-      <div class='list-group'>
-        <% consignments.each do |consignment| %>
-          <%= render 'admin/consignments/consignment', consignment: consignment, artist: artist_details&.dig(consignment.submission.artist_id) %>
-        <% end %>
-      </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Sent',
+                 items_count: grouped_offers[:sent],
+                 filtered_path: admin_offers_path(state: :sent)
+      %>
     </div>
-    <div class='row col-sm-12'>
-      <div class='section-actions'>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Introduced',
+                 items_count: grouped_offers[:review],
+                 filtered_path: admin_offers_path(state: :review)
+      %>
+    </div>
+  </div>
+  <div class='row upcoming-consignments dashboard_category_row'>
+    <div class='row section-header col-sm-12'>
+      <div class='col-sm-9'>
+        <h3>
+          Upcoming Consignments
+        </h3>
+      </div>
+      <div class='col-sm-3'>
         <div class='pull-right'>
-          <%= link_to 'See All', admin_consignments_path, class: 'btn btn-secondary btn-small' %>
+          <h3>
+            <%= grouped_consignments.dig(:open, :total) || 0 %>
+          </h3>
         </div>
       </div>
+    </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Auction House',
+                 items_count: grouped_consignments.dig(:open, :auction_house),
+                 filtered_path: admin_consignments_path(state: :open, term: '!Artsy')
+      %>
+    </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Artsy Curated Auctions',
+                 items_count: grouped_consignments.dig(:open, :artsy_curated),
+                 filtered_path: admin_consignments_path(state: :open, term: 'Artsy')
+      %>
+    </div>
+  </div>
+  <div class='row sold-consignments dashboard_category_row'>
+    <div class='row section-header col-sm-12'>
+      <div class='col-sm-9'>
+        <h3>
+          Sold Consignments
+        </h3>
+      </div>
+      <div class='col-sm-3'>
+        <div class='pull-right'>
+          <h3>
+            <%= grouped_consignments.dig(:sold, :total) || 0 %>
+          </h3>
+        </div>
+      </div>
+    </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Auction House',
+                 items_count: grouped_consignments.dig(:sold, :auction_house),
+                 filtered_path: admin_consignments_path(state: :sold, term: '!Artsy')
+      %>
+    </div>
+    <div>
+      <%= render 'admin/dashboard/row',
+                 section_name: 'Artsy Curated Auctions',
+                 items_count: grouped_consignments.dig(:sold, :artsy_curated),
+                 filtered_path: admin_consignments_path(state: :sold, term: 'Artsy')
+      %>
     </div>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,7 @@ module Convection
         #{Rails.root.join('app', 'graphql', 'resolvers')}
         #{Rails.root.join('app', 'controllers', 'concerns')}
         #{Rails.root.join('app', 'models', 'concerns')}
+        #{Rails.root.join('app', 'queries')}
       ]
 
     # include JWT middleware

--- a/spec/queries/dashboard_reporting_query_spec.rb
+++ b/spec/queries/dashboard_reporting_query_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DashboardReportingQuery::Submission do
+  context 'when no submission' do
+    describe 'grouped_by_state' do
+      subject { DashboardReportingQuery::Submission.grouped_by_state }
+      it { is_expected.to eq({}) }
+    end
+
+    describe 'unreviewed_user_submissions' do
+      subject { DashboardReportingQuery::Submission.unreviewed_user_submissions('user_id') }
+      it { is_expected.to eq({self_assigned: 0, total: 0, unassigned: 0}) }
+    end
+  end
+
+  context 'when submissions exist' do
+    before do
+      Fabricate(:submission, state: Submission::APPROVED, assigned_to: nil)
+      Fabricate(:submission, state: Submission::SUBMITTED, assigned_to: nil)
+      Fabricate(:submission, state: Submission::DRAFT,  assigned_to: 'user_id')
+      Fabricate(:submission, state: Submission::SUBMITTED, assigned_to: 'user_id')
+      Fabricate(:submission, state: Submission::SUBMITTED, assigned_to: 'user_id', deleted_at: Time.now.utc)
+    end
+
+    describe 'grouped_by_state' do
+      subject { DashboardReportingQuery::Submission.grouped_by_state }
+      it { is_expected.to include({ draft: 1, approved: 1, submitted: 2 }) }
+    end
+
+    describe 'unreviewed_user_submissions' do
+      subject { DashboardReportingQuery::Submission.unreviewed_user_submissions('user_id') }
+      it { is_expected.to include({total: 2, unassigned: 1, self_assigned: 1 }) }
+    end
+  end
+end
+
+describe DashboardReportingQuery::Offer do
+  context 'when no offer' do
+    describe 'grouped_by_state' do
+      subject { DashboardReportingQuery::Offer.grouped_by_state }
+      it { is_expected.to eq({ review: 0, sent: 0, total: 0 }) }
+    end
+  end
+
+  context 'when offers exist' do
+    before do
+      Fabricate(:offer, state: Offer::DRAFT)
+      Fabricate(:offer, state: Offer::SENT)
+      Fabricate(:offer, state: Offer::REVIEW)
+      Fabricate(:offer, state: Offer::REJECTED)
+    end
+
+    describe 'grouped_by_state' do
+      subject { DashboardReportingQuery::Offer.grouped_by_state }
+      it { is_expected.to include({ review: 1, sent: 1, total: 4 }) }
+    end
+  end
+end
+
+
+describe DashboardReportingQuery::Consignment do
+  context 'when no consignment' do
+    describe 'grouped_by_state_and_partner' do
+      subject { DashboardReportingQuery::Consignment.grouped_by_state_and_partner }
+      it { is_expected.to eq({}) }
+    end
+  end
+
+  context 'when consignments exist' do
+    before do
+      @partner1 = Fabricate(:partner, name: 'Artsy')
+      @partner2 = Fabricate(:partner, name: 'Heritage Auctions')
+      @partner3 = Fabricate(:partner, name: 'Artsy x SomeGallery')
+
+      Fabricate(:consignment, state: 'open', partner: @partner1)
+      Fabricate(:consignment, state: 'sold', partner: @partner1)
+      Fabricate(:consignment, state: 'canceled', partner: @partner1)
+      Fabricate(:consignment, state: 'open', partner: @partner2)
+      Fabricate(:consignment, state: 'sold', partner: @partner2)
+      Fabricate(:consignment, state: 'bought in', partner: @partner2)
+      Fabricate(:consignment, state: 'open', partner: @partner3)
+      Fabricate(:consignment, state: 'sold', partner: @partner3)
+    end
+
+    describe 'grouped_by_state_and_partner' do
+      subject { DashboardReportingQuery::Consignment.grouped_by_state_and_partner }
+
+      it { is_expected.to include({
+                                    open: { total: 3, artsy_curated: 2, auction_house: 1 },
+                                    canceled: {total: 1, artsy_curated: 1, auction_house: 0},
+                                    sold: {total: 3, artsy_curated: 2, auction_house: 1},
+                                    "bought in": {total: 1, artsy_curated: 0, auction_house: 1}
+        })
+      }
+    end
+  end
+end


### PR DESCRIPTION
Refs: [CX-1313]

Note: Page is zoomed out 50%.

When tables are empty:
<img width="1279" alt="when empty tables" src="https://user-images.githubusercontent.com/3873525/118883873-d2a67a00-b906-11eb-9670-e9c4ba19742c.png">

When records exist:
<img width="1273" alt="when records exist" src="https://user-images.githubusercontent.com/3873525/118883881-d3d7a700-b906-11eb-9b9a-6b3905e7c507.png">


[CX-1313]: https://artsyproduct.atlassian.net/browse/CX-1313