### PR TITLE
feat: Added rake tasks to cancel all consignments opened before a certain date

### DIFF
--- a/lib/tasks/partner_submissions.rake
+++ b/lib/tasks/partner_submissions.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# rubocop:disable Lint/RedundantCopDisableDirective
+# rubocop:disable Rails/SkipsModelValidations
+
+namespace :partner_submissions do
+  desc 'Cancel all consignments that were open before a certain date'
+  task :cancel_open, [:date] => :environment do |_task, args|
+    raise 'Please supply a date until which open consignments should be considered to canceled!' unless args[:date]
+
+    datetime = args[:date].to_datetime
+    PartnerSubmission.consigned.where("state = ? AND created_at < ?", "open", datetime).update_all(state: "canceled")
+  end
+end
+
+# rubocop:enable Rails/SkipsModelValidations
+# rubocop:enable Lint/RedundantCopDisableDirective

--- a/spec/tasks/partner_submissions_spec.rb
+++ b/spec/tasks/partner_submissions_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+Rails.application.load_tasks
+
+describe "Consigments cancel open rake task" do
+  subject(:invoke_task) do
+    Rake.application.invoke_task("partner_submissions:cancel_open[#{date}]")
+  end
+
+  let(:date) { "2021-09-01" }
+  let(:past_consignment) { Fabricate(:consignment, state: "open", created_at: date.to_date - 1.day) }
+  let(:future_consignment) { Fabricate(:consignment, state: "open", created_at: date.to_date + 1.day) }
+  let(:future_consignment1) { Fabricate(:consignment, state: "open", created_at: date.to_date + 1.month) }
+  let(:future_consignment2) { Fabricate(:consignment, state: "open", created_at: date.to_date + 1.year) }
+  let(:past_sold_consignment) { Fabricate(:consignment, state: "sold", created_at: date.to_date - 1.day) }
+
+  it "update the state if consigment is set to 'open' before a certain date" do
+    expect { invoke_task }.to(change { past_consignment.reload.state }.from("open").to("canceled"))      
+    expect { invoke_task }.not_to(change { future_consignment.reload.state })
+    expect { invoke_task }.not_to(change { future_consignment1.reload.state })
+    expect { invoke_task }.not_to(change { future_consignment2.reload.state })
+    expect { invoke_task }.not_to(change { past_sold_consignment.reload.state })
+  end
+end


### PR DESCRIPTION
Resolves: [CX-1510](https://artsyproduct.atlassian.net/browse/CX-1510)

I added rake task to cancel consignments that are open before a certain date.
As an example of launching: rake partner_submissions:cancel_open[date]