### PR TITLE
feat(CX-1711): Add saved state to offers

### DIFF
--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -28,6 +28,7 @@ class Offer < ApplicationRecord
   STATES = [
     DRAFT = 'draft',
     SENT = 'sent',
+    SAVED = 'saved',
     ACCEPTED = 'accepted',
     REJECTED = 'rejected',
     LAPSED = 'lapsed',
@@ -78,7 +79,7 @@ class Offer < ApplicationRecord
   end
 
   def reviewed?
-    !draft? && !sent? && !review?
+    !draft? && !sent? && !review? && !saved?
   end
 
   def locked?

--- a/app/views/admin/offers/_state_actions.html.erb
+++ b/app/views/admin/offers/_state_actions.html.erb
@@ -3,6 +3,9 @@
     <div class='overview-section offer-draft-actions'>
       <div class='single-padding-top'>
         <div>
+          <%= link_to 'Save', admin_offer_path(@offer, offer: { state: 'saved' }), method: :put, class: 'btn btn-secondary btn-small btn-full-width', data: { confirm: 'Mark an offer as saved. This action cannot be undone.' } %>
+        </div>
+        <div class='single-padding-top'>
           <%= link_to 'Save & Send', admin_offer_path(@offer, offer: { state: 'sent' }), method: :put, class: 'btn btn-secondary btn-small btn-full-width', data: { confirm: 'This action will send the offer to the collector. This action cannot be undone.' } %>
         </div>
         <div class='single-padding-top'>
@@ -25,6 +28,11 @@
   <% else %>
     <div class='overview-section offer-actions'>
       <div class='single-padding-top'>
+        <% if @offer.saved? %>
+          <div class='single-padding-top'>
+            <%= link_to 'Send', admin_offer_path(@offer, offer: { state: 'sent' }), method: :put, class: 'btn btn-secondary btn-small btn-full-width', data: { confirm: 'This action will send the offer to the collector. This action cannot be undone.' } %>
+          </div>
+        <% end %>
         <% unless @offer.review? %>
           <div class='single-padding-top'>
             <%= link_to 'Consignor Interested', '#', { 'data-remodal-target' => 'interested-modal', class: 'btn btn-secondary btn-small btn-full-width offer-review-button' } %>

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -259,8 +259,8 @@ describe OfferService do
         end
       end
 
-      context 'does not sending an offer' do
-        it 'does not sends an email to a user if the state is saved' do
+      context 'does not send an offer email' do
+        it 'does not send an email to a user if the state is saved' do
           OfferService.update_offer(offer, 'userid', state: Offer::SAVED)
           emails = ActionMailer::Base.deliveries
           expect(emails.length).to eq 0

--- a/spec/services/offer_service_spec.rb
+++ b/spec/services/offer_service_spec.rb
@@ -259,6 +259,20 @@ describe OfferService do
         end
       end
 
+      context 'does not sending an offer' do
+        it 'does not sends an email to a user if the state is saved' do
+          OfferService.update_offer(offer, 'userid', state: Offer::SAVED)
+          emails = ActionMailer::Base.deliveries
+          expect(emails.length).to eq 0
+
+          offer.reload
+
+          expect(offer.state).to eq Offer::SAVED
+          expect(offer.sent_by).to be_nil
+          expect(offer.sent_at).to be_nil
+        end
+      end
+
       context 'introducing an offer' do
         it 'sends an email saying the user is interested in the offer' do
           OfferService.update_offer(offer, 'userid', state: Offer::REVIEW)

--- a/spec/views/admin/offers/index.html.erb_spec.rb
+++ b/spec/views/admin/offers/index.html.erb_spec.rb
@@ -40,6 +40,7 @@ describe 'admin/offers/index.html.erb', type: :feature do
       within(:css, '#offer-filter-form') do
         expect(page).to have_content('all')
         expect(page).to have_content('draft')
+        expect(page).to have_content('saved')
         expect(page).to have_content('sent')
         expect(page).to have_content('accepted')
         expect(page).to have_content('rejected')
@@ -72,6 +73,14 @@ describe 'admin/offers/index.html.erb', type: :feature do
         Fabricate(:offer_response, offer: offer, intended_state: Offer::REVIEW)
         page.visit admin_offers_path
         expect(page).to have_content('Response: Interested')
+      end
+
+      it 'displays the correct state when the offer is saved' do
+        offer.update!(state: Offer::SAVED)
+        page.visit admin_offers_path
+        within(:css, 'a.list-group-item') do
+          expect(page).to have_content('saved')
+        end
       end
 
       it 'displays the correct state when the offer is sent' do


### PR DESCRIPTION
Resolve [CX-1711](https://artsyproduct.atlassian.net/browse/CX-1711)

![Screenshot 2021-07-21 at 14 11 04](https://user-images.githubusercontent.com/21379857/126479637-d4f9d83a-6c43-4d53-974c-2fc57dd65f10.png)

After save you can send
![Screenshot 2021-07-21 at 14 11 17](https://user-images.githubusercontent.com/21379857/126479678-1e584baf-d9ab-41e3-a55e-d499993c0ac9.png)

What is the problem?
Convection was built to flow to Auction House (AH) digest, and to approve organic pipeline submissions. We are now predominantly using it to approve and track ALL consignments, so all non-organic consignments have to go through the same offer approval process in the system. This includes an automatic email sent to the consignor letting them know they have a new offer on their submission - a very bad and confusing consignor experience when they have already negotiated with specialists and agreed on sale placement and pricing.

Expected Outcome

Create a separate "Save" button for offers which have already been consigned to an ACA. This will not trigger an automated email to the consignor offer email (as with the organic pipeline approvals), but will officially record the offer in Convection for data tracking purposes. Or re-purpose the existing "Accept Offer" button in the offer draft stage so that the offer can be officially recorded without being "sent" to the user.

Actual outcome
To circumvent this, our team has been using their own user accounts to send through the offer, and then going back later to update the submission with the consignor's email for tracking. Unfortunately this is error prone and unsustainable considering our team's bandwidth and cadence. This results in EOQ backlog editing, which means that there is insufficient and unreliable data throughout the quarter, which is problematic for us all.  
