### PR TITLE
[SWA-45]: Display new user fields in Convection admin

### DIFF
--- a/app/views/admin/consignments/_consignment.html.erb
+++ b/app/views/admin/consignments/_consignment.html.erb
@@ -12,7 +12,7 @@
     <%= artist %>, <%= consignment.submission&.title&.truncate(30) %>
   </div>
   <div class='list-group-item-info'>
-    <%= consignment.submission.user&.email %>
+    <%= consignment.submission.user_email || consignment.submission.user&.email %>
   </div>
   <div class='list-group-item-info'>
     <%= formatted_location(consignment.submission)  %>

--- a/app/views/admin/offers/_offer.html.erb
+++ b/app/views/admin/offers/_offer.html.erb
@@ -47,7 +47,7 @@
       <%= offer_artist(offer) %>, <%= offer.submission&.title&.truncate(30) %>
     </div>
     <div class='list-group-item-info'>
-      <%= offer.submission.user&.email %>
+      <%= offer.submission.user_email || offer.submission.user&.email %>
     </div>
     <div class='list-group-item-info'>
       <%= formatted_location(offer.submission)  %>

--- a/app/views/admin/submissions/_collector_info.html.erb
+++ b/app/views/admin/submissions/_collector_info.html.erb
@@ -7,16 +7,16 @@
       </div>
     <% end %>
     <div>
-      <%= submission.user&.name %>
+      <%= submission.user_name || submission.user&.name %>
     </div>
     <div>
       <%= submission.user&.submissions&.count || 0 %> submissions made
     </div>
     <div>
-      <%= submission.user&.user_detail&.email %>
+      <%= submission.user_email || submission.user&.user_detail&.email %>
     </div>
     <div>
-      <%= submission.user&.user_detail&.phone %>
+      <%= submission.user_phone || submission.user&.user_detail&.phone %>
     </div>
   </div>
 </div>

--- a/app/views/admin/submissions/_submission.html.erb
+++ b/app/views/admin/submissions/_submission.html.erb
@@ -19,7 +19,7 @@
     <%= submission&.title&.truncate(30) %>
   </div>
   <div class='list-group-item-info list-group-item-info--email'>
-    <%= submission.user&.email %>
+    <%= submission.user_email || submission.user&.email %>
   </div>
   <div class='list-group-item-info'>
     <%= formatted_location(submission)  %>


### PR DESCRIPTION
This PR resolve [SWA-45](https://artsyproduct.atlassian.net/browse/SWA-45)

Added the display of names, phone number and email which is in the submission itself, if it is absent, information is taken from the user profile from gravity

<img width="767" alt="Screen Shot 2021-10-29 at 4 57 55 PM" src="https://user-images.githubusercontent.com/21379857/139448040-84a61044-7b67-45ee-b984-6a4cc16f700e.png">


Submission index page:
<img width="1201" alt="Screen Shot 2021-10-29 at 3 10 29 PM" src="https://user-images.githubusercontent.com/21379857/139444171-004c32bc-13b0-444e-bfe4-e5afb5dda652.png">
Offers index page:
<img width="1147" alt="Screen Shot 2021-10-29 at 3 11 05 PM" src="https://user-images.githubusercontent.com/21379857/139444173-ad53b34d-5231-4f03-bdbf-deb8a8a875cb.png">
Consignment index page:
<img width="1104" alt="Screen Shot 2021-10-29 at 3 11 35 PM" src="https://user-images.githubusercontent.com/21379857/139444175-5eae14bd-bda7-4775-a997-58908bff8a21.png">
Submission page:
<img width="1203" alt="Screen Shot 2021-10-29 at 4 18 42 PM" src="https://user-images.githubusercontent.com/21379857/139444184-2fe71847-6f44-4e2f-9fe0-65a497fbd48c.png">
Offer page:
<img width="1060" alt="Screen Shot 2021-10-29 at 4 19 08 PM" src="https://user-images.githubusercontent.com/21379857/139444187-d032989a-ae39-4466-a159-5203b537b269.png">
Consignment page:
<img width="1076" alt="Screen Shot 2021-10-29 at 4 19 32 PM" src="https://user-images.githubusercontent.com/21379857/139444190-dfca87c2-f001-483f-b98d-d1d40a65fe99.png">