### PR TITLE
[CX-1313]: Show `My Submissions` only to assignable admins

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -121,4 +121,8 @@ module SubmissionsHelper
     return 'P1' if is_p1
     return 'P2' if target_supply
   end
+
+  def assignable_admin?(user)
+    ADMINS.keys.include?(user.to_sym)
+  end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -21,13 +21,15 @@
                  filtered_path: admin_submissions_path(state: :submitted, assigned_to: '')
       %>
     </div>
-    <div>
-      <%= render 'admin/dashboard/row',
-                 section_name: 'My Submissions',
-                 items_count: unreviewed_submissions[:self_assigned],
-                 filtered_path: admin_submissions_path(state: :submitted, assigned_to: @current_user)
-      %>
-    </div>
+    <% if assignable_admin?(@current_user) %>
+      <div>
+        <%= render 'admin/dashboard/row',
+                   section_name: 'My Submissions',
+                   items_count: unreviewed_submissions[:self_assigned],
+                   filtered_path: admin_submissions_path(state: :submitted, assigned_to: @current_user)
+        %>
+      </div>
+    <% end %>
   </div>
   <div class='row approved-submissions dashboard_category_row'>
     <div class='row section-header col-sm-12'>

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -259,4 +259,22 @@ describe SubmissionsHelper, type: :helper do
       it { is_expected.to eq nil }
     end
   end
+
+  context 'assignable_admin?' do
+    subject { helper.assignable_admin?(user) }
+
+    before do
+      stub_const('ADMINS', { admin: 'AdminName' })
+    end
+
+    context 'for non-admin user' do
+      let(:user) { 'non-admin' }
+      it { is_expected.to be_falsey }
+    end
+
+    context 'for admin user' do
+      let(:user) { 'admin' }
+      it { is_expected.to be_truthy }
+    end
+  end
 end

--- a/spec/views/admin/dashboard/index.html.erb_spec.rb
+++ b/spec/views/admin/dashboard/index.html.erb_spec.rb
@@ -12,13 +12,15 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
         :decode_user
       ).and_return('me')
 
+      allow_any_instance_of(SubmissionsHelper).to receive(:assignable_admin?).and_return(false)
+
       page.visit '/'
     end
 
     it 'displays the section titles' do
       expect(page).to have_content('Unreviewed Submissions 0')
       expect(page).to have_content('Unassigned Submissions : 0')
-      expect(page).to have_content('My Submissions : 0')
+      expect(page).not_to have_content('My Submissions : 0')
       expect(page).to have_content('Approved 0')
       expect(page).to have_content('Approved without CMS : 0')
       expect(page).to have_content('Published to CMS : 0')
@@ -33,7 +35,7 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
 
     it 'lets you click and go to filtered submissions page' do
       expect(page).to have_selector(".unreviewed-submissions a.unassigned-submissions[href='#{admin_submissions_path(state: :submitted, assigned_to: '')}']")
-      expect(page).to have_selector(".unreviewed-submissions a.my-submissions[href='#{admin_submissions_path(state: :submitted, assigned_to: 'me')}']")
+      expect(page).not_to have_selector(".unreviewed-submissions a.my-submissions[href='#{admin_submissions_path(state: :submitted, assigned_to: 'me')}']")
 
       expect(page).to have_selector(".approved-submissions a.approved-without-cms[href='#{admin_submissions_path(state: :approved)}']")
       expect(page).to have_selector(".approved-submissions a.published-to-cms[href='#{admin_submissions_path(state: :published)}']")
@@ -56,17 +58,6 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
 
       expect(page).to have_selector(".sold-consignments a.auction-house[href='#{admin_consignments_path(state: :sold, term: '!Artsy')}']")
       expect(page).to have_selector(".sold-consignments a.artsy-curated-auctions[href='#{admin_consignments_path(state: :sold, term: 'Artsy')}']")
-    end
-
-    context 'with just submissions' do
-      before do
-        Fabricate(:submission, state: 'draft', assigned_to: nil)
-        Fabricate(:submission, state: 'approved', assigned_to: 'me')
-        2.times { Fabricate(:submission, state: 'submitted', assigned_to: nil) }
-        2.times { Fabricate(:submission, state: 'submitted', assigned_to: 'some_user') }
-        Fabricate(:submission, state: 'submitted', assigned_to: 'me')
-        page.visit '/'
-      end
     end
 
     context 'with some offers and submissions and consignments' do
@@ -97,7 +88,7 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
       it 'displays right counts for Unreviewed Submissions category' do
         expect(page).to have_content('Unreviewed Submissions 4')
         expect(page).to have_content('Unassigned Submissions : 1')
-        expect(page).to have_content('My Submissions : 2')
+        expect(page).not_to have_content('My Submissions : 2')
 
         expect(page).to have_content('Approved 3')
         expect(page).to have_content('Approved without CMS : 1')
@@ -115,6 +106,31 @@ describe 'admin/dashboard/index.html.erb', type: :feature do
         expect(page).to have_content('Auction House : 1')
         expect(page).to have_content('Artsy Curated Auctions : 2')
       end
+    end
+
+    context 'for assignable admins' do
+      before {
+        allow_any_instance_of(SubmissionsHelper).to receive(:assignable_admin?).and_return(true)
+      }
+
+      subject { page.tap { |p| p.visit '/' } }
+
+      it { is_expected.to have_content('My Submissions : 0') }
+      it { is_expected.to have_selector(".unreviewed-submissions a.my-submissions[href='#{admin_submissions_path(state: :submitted, assigned_to: 'me')}']") }
+
+      context 'with submissions' do
+        before do
+          2.times { Fabricate(:submission, state: 'submitted', assigned_to: 'me') }
+          Fabricate(:submission, state: 'submitted', assigned_to: nil)
+          Fabricate(:submission, state: 'submitted', assigned_to: 'some_user')
+          Fabricate(:submission, state: 'approved', assigned_to: 'me')
+          2.times { Fabricate(:submission, state: 'published', assigned_to: nil) }
+          Fabricate(:submission, state: 'draft', assigned_to: 'me')
+        end
+
+        it { is_expected.to have_content('My Submissions : 2') }
+      end
+
     end
   end
 end


### PR DESCRIPTION
Refs [CX-1313]

<img width="1278" alt="for_assignable_admins" src="https://user-images.githubusercontent.com/3873525/119570468-35918880-bdc1-11eb-869e-2a075ec37aca.png">
<img width="1279" alt="for_other_users" src="https://user-images.githubusercontent.com/3873525/119570474-375b4c00-bdc1-11eb-8c74-6e474121ff01.png">


[CX-1313]: https://artsyproduct.atlassian.net/browse/CX-1313