### PR TITLE
feat: Allow anonymous consignment submissions GRO-504

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -2,7 +2,8 @@
 
 module Api
   class SubmissionsController < RestController
-    before_action :require_authentication
+    before_action :require_authentication, except: :create
+    before_action :require_app_or_auth, only: :create
     before_action :set_submission, only: %i[show update]
     before_action :require_authorized_submission, only: %i[show update]
 
@@ -37,6 +38,15 @@ module Api
     end
 
     private
+
+    def require_app_or_auth
+      if params[:gravity_user_id]
+        require_trusted_app
+        @current_user = User.anonymous.gravity_user_id
+      else
+        require_authentication
+      end
+    end
 
     def submission_params
       params.permit(

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -2,8 +2,8 @@
 
 module Api
   class SubmissionsController < RestController
-    before_action :require_authentication, except: :create
-    before_action :require_app_or_auth, only: :create
+    before_action :require_authentication, except: %i[create update]
+    before_action :require_app_or_auth, only: %i[create update]
     before_action :set_submission, only: %i[show update]
     before_action :require_authorized_submission, only: %i[show update]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,4 +39,8 @@ class User < ApplicationRecord
   def unique_code_for_digest
     created_at.to_i % 100_000 + id + (submissions.first&.id || 0)
   end
+
+  def self.anonymous
+    User.find_or_create_by(gravity_user_id: 'anonymous')
+  end
 end

--- a/app/services/user_service.rb
+++ b/app/services/user_service.rb
@@ -3,6 +3,8 @@
 class UserService
   class << self
     def update_email(user_id)
+      return if user_id == User.anonymous.id
+
       user = User.find(user_id)
       email = Gravity.client.user_detail(id: user.gravity_user_id).email
       raise 'User lacks email.' if email.blank?

--- a/spec/requests/api/submissions/create_spec.rb
+++ b/spec/requests/api/submissions/create_spec.rb
@@ -105,4 +105,23 @@ describe 'POST /api/submissions' do
       expect(response_json['user_agent']).to eq 'Eigen'
     end
   end
+
+  context 'with a trusted app token' do
+    let(:jwt_token) do
+      payload = { aud: 'force', roles: 'trusted' }
+      JWT.encode(payload, Convection.config.jwt_secret)
+    end
+
+    it 'uses the anonymous user' do
+      params = {
+        artist_id: 'artistid',
+        gravity_user_id: 'anonymous',
+        title: 'my artwork',
+      }
+
+      expect do
+        post '/api/submissions', params: params, headers: headers
+      end.to change { User.anonymous.submissions.count }.by(1)
+    end
+  end
 end

--- a/spec/requests/api/submissions/create_spec.rb
+++ b/spec/requests/api/submissions/create_spec.rb
@@ -3,88 +3,106 @@
 require 'rails_helper'
 require 'support/gravity_helper'
 
-describe 'Create Submission' do
+describe 'POST /api/submissions' do
   let(:jwt_token) do
-    JWT.encode(
-      { aud: 'gravity', sub: 'userid', roles: 'user' },
-      Convection.config.jwt_secret
-    )
+    payload = { aud: 'gravity', sub: 'userid', roles: 'user' }
+    JWT.encode(payload, Convection.config.jwt_secret)
   end
+
   let(:headers) { { 'Authorization' => "Bearer #{jwt_token}" } }
 
-  describe 'POST /submissions' do
-    it 'rejects unauthorized submissions' do
-      post '/api/submissions',
-           params: { artist_id: 'artistid' },
-           headers: { 'Authorization' => 'Bearer foo.bar.baz' }
+  context 'with an unauthorized submission' do
+    let(:headers) { { 'Authorization' => 'Bearer foo.bar.baz' } }
+
+    it 'returns a 401' do
+      params = { artist_id: 'artistid' }
+      post '/api/submissions', params: params, headers: headers
       expect(response.status).to eq 401
     end
+  end
 
-    it 'rejects submissions without an artist_id' do
-      post '/api/submissions', params: {}, headers: headers
+  context 'without an artist id' do
+    it 'returns a 400 with an error message' do
+      params = {}
+      post '/api/submissions', params: params, headers: headers
       expect(response.status).to eq 400
-      expect(
-        JSON.parse(response.body)['error']
-      ).to eq 'Parameter artist_id is required'
+      response_json = JSON.parse(response.body)
+      expect(response_json['error']).to eq 'Parameter artist_id is required'
     end
+  end
 
-    it 'creates a submission' do
+  context 'with an authorized submission and artist id' do
+    it 'returns a 201 and creates a submission' do
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
 
-      expect {
-        post '/api/submissions',
-             params: { title: 'my sartwork', artist_id: 'artistid' },
-             headers: headers
-      }.to change { Submission.count }.by(1)
-    end
+      params = { title: 'my sartwork', artist_id: 'artistid' }
 
-    it 'creates a submission with edition fields' do
+      expect do
+        post '/api/submissions', params: params, headers: headers
+      end.to change { Submission.count }.by(1)
+
+      expect(response.status).to eq 201
+    end
+  end
+
+  context 'with an editioned submission' do
+    it 'returns a 201 and creates a submission with edition fields' do
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
 
-      expect {
-        post '/api/submissions',
-             params: {
-               title: 'my sartwork',
-               artist_id: 'artistid',
-               edition: true,
-               edition_size: 100,
-               edition_number: '23a',
-               category: 'Painting'
-             },
-             headers: headers
+      params = {
+        artist_id: 'artistid',
+        category: 'Painting',
+        edition: true,
+        edition_number: '23a',
+        edition_size: 100,
+        title: 'my sartwork'
+      }
 
-        expect(JSON.parse(response.body)['edition_size']).to eq 100
-      }.to change { Submission.count }.by(1)
+      expect do
+        post '/api/submissions', params: params, headers: headers
+      end.to change { Submission.count }.by(1)
+
+      expect(response.status).to eq 201
+
+      response_json = JSON.parse(response.body)
+      expect(response_json['edition_size']).to eq 100
     end
+  end
 
-    it 'creates a submission with a minimum price' do
+  context 'with a submission that includes a minimum price' do
+    it 'returns a 201 and creates a submission with that minimum price' do
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
 
-      expect {
-        post '/api/submissions',
-             params: {
-               title: 'my sartwork',
-               artist_id: 'artistid',
-               edition: true,
-               edition_size: 100,
-               edition_number: '23a',
-               category: 'Painting',
-               minimum_price_dollars: 50_000,
-               currency: 'GBP'
-             },
-             headers: headers.merge('User-Agent' => 'Eigen')
+      params = {
+        artist_id: 'artistid',
+        category: 'Painting',
+        currency: 'GBP',
+        edition: true,
+        edition_number: '23a',
+        edition_size: 100,
+        minimum_price_dollars: 50_000,
+        title: 'my sartwork'
+      }
 
-        expect(JSON.parse(response.body)['edition_size']).to eq 100
-        expect(JSON.parse(response.body)['minimum_price_dollars']).to eq 50_000
-        expect(JSON.parse(response.body)['currency']).to eq 'GBP'
-        expect(JSON.parse(response.body)['user_agent']).to eq 'Eigen'
-      }.to change { Submission.count }.by(1)
+      eigen_headers = headers.merge('User-Agent' => 'Eigen')
+
+      expect do
+        post '/api/submissions', params: params, headers: eigen_headers
+      end.to change { Submission.count }.by(1)
+
+      expect(response.status).to eq 201
+
+      response_json = JSON.parse(response.body)
+      expect(response_json['edition_size']).to eq 100
+      expect(response_json['minimum_price_dollars']).to eq 50_000
+      expect(response_json['currency']).to eq 'GBP'
+      expect(response_json['user_agent']).to eq 'Eigen'
     end
   end
 end


### PR DESCRIPTION
This PR supports the goal of allowing more anonymous consignment submissions. It's a spiritual successor to https://github.com/artsy/convection/pull/1122 but closer to reality than that spike.

## The Anonymous User

Taken from that other PR is the idea of a singleton user that we can attach these submission to. My approach to this was defining a class method on user called `anonymous` that uses Rails' `find_or_create_by` method to return or make the singleton user.

## A Special Param

Then in order to work with this user I'm now supporting a special param called `gravity_user_id`. When that is passed and is set to `anonymous`, then slightly different authentication logic and current user calculation are used. For the auth logic we look to the JWT being used and see if it's trusted. If it is, then cool, if not, then we fallback to the existing auth logic.

If the app is deemed trusted then we set the `current_user` to that anon user and march on.

## Updated Tests

To drive this out I started by looking at the create and update specs for the REST api endpoints. I did some organizing of what I found and then added my behavior to demonstrate how this can be used. It'll take a little more messing around to figure out how to generate and send the JWT token correctly from force but we're smart, we can figure it out!

https://artsyproduct.atlassian.net/browse/GRO-504

/cc @artsy/grow-devs @joeyAghion 