### PR TITLE
update: add coa fields to submissions table and mutation

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -436,6 +436,8 @@ input CreateSubmissionMutationInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  coaByAuthenticatingBody: Boolean
+  coaByGallery: Boolean
   currency: String
   depth: String
   dimensionsMetric: String
@@ -1404,6 +1406,26 @@ enum SubmissionSort {
   sort by category in descending order
   """
   CATEGORY_DESC
+
+  """
+  sort by coa_by_authenticating_body in ascending order
+  """
+  COA_BY_AUTHENTICATING_BODY_ASC
+
+  """
+  sort by coa_by_authenticating_body in descending order
+  """
+  COA_BY_AUTHENTICATING_BODY_DESC
+
+  """
+  sort by coa_by_gallery in ascending order
+  """
+  COA_BY_GALLERY_ASC
+
+  """
+  sort by coa_by_gallery in descending order
+  """
+  COA_BY_GALLERY_DESC
 
   """
   sort by condition_report in ascending order

--- a/app/graphql/mutations/create_submission_mutation.rb
+++ b/app/graphql/mutations/create_submission_mutation.rb
@@ -7,6 +7,8 @@ module Mutations
     argument :additional_info, String, required: false
     argument :authenticity_certificate, Boolean, required: false
     argument :category, Types::CategoryType, required: false
+    argument :coaByAuthenticatingBody, Boolean, required: false
+    argument :coaByGallery, Boolean, required: false
     argument :currency, String, required: false
     argument :depth, String, required: false
     argument :dimensions_metric,

--- a/db/migrate/20210622110240_add_coa_fields_to_submissions.rb
+++ b/db/migrate/20210622110240_add_coa_fields_to_submissions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddCoaFieldsToSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    change_table :submissions, bulk: true do |t|
+      t.boolean :coa_by_authenticating_body
+      t.boolean :coa_by_gallery
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_02_193423) do
+ActiveRecord::Schema.define(version: 2021_06_22_110240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -188,6 +188,8 @@ ActiveRecord::Schema.define(version: 2021_06_02_193423) do
     t.string "utm_source"
     t.string "utm_medium"
     t.string "utm_term"
+    t.boolean "coa_by_authenticating_body"
+    t.boolean "coa_by_gallery"
     t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
     t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
     t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"


### PR DESCRIPTION
Resolving this ticket: [PX-4130](https://artsyproduct.atlassian.net/browse/PX-4130)

Paired with @mdole on this.

Connected to the `create_consignment_submission` action over on the [volt artworks controller](https://github.com/artsy/volt/blob/5d4da239203b1c13e7e9151efbac0c0cd03375ae/app/controllers/artworks_controller.rb#L238), where we were introducing a bug by not actually having the fields for the params that we send over to convection. 

This is also confirmed as useful by Sarah Shelburn 👍 
 
In order to fix this bug, we need to first introduce it to the schema here in convection. 
Follow up tasks:
- [ ] copy the new schema to metaphysics and maybe stitch
- [x] implement both new fields into the [view on convection](https://github.com/artsy/convection/blob/835432291c8c1fc56a1179e2bc42740d92f90dfa/app/views/admin/submissions/_submission_details.html.erb)

Screenshot of where to add the view:
<img width="1193" alt="Bildschirmfoto 2021-06-22 um 13 16 30" src="https://user-images.githubusercontent.com/15628617/122915610-34219480-d35c-11eb-85d8-3ba6f4c36b2e.png">
