### PR TITLE
feat: Added rake tasks to lapse all offers sent or reviewed before a certain date

### DIFF
--- a/lib/tasks/offers.rake
+++ b/lib/tasks/offers.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :offers do
+  desc 'Lapse all offers that were sent before a certain date'
+  task :lapse_sent, [:date] => :environment do |_task, args|
+    raise 'Please supply a date until which sent offers should be considered to lapse!' unless args[:date]
+
+    datetime = args[:date].to_datetime
+    Offer.where("state = ? AND (sent_at < ? OR sent_at IS NULL)", "sent", datetime).update_all(state: "lapsed")
+  end
+
+  desc 'Lapse all offers that were reviewed before a certain date'
+  task :lapse_review, [:date] => :environment do |_task, args|
+    raise 'Please supply a date until which reviewed offers should be considered to lapse!' unless args[:date]
+
+    datetime = args[:date].to_datetime
+    Offer.where("state = ? AND review_started_at < ?", "review", datetime).update_all(state: "lapsed")
+  end
+end

--- a/lib/tasks/offers.rake
+++ b/lib/tasks/offers.rake
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# rubocop:disable Lint/RedundantCopDisableDirective
+# rubocop:disable Rails/SkipsModelValidations
+
 namespace :offers do
   desc 'Lapse all offers that were sent before a certain date'
   task :lapse_sent, [:date] => :environment do |_task, args|
@@ -17,3 +20,6 @@ namespace :offers do
     Offer.where("state = ? AND review_started_at < ?", "review", datetime).update_all(state: "lapsed")
   end
 end
+
+# rubocop:enable Rails/SkipsModelValidations
+# rubocop:enable Lint/RedundantCopDisableDirective

--- a/spec/tasks/offers_spec.rb
+++ b/spec/tasks/offers_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+Rails.application.load_tasks
+
+describe "Offers rake tasks" do
+  describe "Offers lapse sent rake task" do
+    subject(:invoke_task) do
+      Rake.application.invoke_task("offers:lapse_sent[#{date}]")
+    end
+
+    let(:date) { "2021-09-01" }
+    let(:past_offer) { Fabricate(:offer, state: "sent", sent_at: date.to_date - 1.day) }
+    let(:future_offer) { Fabricate(:offer, state: "sent", sent_at: date.to_date + 1.day) }
+    let(:future_offer1) { Fabricate(:offer, state: "sent", sent_at: date.to_date + 1.month) }
+    let(:future_offer2) { Fabricate(:offer, state: "sent", sent_at: date.to_date + 1.year) }
+    let(:past_review_offer) { Fabricate(:offer, state: "review", sent_at: date.to_date - 1.day) }
+
+    it "update the state if offer is set to 'sent' before a certain date" do
+      expect { invoke_task }.to(change { past_offer.reload.state }.from("sent").to("lapsed"))
+      expect { invoke_task }.not_to(change { future_offer.reload.state })
+      expect { invoke_task }.not_to(change { future_offer1.reload.state })
+      expect { invoke_task }.not_to(change { future_offer2.reload.state })
+      expect { invoke_task }.not_to(change { past_review_offer.reload.state })
+    end
+  end
+
+  describe "Offers lapse review rake task" do
+    subject(:invoke_task) do
+      Rake.application.invoke_task("offers:lapse_review[#{date}]")
+    end
+
+    let(:date) { "2021-09-01" }
+    let(:past_offer) { Fabricate(:offer, state: "review", review_started_at: date.to_date - 1.day) }
+    let(:future_offer) { Fabricate(:offer, state: "review", review_started_at: date.to_date + 1.day) }
+    let(:future_offer1) { Fabricate(:offer, state: "review", review_started_at: date.to_date + 1.month) }
+    let(:future_offer2) { Fabricate(:offer, state: "review", review_started_at: date.to_date + 1.year) }
+    let(:past_sent_offer) { Fabricate(:offer, state: "sent", review_started_at: date.to_date - 1.day) }
+
+    it "update the state if offer is set to 'review' before a certain date" do
+      expect { invoke_task }.to(change { past_offer.reload.state }.from("review").to("lapsed"))
+      expect { invoke_task }.not_to(change { future_offer.reload.state })
+      expect { invoke_task }.not_to(change { future_offer1.reload.state })
+      expect { invoke_task }.not_to(change { future_offer2.reload.state })
+      expect { invoke_task }.not_to(change { past_sent_offer.reload.state })
+    end
+  end
+end


### PR DESCRIPTION
Resolves: [CX-1509](https://artsyproduct.atlassian.net/browse/CX-1509) and [CX-1511](https://artsyproduct.atlassian.net/browse/CX-1511)

I have added two rake tasks for lapsing offers that are in the status of sent or reviewed before a certain date. 
As an example of launching: `rake offers:lapse_review ["2021-09-01"]`