### PR TITLE
(CX-1513) Automatic emails sent to partners come from the email of assignee

### DIFF
--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -54,6 +54,6 @@ class PartnerMailer < ApplicationMailer
       )
 
     smtpapi category: %w[offer], unique_args: { offer_id: offer.id }
-    mail(to: email, subject: 'A response to your consignment offer')
+    mail(to: email, from: submission.assigned_to, subject: 'A response to your consignment offer')
   end
 end

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -63,7 +63,7 @@ class PartnerMailer < ApplicationMailer
     )
   end
 
-  def reply_email(gravity_user_id)
-    Gravity.client.user(id: gravity_user_id)._get.user_detail._get.email || Convection.config.admin_email_address
+  def reply_email(assigned_user_id)
+    Gravity.client.user(id: assigned_user_id)._get.user_detail._get.email || Convection.config.admin_email_address
   end
 end

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -40,7 +40,9 @@ class PartnerMailer < ApplicationMailer
 
     smtpapi category: %w[offer], unique_args: { offer_id: offer.id }
     mail(
-      to: email, subject: 'The consignor has expressed interest in your offer'
+      to: email,
+      reply_to: reply_email(@submission.assigned_to),
+      subject: 'The consignor has expressed interest in your offer'
     )
   end
 
@@ -54,6 +56,14 @@ class PartnerMailer < ApplicationMailer
       )
 
     smtpapi category: %w[offer], unique_args: { offer_id: offer.id }
-    mail(to: email, from: submission.assigned_to, subject: 'A response to your consignment offer')
+    mail(
+      to: email,
+      reply_to: reply_email(@submission.assigned_to),
+      subject: 'A response to your consignment offer'
+    )
+  end
+
+  def reply_email(gravity_user_id)
+    Gravity.client.user(id: gravity_user_id)._get.user_detail._get.email || Convection.config.admin_email_address
   end
 end

--- a/config/initializers/global_constants.rb
+++ b/config/initializers/global_constants.rb
@@ -11,8 +11,7 @@ ADMINS = { '5ba2872826cbf26b896b1d71': 'Agnieszka',
            '602692836c6a2c0011e96827': 'Robin',
            '60b62f317a4fa058b2a5044d': 'Daniela',
            '60ba938a6e6d1d000f35e5f4': 'George',
-           '60d0bc325a651500132f91b1': 'Louis',
-           '60aba10a1ac0ea0012e121b2': 'Stas' }.freeze
+           '60d0bc325a651500132f91b1': 'Louis' }.freeze
 
 CATALOGUERS = {
     '5abbfc38c9dc2458cd28ca6b': 'Phoebe Mitchell',

--- a/config/initializers/global_constants.rb
+++ b/config/initializers/global_constants.rb
@@ -11,7 +11,8 @@ ADMINS = { '5ba2872826cbf26b896b1d71': 'Agnieszka',
            '602692836c6a2c0011e96827': 'Robin',
            '60b62f317a4fa058b2a5044d': 'Daniela',
            '60ba938a6e6d1d000f35e5f4': 'George',
-           '60d0bc325a651500132f91b1': 'Louis' }.freeze
+           '60d0bc325a651500132f91b1': 'Louis',
+           '60aba10a1ac0ea0012e121b2': 'Stas' }.freeze
 
 CATALOGUERS = {
     '5abbfc38c9dc2458cd28ca6b': 'Phoebe Mitchell',

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -8,6 +8,8 @@ describe OfferService do
   let(:partner) { Fabricate(:partner, name: 'Gagosian Gallery') }
   let(:submission) { Fabricate(:submission, state: submission_state) }
 
+  before { allow_any_instance_of(PartnerMailer).to receive(:reply_email).and_return('reply_email@artsy.net') }
+
   describe 'create_offer' do
     context 'with an id for created by but no current user' do
       let(:submission_state) { Submission::APPROVED }
@@ -268,6 +270,7 @@ describe OfferService do
           expect(emails.map(&:to).flatten).to eq(
             %w[contact1@partner.com contact2@partner.com]
           )
+          expect(emails.first.reply_to).to eq(%w[reply_email@artsy.net])
           expect(emails.first.from).to eq(%w[consign@artsy.net])
           expect(emails.first.subject).to eq(
             'The consignor has expressed interest in your offer'
@@ -329,6 +332,7 @@ describe OfferService do
             %w[contact1@partner.com contact2@partner.com]
           )
           expect(emails.first.from).to eq(%w[consign@artsy.net])
+          expect(emails.first.reply_to).to eq(%w[reply_email@artsy.net])
           expect(emails.first.subject).to eq(
             'A response to your consignment offer'
           )

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -38,6 +38,7 @@ describe 'admin/offers/show.html.erb', type: :feature do
       allow(Convection.config).to receive(:gravity_xapp_token).and_return(
         'xapp_token'
       )
+      allow_any_instance_of(PartnerMailer).to receive(:reply_email).and_return('reply_email@artsy.net')
 
       stub_gravql_artists(body: {
         data: {
@@ -316,6 +317,7 @@ describe 'admin/offers/show.html.erb', type: :feature do
         expect(emails.map(&:to).flatten).to eq(
           %w[contact1@partner.com contact2@partner.com]
         )
+        expect(emails.first.reply_to).to eq(%w[reply_email@artsy.net])
         expect(emails.first.from).to eq(%w[consign@artsy.net])
         expect(emails.first.subject).to eq(
           'A response to your consignment offer'
@@ -341,6 +343,7 @@ describe 'admin/offers/show.html.erb', type: :feature do
         expect(emails.map(&:to).flatten).to eq(
           %w[contact1@partner.com contact2@partner.com]
         )
+        expect(emails.first.reply_to).to eq(%w[reply_email@artsy.net])
         expect(emails.first.from).to eq(%w[consign@artsy.net])
         expect(emails.first.subject).to eq(
           'A response to your consignment offer'
@@ -357,6 +360,7 @@ describe 'admin/offers/show.html.erb', type: :feature do
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
         expect(emails.map(&:to).flatten).to eq(%w[override@partner.com])
+        expect(emails.first.reply_to).to eq(%w[reply_email@artsy.net])
         expect(emails.first.from).to eq(%w[consign@artsy.net])
         expect(emails.first.subject).to eq(
           'A response to your consignment offer'


### PR DESCRIPTION
Resolves [CX-1513](https://artsyproduct.atlassian.net/browse/CX-1513)

Description:
Emails to partners are sent from our personal emails so that if the partner replies directly to an offer/rejection email, the reply is sent back to our personal inbox. This would avoid responses to get lost in the consign@ inbox which can fall through the cracks.