### PR TITLE
feat: Introduce admin users

### DIFF
--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -320,3 +320,7 @@ a.make-primary-link {
     line-height: inherit;
   }
 }
+
+.align-center {
+  text-align: center;
+}

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -58,7 +58,7 @@ module Admin
     end
 
     def admin_user_params
-      params.require(:admin_user).permit(:name, :gravity_user_id, :super_admin, :admin, :cataloguer)
+      params.require(:admin_user).permit(:name, :gravity_user_id, :super_admin, :assignee, :cataloguer)
     end
 
     def authorize_user!

--- a/app/controllers/admin/admin_users_controller.rb
+++ b/app/controllers/admin/admin_users_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Admin
+  class AdminUsersController < ApplicationController
+    include ApplicationHelper
+
+    before_action :authorize_user!
+    before_action :set_admin_user, only: [:show, :edit, :update, :destroy]
+
+    # GET /admin/admin_users
+    def index
+      @admin_users = AdminUser.order('LOWER(name)').all
+    end
+
+    # GET /admin/admin_users/1
+    def show
+      redirect_to edit_admin_admin_user_path(params[:id])
+    end
+
+    # GET /admin/admin_users/new
+    def new
+      @admin_user = AdminUser.new
+    end
+
+    # GET /admin/admin_users/1/edit
+    def edit; end
+
+    # POST /admin/admin_users
+    def create
+      @admin_user = AdminUser.new(admin_user_params)
+
+      if @admin_user.save
+        redirect_to admin_admin_users_path, notice: 'Admin was successfully created.'
+      else
+        render :new
+      end
+    end
+
+    # PATCH/PUT /admin/admin_users/1
+    def update
+      if @admin_user.update(admin_user_params)
+        redirect_to admin_admin_users_path, notice: 'Admin was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
+    # DELETE /admin/admin_users/1
+    def destroy
+      @admin_user.destroy
+      redirect_to admin_admin_users_url, notice: 'Admin was successfully destroyed.'
+    end
+
+    private
+
+    def set_admin_user
+      @admin_user = AdminUser.find(params[:id])
+    end
+
+    def admin_user_params
+      params.require(:admin_user).permit(:name, :gravity_user_id, :super_admin, :admin, :cataloguer)
+    end
+
+    def authorize_user!
+      raise ApplicationController::NotAuthorized unless super_admin_user? @current_user
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,10 +21,18 @@ module ApplicationHelper
   end
 
   def filter_by_assigned_to_options
-    ADMINS.collect.map { |id, name| [name, id] }.unshift(%w[all all], ['none', nil])
+    AdminUser.admins.map {
+      |admin| [admin.name, admin.gravity_user_id]
+    }.unshift(%w[all all], ['none', nil])
   end
 
   def filter_by_cataloguers_options
-    CATALOGUERS.collect.map { |id, name| [name, id] }.unshift(%w[all all], ['none', nil])
+    AdminUser.cataloguers.map {
+      |cataloguer| [cataloguer.name, cataloguer.gravity_user_id]
+    }.unshift(%w[all all], ['none', nil])
+  end
+
+  def super_admin_user?(user_id)
+    AdminUser.exists?(gravity_user_id: user_id, admin: true)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -21,7 +21,7 @@ module ApplicationHelper
   end
 
   def filter_by_assigned_to_options
