### PR TITLE
feat(CX-1712) Add new Withdrawn states to consignment

### DIFF
--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -23,7 +23,7 @@ class PartnerSubmission < ApplicationRecord
   has_many :offers, dependent: :destroy
   belongs_to :accepted_offer, class_name: 'Offer'
 
-  STATES = ['open', 'sold', 'bought in', 'canceled', 'withdrawn - Pre-Launch', 'withdrawn - Post-Launch'].freeze
+  STATES = ['open', 'sold', 'bought in', 'canceled', 'withdrawn - pre-launch', 'withdrawn - post-launch'].freeze
 
   scope :group_by_day, -> { group("date_trunc('day', notified_at) ") }
   scope :consigned, -> { where.not(accepted_offer_id: nil) }

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -23,7 +23,7 @@ class PartnerSubmission < ApplicationRecord
   has_many :offers, dependent: :destroy
   belongs_to :accepted_offer, class_name: 'Offer'
 
-  STATES = ['open', 'sold', 'bought in', 'canceled'].freeze
+  STATES = ['open', 'sold', 'bought in', 'canceled', 'withdrawn - Pre-launch', 'withdrawn - Post-Launch'].freeze
 
   scope :group_by_day, -> { group("date_trunc('day', notified_at) ") }
   scope :consigned, -> { where.not(accepted_offer_id: nil) }

--- a/app/models/partner_submission.rb
+++ b/app/models/partner_submission.rb
@@ -23,7 +23,7 @@ class PartnerSubmission < ApplicationRecord
   has_many :offers, dependent: :destroy
   belongs_to :accepted_offer, class_name: 'Offer'
 
-  STATES = ['open', 'sold', 'bought in', 'canceled', 'withdrawn - Pre-launch', 'withdrawn - Post-Launch'].freeze
+  STATES = ['open', 'sold', 'bought in', 'canceled', 'withdrawn - Pre-Launch', 'withdrawn - Post-Launch'].freeze
 
   scope :group_by_day, -> { group("date_trunc('day', notified_at) ") }
   scope :consigned, -> { where.not(accepted_offer_id: nil) }

--- a/spec/controllers/admin/consignments_controller_spec.rb
+++ b/spec/controllers/admin/consignments_controller_spec.rb
@@ -55,14 +55,14 @@ describe Admin::ConsignmentsController, type: :controller do
       @consignment6 =
         Fabricate(
           :partner_submission,
-          state: 'withdrawn - Pre-Launch',
+          state: 'withdrawn - pre-launch',
           submission: Fabricate(:submission, state: 'approved'),
           partner: partner2
         )
       @consignment7 =
         Fabricate(
           :partner_submission,
-          state: 'withdrawn - Post-Launch',
+          state: 'withdrawn - post-launch',
           submission: Fabricate(:submission, state: 'approved'),
           partner: partner2
         )
@@ -158,13 +158,13 @@ describe Admin::ConsignmentsController, type: :controller do
         expect(controller.consignments.pluck(:id)).to eq [@consignment3.id]
       end
 
-      it 'allows you to filter by state = withdrawn - Pre-Launch' do
-        get :index, params: { state: 'withdrawn - Pre-Launch' }
+      it 'allows you to filter by state = withdrawn - pre-launch' do
+        get :index, params: { state: 'withdrawn - pre-launch' }
         expect(controller.consignments.pluck(:id)).to eq [@consignment6.id]
       end
 
-      it 'allows you to filter by state = withdrawn - Post-Launch' do
-        get :index, params: { state: 'withdrawn - Post-Launch' }
+      it 'allows you to filter by state = withdrawn - post-launch' do
+        get :index, params: { state: 'withdrawn - post-launch' }
         expect(controller.consignments.pluck(:id)).to eq [@consignment7.id]
       end
 

--- a/spec/controllers/admin/consignments_controller_spec.rb
+++ b/spec/controllers/admin/consignments_controller_spec.rb
@@ -52,6 +52,20 @@ describe Admin::ConsignmentsController, type: :controller do
           submission: Fabricate(:submission, state: 'approved'),
           partner: partner2
         )
+      @consignment6 =
+        Fabricate(
+          :partner_submission,
+          state: 'withdrawn - Pre-Launch',
+          submission: Fabricate(:submission, state: 'approved'),
+          partner: partner2
+        )
+      @consignment7 =
+        Fabricate(
+          :partner_submission,
+          state: 'withdrawn - Post-Launch',
+          submission: Fabricate(:submission, state: 'approved'),
+          partner: partner2
+        )
 
       @consignment1.update!(
         accepted_offer:
@@ -98,6 +112,24 @@ describe Admin::ConsignmentsController, type: :controller do
             offer_type: 'retail'
           )
       )