-    AdminUser.admins.map {
+    AdminUser.assignees.map {
       |admin| [admin.name, admin.gravity_user_id]
     }.unshift(%w[all all], ['none', nil])
   end
@@ -33,6 +33,6 @@ module ApplicationHelper
   end
 
   def super_admin_user?(user_id)
-    AdminUser.exists?(gravity_user_id: user_id, admin: true)
+    AdminUser.exists?(gravity_user_id: user_id, super_admin: true)
   end
 end

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -123,6 +123,6 @@ module SubmissionsHelper
   end
 
   def assignable_admin?(user)
-    ADMINS.keys.include?(user.to_sym)
+    AdminUser.exists?(gravity_user_id: user)
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AdminUser < ApplicationRecord
+  validates :gravity_user_id, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true
+
+  scope :admins, -> { where(admin: true) }
+  scope :cataloguers, -> { where(cataloguer: true) }
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -4,6 +4,6 @@ class AdminUser < ApplicationRecord
   validates :gravity_user_id, presence: true, uniqueness: true
   validates :name, presence: true, uniqueness: true
 
-  scope :admins, -> { where(admin: true) }
+  scope :assignees, -> { where(assignee: true) }
   scope :cataloguers, -> { where(cataloguer: true) }
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -167,13 +167,13 @@ class Submission < ApplicationRecord
   def validate_primary_image
     return if primary_image.blank?
 
-    unless primary_image.asset_type == 'image'
-      errors.add(:primary_image, 'Primary image must have asset_type=image')
-    end
+    return if primary_image.asset_type == 'image'
+
+    errors.add(:primary_image, 'Primary image must have asset_type=image')
   end
 
   def exchange_assigned_to_real_user!
-    admin_gravity_id = ADMINS.key assigned_to
+    admin_gravity_id = AdminUser.find_by(name: assigned_to)&.gravity_user_id
 
     return if assigned_to == admin_gravity_id
 

--- a/app/views/admin/admin_users/_form.html.erb
+++ b/app/views/admin/admin_users/_form.html.erb
@@ -1,0 +1,45 @@
+<div class='container'>
+  <%= form_for @admin_user, url: @admin_user.persisted? ? admin_admin_user_path(@admin_user) : admin_admin_users_path do |f| %>
+  <% if @admin_user.errors.any? %>
+  <div id="error_explanation">
+    <h2>
+      <%= "#{pluralize(@admin_user.errors.count, "error")} prohibited this admin from being saved:" %>
+    </h2>
+    <ul>
+      <% @admin_user.errors.full_messages.each do |message| %>
+      <li>
+        <%= message %>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+  <% end %>
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_field :name %>
+  </div>
+  <div class="field">
+    <%= f.label :gravity_user_id %>
+    <%= f.text_field :gravity_user_id %>
+  </div>
+  <div class="field">
+    <%= f.label :assignee %>
+    <%= f.check_box :admin %>
+  </div>
+  <div class="field">
+    <%= f.label :cataloguer %>
+    <%= f.check_box :cataloguer %>
+  </div>
+  <div class="field">
+    <%= f.label :super_admin %>
+    <%= f.check_box :super_admin %>
+  </div>
+  <div class="actions">
+    <div class='row triple-padding-top'>
+      <div class='col-md-12'>
+        <%= f.submit 'Save', class: 'btn btn-primary btn-full-width' %>
+      </div>
+    </div>
+  </div>
+  <% end %>
+</div>

--- a/app/views/admin/admin_users/_form.html.erb
+++ b/app/views/admin/admin_users/_form.html.erb
@@ -24,7 +24,7 @@
   </div>
   <div class="field">
     <%= f.label :assignee %>
-    <%= f.check_box :admin %>
+    <%= f.check_box :assignee %>
   </div>
   <div class="field">
     <%= f.label :cataloguer %>

--- a/app/views/admin/admin_users/edit.html.erb
+++ b/app/views/admin/admin_users/edit.html.erb
@@ -1,0 +1,8 @@
+<div class='page-title'>
+  <%= link_to 'Back', admin_admin_users_path, class: 'btn btn-small btn-primary pull-right' %>
+  <h2>
+    Edit Admin
+  </h2>
+</div>
+
+<%= render 'form' %>

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -33,7 +33,7 @@
       <%= admin_user.gravity_user_id %>
     </div>
     <div class='col-md-1'>
-      <%= admin_user.admin ? "Yes" : "No" %>
+      <%= admin_user.assignee ? "Yes" : "No" %>
     </div>
     <div class='col-md-1'>
       <%= admin_user.cataloguer ? "Yes" : "No" %>

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -1,0 +1,52 @@
+<div class='page-title'>
+  <%= link_to 'Create New', new_admin_admin_user_path, class: 'btn btn-small btn-primary pull-right' %>
+  <h2>
+    Admins
+  </h2>
+</div>
+
+<div class='container double-padding-top'>
+
+  <div class='row'>
+    <div class='col-md-2'>
+      <div class='list-group-item-info bold-label'>Name</div>
+    </div>
+    <div class='col-md-4'>
+      <div class='list-group-item-info bold-label'>Gravity User ID</div>
+    </div>
+    <div class='col-md-1'>
+      <div class='list-group-item-info bold-label'>Assignee</div>
+    </div>
+    <div class='col-md-1'>
+      <div class='list-group-item-info bold-label'>Cataloguer</div>
+    </div>
+    <div class='col-md-1'>
+      <div class='list-group-item-info bold-label'>Admin</div>
+    </div>
+  </div>
+  <% @admin_users.each do |admin_user| %>
+  <div class='row double-padding-top'>
+    <div class='col-md-2'>
+      <%= admin_user.name %>
+    </div>
+    <div class='col-md-4'>
+      <%= admin_user.gravity_user_id %>
+    </div>
+    <div class='col-md-1'>
+      <%= admin_user.admin ? "Yes" : "No" %>
+    </div>
+    <div class='col-md-1'>
+      <%= admin_user.cataloguer ? "Yes" : "No" %>
+    </div>
+    <div class='col-md-1'>
+      <%= admin_user.super_admin ? "Yes" : "No" %>
+    </div>
+    <div class='col-md-1'>
+      <%= button_to 'Edit', edit_admin_admin_user_path(admin_user), method: :get, class: 'btn btn-small btn-primary pull-right' %>
+    </div>
+    <div class='col-md-2'>
+      <%= button_to 'Remove', admin_admin_user_path(admin_user), method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-small btn-primary pull-right' %>
+    </div>
+  </div>
+  <% end %>
+</div>

--- a/app/views/admin/admin_users/index.html.erb
+++ b/app/views/admin/admin_users/index.html.erb
@@ -11,17 +11,17 @@
     <div class='col-md-2'>
       <div class='list-group-item-info bold-label'>Name</div>
     </div>
-    <div class='col-md-4'>
-      <div class='list-group-item-info bold-label'>Gravity User ID</div>
+    <div class='col-md-3'>
+      <div class='list-group-item-info bold-label align-center'>Gravity User ID</div>
     </div>
     <div class='col-md-1'>
-      <div class='list-group-item-info bold-label'>Assignee</div>
+      <div class='list-group-item-info bold-label align-center'>Assignee</div>
     </div>
     <div class='col-md-1'>
-      <div class='list-group-item-info bold-label'>Cataloguer</div>
+      <div class='list-group-item-info bold-label align-center'>Cataloguer</div>
     </div>
     <div class='col-md-1'>
-      <div class='list-group-item-info bold-label'>Admin</div>
+      <div class='list-group-item-info bold-label align-center'>Admin</div>
     </div>
   </div>
   <% @admin_users.each do |admin_user| %>
@@ -29,23 +29,23 @@
     <div class='col-md-2'>
       <%= admin_user.name %>
     </div>
-    <div class='col-md-4'>
+    <div class='col-md-3 align-center'>
       <%= admin_user.gravity_user_id %>
     </div>
-    <div class='col-md-1'>
+    <div class='col-md-1 align-center'>
       <%= admin_user.assignee ? "Yes" : "No" %>
     </div>
-    <div class='col-md-1'>
+    <div class='col-md-1 align-center'>
       <%= admin_user.cataloguer ? "Yes" : "No" %>
     </div>
-    <div class='col-md-1'>
+    <div class='col-md-1 align-center'>
       <%= admin_user.super_admin ? "Yes" : "No" %>
     </div>
-    <div class='col-md-1'>
-      <%= button_to 'Edit', edit_admin_admin_user_path(admin_user), method: :get, class: 'btn btn-small btn-primary pull-right' %>
+    <div class='col-md-2'%>
+      <%= button_to '&emsp;Edit&emsp;'.html_safe, edit_admin_admin_user_path(admin_user), method: :get, class: 'btn btn-small btn-primary pull-right', style: 'float: center;'%>
     </div>
     <div class='col-md-2'>
-      <%= button_to 'Remove', admin_admin_user_path(admin_user), method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-small btn-primary pull-right' %>
+      <%= button_to 'Remove', admin_admin_user_path(admin_user), method: :delete, data: { confirm: 'Are you sure?'}, class: 'btn btn-small btn-primary pull-right'%>
     </div>
   </div>
   <% end %>

--- a/app/views/admin/admin_users/new.html.erb
+++ b/app/views/admin/admin_users/new.html.erb
@@ -1,0 +1,8 @@
+<div class='page-title'>
+  <%= link_to 'Back', admin_admin_users_path, class: 'btn btn-small btn-primary pull-right' %>
+  <h2>
+    New Admin
+  </h2>
+</div>
+
+<%= render 'form' %>

--- a/app/views/admin/submissions/_assigned_to.html.erb
+++ b/app/views/admin/submissions/_assigned_to.html.erb
@@ -1,4 +1,4 @@
 <div class='col-md-9' id='assigned-to'>
-  <%= @submission.assigned_to == '' ?  'Unassigned' : ADMINS[:"#{@submission.assigned_to}"] %>
+  <%= @submission.assigned_to == '' ?  'Unassigned' : AdminUser.find_by(gravity_user_id: @submission.assigned_to)&.name %>
 </div>
 <button class="col-md-3" id="edit" onclick="switchVisible('update', 'edit')"> Edit </button>

--- a/app/views/admin/submissions/_form.html.erb
+++ b/app/views/admin/submissions/_form.html.erb
@@ -311,7 +311,7 @@
                   Assigned To:
                 </label>
                 <div class='col-sm-10'>
-                  <% options = [['Please select one', '']] + ADMINS.collect { |id, name| [name, id] } %>
+                  <% options = [['Please select one', '']] + AdminUser.admins.map { |admin| [admin.name, admin.gravity_user_id] } %>
                   <%= f.select :assigned_to, options, {}, class: 'form-control' %>
                 </div>
               </div>

--- a/app/views/admin/submissions/_form.html.erb
+++ b/app/views/admin/submissions/_form.html.erb
@@ -311,7 +311,7 @@
                   Assigned To:
                 </label>
                 <div class='col-sm-10'>
-                  <% options = [['Please select one', '']] + AdminUser.admins.map { |admin| [admin.name, admin.gravity_user_id] } %>
+                  <% options = [['Please select one', '']] + AdminUser.assignees.map { |admin| [admin.name, admin.gravity_user_id] } %>
                   <%= f.select :assigned_to, options, {}, class: 'form-control' %>
                 </div>
               </div>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -95,7 +95,7 @@
             <div class='single-padding-top'>
               <div id="update" style="display: <%= @submission.assigned_to.nil? ? 'block' : 'none' %>">
                 <%= form_with model: [:admin, @submission] do |f| %>
-                  <% options = [['Please select one', '']] + ADMINS.collect { |grav_id, name| [name, grav_id] } %>
+                  <% options = [['Please select one', '']] + AdminUser.admins.map { |admin| [admin.name, admin.gravity_user_id] } %>
                   <div class="col-md-9">
                     <%= f.select :assigned_to, options, {}, class: 'form-control'%>
                   </div>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -95,7 +95,7 @@
             <div class='single-padding-top'>
               <div id="update" style="display: <%= @submission.assigned_to.nil? ? 'block' : 'none' %>">
                 <%= form_with model: [:admin, @submission] do |f| %>
-                  <% options = [['Please select one', '']] + AdminUser.admins.map { |admin| [admin.name, admin.gravity_user_id] } %>
+                  <% options = [['Please select one', '']] + AdminUser.assignees.map { |admin| [admin.name, admin.gravity_user_id] } %>
                   <div class="col-md-9">
                     <%= f.select :assigned_to, options, {}, class: 'form-control'%>
                   </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -13,6 +13,7 @@
   <%= link_to 'Offers', admin_offers_url %>
   <%= link_to 'Consignments', admin_consignments_url %>
   <%= link_to 'Partners', admin_partners_url %>
+  <%= link_to 'Admins', admin_admin_users_url if super_admin_user?(@current_user) %>
   <%= link_to 'log out', '/sign_out' %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
     end
     resources :consignments, only: %i[show edit update index]
     resources :users, only: :index
+    resources :admin_users
     root to: 'dashboard#index'
   end
   get '/match_artist', to: 'admin/submissions#match_artist'

--- a/db/migrate/20210712125843_create_admin_users.rb
+++ b/db/migrate/20210712125843_create_admin_users.rb
@@ -3,11 +3,11 @@
 class CreateAdminUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :admin_users do |t|
-      t.string :name, index: { unique: true }, default: false
-      t.string :gravity_user_id, index: { unique: true }, default: false
-      t.boolean :super_admin, index: true
-      t.boolean :admin, index: true
-      t.boolean :cataloguer, index: true
+      t.string :name, index: { unique: true }
+      t.string :gravity_user_id, index: { unique: true }
+      t.boolean :super_admin, index: true, default: false
+      t.boolean :admin, index: true, default: false
+      t.boolean :cataloguer, index: true, default: false
 
       t.timestamps
     end

--- a/db/migrate/20210712125843_create_admin_users.rb
+++ b/db/migrate/20210712125843_create_admin_users.rb
@@ -6,7 +6,7 @@ class CreateAdminUsers < ActiveRecord::Migration[6.1]
       t.string :name, index: { unique: true }
       t.string :gravity_user_id, index: { unique: true }
       t.boolean :super_admin, index: true, default: false
-      t.boolean :admin, index: true, default: false
+      t.boolean :assignee, index: true, default: false
       t.boolean :cataloguer, index: true, default: false
 
       t.timestamps

--- a/db/migrate/20210712125843_create_admin_users.rb
+++ b/db/migrate/20210712125843_create_admin_users.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateAdminUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :admin_users do |t|
+      t.string :name, index: { unique: true }, default: false
+      t.string :gravity_user_id, index: { unique: true }, default: false
+      t.boolean :super_admin, index: true
+      t.boolean :admin, index: true
+      t.boolean :cataloguer, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_28_123858) do
+ActiveRecord::Schema.define(version: 2021_07_12_125843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
-  enable_extension "unaccent"
+
+  create_table "admin_users", force: :cascade do |t|
+    t.string "name", default: "f"
+    t.string "gravity_user_id", default: "f"
+    t.boolean "super_admin"
+    t.boolean "admin"
+    t.boolean "cataloguer"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["admin"], name: "index_admin_users_on_admin"
+    t.index ["cataloguer"], name: "index_admin_users_on_cataloguer"
+    t.index ["gravity_user_id"], name: "index_admin_users_on_gravity_user_id", unique: true
+    t.index ["name"], name: "index_admin_users_on_name", unique: true
+  end
 
   create_table "artist_standing_scores", force: :cascade do |t|
     t.string "artist_id"
@@ -178,6 +191,9 @@ ActiveRecord::Schema.define(version: 2021_06_28_123858) do
     t.string "assigned_to"
     t.datetime "published_at"
     t.string "source_artwork_id"
+    t.string "utm_source"
+    t.string "utm_medium"
+    t.string "utm_term"
     t.integer "attribution_class"
     t.string "publisher"
     t.string "artist_proofs"
@@ -185,13 +201,10 @@ ActiveRecord::Schema.define(version: 2021_06_28_123858) do
     t.string "exhibition"
     t.string "condition_report"
     t.string "signature_detail"
-    t.string "utm_source"
-    t.string "utm_medium"
-    t.string "utm_term"
     t.boolean "coa_by_authenticating_body"
     t.boolean "coa_by_gallery"
-    t.string "cataloguer"
     t.string "rejection_reason"
+    t.string "cataloguer"
     t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
     t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
     t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2021_07_12_125843) do
     t.index ["cataloguer"], name: "index_admin_users_on_cataloguer"
     t.index ["gravity_user_id"], name: "index_admin_users_on_gravity_user_id", unique: true
     t.index ["name"], name: "index_admin_users_on_name", unique: true
+    t.index ["super_admin"], name: "index_admin_users_on_super_admin"
   end
 
   create_table "artist_standing_scores", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,14 +17,14 @@ ActiveRecord::Schema.define(version: 2021_07_12_125843) do
   enable_extension "plpgsql"
 
   create_table "admin_users", force: :cascade do |t|
-    t.string "name", default: "f"
-    t.string "gravity_user_id", default: "f"
-    t.boolean "super_admin"
-    t.boolean "admin"
-    t.boolean "cataloguer"
+    t.string "name"
+    t.string "gravity_user_id"
+    t.boolean "super_admin", default: false
+    t.boolean "assignee", default: false
+    t.boolean "cataloguer", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["admin"], name: "index_admin_users_on_admin"
+    t.index ["assignee"], name: "index_admin_users_on_assignee"
     t.index ["cataloguer"], name: "index_admin_users_on_cataloguer"
     t.index ["gravity_user_id"], name: "index_admin_users_on_gravity_user_id", unique: true
     t.index ["name"], name: "index_admin_users_on_name", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_07_130204) do
+ActiveRecord::Schema.define(version: 2021_07_12_125843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"

--- a/lib/tasks/admin_users.rake
+++ b/lib/tasks/admin_users.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+namespace :admin_users do
+  desc 'Create admins and cataloguers from constants'
+  task create: :environment do
+    ADMINS.each do |id, name|
+      admin = AdminUser.find_by(gravity_user_id: id)
+
+      if admin && !admin.admin
+        admin.update(admin: true)
+      end
+
+      unless admin
+        AdminUser.create!(gravity_user_id: id, name: name, admin: true)
+      end
+    end
+
+    CATALOGUERS.each do |id, name|
+      admin = AdminUser.find_by(gravity_user_id: id)
+
+      if admin && !admin.cataloguer
+        admin.update(cataloguer: true)
+      end
+
+      unless admin
+        AdminUser.create!(gravity_user_id: id, name: name, cataloguer: true)
+      end
+    end
+  end
+end

--- a/lib/tasks/admin_users.rake
+++ b/lib/tasks/admin_users.rake
@@ -7,7 +7,7 @@ namespace :admin_users do
       admin = AdminUser.find_by(gravity_user_id: id)
 
       if admin && !admin.admin
-        admin.update(admin: true)
+        admin.update(assignee: true)
       end
 
       unless admin

--- a/lib/tasks/admin_users.rake
+++ b/lib/tasks/admin_users.rake
@@ -11,7 +11,7 @@ namespace :admin_users do
       end
 
       unless admin
-        AdminUser.create!(gravity_user_id: id, name: name, admin: true)
+        AdminUser.create!(gravity_user_id: id, name: name, assignee: true)
       end
     end
 

--- a/lib/tasks/offers_spec.rb
+++ b/lib/tasks/offers_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+Rails.application.load_tasks
+
+describe "Offers lapse sent rake task" do
+  subject(:invoke_task) do
+    Rake.application.invoke_task("offers:lapse_sent[#{date}]")
+  end
+
+  let(:date) { "2021-09-01" }
+  let(:past_offer) { Fabricate(:offer, state: "sent", sent_at: date.to_date - 1.day) }
+  let(:future_offer) { Fabricate(:offer, state: "sent", sent_at: date.to_date + 1.day) }
+  # ... add other offers that shouldn't change
+
+  it "testing..." do
+    expect { invoke_task }.to(change { past_offer.reload.state }.from("sent").to("lapsed"))
+    expect { invoke_task }.not_to(change { future_offer.reload.state })
+  end
+end

--- a/spec/fabricators/admin_user_fabricator.rb
+++ b/spec/fabricators/admin_user_fabricator.rb
@@ -5,6 +5,6 @@ Fabricator(:admin_user) do
     Fabricate.sequence(:gravity_user_id) { |i| "user-id-#{i}" }
   end
   name { "jon-jonson" }
-  admin { false }
+  assignee { false }
   cataloguer { false }
 end

--- a/spec/fabricators/admin_user_fabricator.rb
+++ b/spec/fabricators/admin_user_fabricator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Fabricator(:admin_user) do
+  gravity_user_id do
+    Fabricate.sequence(:gravity_user_id) { |i| "user-id-#{i}" }
+  end
+  name { "jon-jonson" }
+  admin { false }
+  cataloguer { false }
+end

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -264,7 +264,7 @@ describe SubmissionsHelper, type: :helper do
     subject { helper.assignable_admin?(user) }
 
     before do
-      AdminUser.create(gravity_user_id: 'admin', name: 'AdminName', admin: true)
+      AdminUser.create(gravity_user_id: 'admin', name: 'AdminName', assignee: true)
     end
 
     context 'for non-admin user' do

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -264,7 +264,7 @@ describe SubmissionsHelper, type: :helper do
     subject { helper.assignable_admin?(user) }
 
     before do
-      stub_const('ADMINS', { admin: 'AdminName' })
+      AdminUser.create(gravity_user_id: 'admin', name: 'AdminName', admin: true)
     end
 
     context 'for non-admin user' do

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdminUser, type: :model do
+  it "creates an admin user" do
+    Fabricate(:admin_user)
+
+    expect(AdminUser.count).to eq(1)
+  end
+end

--- a/spec/requests/admin/admin_users_spec.rb
+++ b/spec/requests/admin/admin_users_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "/admin/admin_users", type: :request do
     context "with valid parameters" do
       it "creates a new AdminUser" do
         expect {
-          post admin_admin_users_url, params: { admin_user: { name: "paula" } }
+          post admin_admin_users_url, params: { admin_user: { name: "paula", gravity_user_id: "123" } }
         }.to change(AdminUser, :count).by(1)
 
         expect(response).to redirect_to(admin_admin_users_url)

--- a/spec/requests/admin/admin_users_spec.rb
+++ b/spec/requests/admin/admin_users_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe "/admin/admin_users", type: :request do
         patch admin_admin_user_url(admin_user), params: { admin_user: { name: "paula" } }
         expect(admin_user.reload.name).to eq("paula")
         expect(response).to redirect_to(admin_admin_users_url)
-
       end
     end
   end

--- a/spec/requests/admin/admin_users_spec.rb
+++ b/spec/requests/admin/admin_users_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "/admin/admin_users", type: :request do
+  before do
+    allow_any_instance_of(ArtsyAuth::Authenticated).
+      to receive(:require_artsy_authentication).
+      and_return(true)
+
+    allow_any_instance_of(Admin::AdminUsersController).
+      to receive(:authorize_user!).
+      and_return(true)
+  end
+
+  let!(:admin_user) { Fabricate(:admin_user, name: "paul") }
+
+  describe "GET /index" do
+    it "renders a successful response" do
+      get admin_admin_users_url
+
+      expect(response).to be_successful
+      expect(response.body).to include("paul")
+    end
+  end
+
+  describe "GET /new" do
+    it "renders a successful response" do
+      get new_admin_admin_user_url
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET /edit" do
+    it "render a successful response" do
+      get edit_admin_admin_user_url(admin_user)
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      it "creates a new AdminUser" do
+        expect {
+          post admin_admin_users_url, params: { admin_user: { name: "paula" } }
+        }.to change(AdminUser, :count).by(1)
+
+        expect(response).to redirect_to(admin_admin_users_url)
+      end
+    end
+  end
+
+  describe "PATCH /update" do
+    context "with valid parameters" do
+      it "updates the requested admin_user" do
+        patch admin_admin_user_url(admin_user), params: { admin_user: { name: "paula" } }
+        expect(admin_user.reload.name).to eq("paula")
+        expect(response).to redirect_to(admin_admin_users_url)
+
+      end
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "destroys the requested admin_user" do
+      expect {
+        delete admin_admin_user_url(admin_user)
+      }.to change(AdminUser, :count).by(-1)
+      expect(response).to redirect_to(admin_admin_users_url)
+    end
+  end
+end

--- a/spec/system/submission_editing_spec.rb
+++ b/spec/system/submission_editing_spec.rb
@@ -76,6 +76,10 @@ describe 'Editing a submission', type: :feature do
     end
 
     context 'from the detail screen' do
+      before do
+        Fabricate(:admin_user, name: 'Agnieszka', admin: true)
+      end
+
       it 'displays that admin on the submission detail page' do
         visit admin_submission_path(submission)
         expect(page).to_not have_select(

--- a/spec/system/submission_editing_spec.rb
+++ b/spec/system/submission_editing_spec.rb
@@ -77,7 +77,7 @@ describe 'Editing a submission', type: :feature do
 
     context 'from the detail screen' do
       before do
-        Fabricate(:admin_user, name: 'Agnieszka', admin: true)
+        Fabricate(:admin_user, name: 'Agnieszka', assignee: true)
       end
 
       it 'displays that admin on the submission detail page' do


### PR DESCRIPTION
Addresses [CX-1647]

### Description

- Adds admin users to replace the `ADMIN` and `CATALOGUERS` consts.
- Adds admin users interface for CRUD actions.

<img width="1602" alt="Screenshot 2021-07-12 at 19 27 40" src="https://user-images.githubusercontent.com/4691889/125746343-880494a2-4bed-486c-aa90-24831ed89083.png">


### Follow Ups

- Run `bundle exec rake admin_users:create`
- Remove `config/initializers/global_constants.rb`

[CX-1647]: https://artsyproduct.atlassian.net/browse/CX-1647