+      @consignment6.update!(
+        accepted_offer:
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission: @consignment1,
+            offer_type: 'purchase'
+          )
+      )
+      @consignment7.update!(
+        accepted_offer:
+          Fabricate(
+            :offer,
+            state: 'sent',
+            partner_submission: @consignment1,
+            offer_type: 'purchase'
+          )
+      )
     end
 
     it 'returns the first two consignments on the first page' do
@@ -106,7 +138,7 @@ describe Admin::ConsignmentsController, type: :controller do
     end
 
     it 'paginates correctly' do
-      get :index, params: { page: 3, size: 2 }
+      get :index, params: { page: 4, size: 2 }
       expect(controller.consignments.count).to eq 1
     end
 
@@ -126,12 +158,24 @@ describe Admin::ConsignmentsController, type: :controller do
         expect(controller.consignments.pluck(:id)).to eq [@consignment3.id]
       end
 
+      it 'allows you to filter by state = withdrawn - Pre-Launch' do
+        get :index, params: { state: 'withdrawn - Pre-Launch' }
+        expect(controller.consignments.pluck(:id)).to eq [@consignment6.id]
+      end
+
+      it 'allows you to filter by state = withdrawn - Post-Launch' do
+        get :index, params: { state: 'withdrawn - Post-Launch' }
+        expect(controller.consignments.pluck(:id)).to eq [@consignment7.id]
+      end
+
       it 'allows you to sort by offer type' do
         get :index, params: { sort: 'offers.offer_type', direction: 'asc' }
         expect(controller.consignments.pluck(:id)).to eq(
           [
             @consignment4.id,
             @consignment3.id,
+            @consignment7.id,
+            @consignment6.id,
             @consignment2.id,
             @consignment1.id,
             @consignment5.id
@@ -143,6 +187,8 @@ describe Admin::ConsignmentsController, type: :controller do
         get :index, params: { sort: 'partners.name', direction: 'desc' }
         expect(controller.consignments.pluck(:id)).to eq(
           [
+            @consignment7.id,
+            @consignment6.id,
             @consignment5.id,
             @consignment4.id,
             @consignment3.id,
@@ -158,6 +204,8 @@ describe Admin::ConsignmentsController, type: :controller do
           [
             @consignment4.id,
             @consignment5.id,
+            @consignment6.id,
+            @consignment7.id,
             @consignment3.id,
             @consignment2.id,
             @consignment1.id

--- a/spec/models/partner_submission_spec.rb
+++ b/spec/models/partner_submission_spec.rb
@@ -11,6 +11,8 @@ describe PartnerSubmission do
       expect(PartnerSubmission.new(state: 'blah')).not_to be_valid
       expect(PartnerSubmission.new(state: 'open')).to be_valid
       expect(PartnerSubmission.new(state: 'canceled')).to be_valid
+      expect(PartnerSubmission.new(state: 'withdrawn - Pre-Launch')).to be_valid
+      expect(PartnerSubmission.new(state: 'withdrawn - Post-Launch')).to be_valid
     end
 
     it 'sets the default to open' do

--- a/spec/models/partner_submission_spec.rb
+++ b/spec/models/partner_submission_spec.rb
@@ -11,8 +11,8 @@ describe PartnerSubmission do
       expect(PartnerSubmission.new(state: 'blah')).not_to be_valid
       expect(PartnerSubmission.new(state: 'open')).to be_valid
       expect(PartnerSubmission.new(state: 'canceled')).to be_valid
-      expect(PartnerSubmission.new(state: 'withdrawn - Pre-Launch')).to be_valid
-      expect(PartnerSubmission.new(state: 'withdrawn - Post-Launch')).to be_valid
+      expect(PartnerSubmission.new(state: 'withdrawn - pre-launch')).to be_valid
+      expect(PartnerSubmission.new(state: 'withdrawn - post-launch')).to be_valid
     end
 
     it 'sets the default to open' do


### PR DESCRIPTION
Resolve [CX-1712](https://artsyproduct.atlassian.net/browse/CX-1712)

![Screenshot 2021-07-23 at 14 45 37](https://user-images.githubusercontent.com/21379857/126777299-16ca5d57-b809-4241-8f69-9b791b09476b.png)

# Description:

### What is the problem?
There is currently not a reliable way to reflect an unrealized consignment in convection. (unrealized being agreed but never signed the contract, became unresponsive, had to withdraw due to authenticity concerns, etc)

### Expected Outcome
Create a state in Convection to track unrealized GMV

### Actual outcome
The current process is to delete the estimate and commission field information so that the data doesn't skew overall consignments reporting. This is creating an incomplete data set for leads and the exec team to review as they can't see what didn't make it to auction. An easy fix would be to add "Withdrawn - Pre-launch" and "Withdrawn - Post-Launch" states to Convection so that these can be filtered easily in looker, and we don't lose the important data.
