### PR TITLE
[Feat]: SWA-82 - Reject no-target supply artist submissions automatically

### DIFF
--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -24,7 +24,8 @@ module SubmissionsHelper
   end
 
   def formatted_dimensions_inch_cm(submission)
-    values = [submission.height, submission.width, submission.depth].select(&:present?)
+    values =
+      [submission.height, submission.width, submission.depth].select(&:present?)
 
     return [] if values.empty?
 
@@ -32,12 +33,12 @@ module SubmissionsHelper
     when 'cm'
       %W[
         #{values.join(' x ')}\ cm
-        #{values.map{ |dimension| convert_cm_to_inch(dimension) }.join(' x ')}\ in
+        #{values.map { |dimension| convert_cm_to_inch(dimension) }.join(' x ')}\ in
       ]
     when 'in'
       %W[
         #{values.join(' x ')}\ in
-        #{values.map{ |dimension| convert_inch_to_cm(dimension) }.join(' x ')}\ cm
+        #{values.map { |dimension| convert_inch_to_cm(dimension) }.join(' x ')}\ cm
       ]
     else
       []
@@ -78,7 +79,11 @@ module SubmissionsHelper
     if submission.approved? || submission.published?
       "Approved by #{submission.reviewed_by_user.try(:name)}"
     elsif submission.rejected?
-      "Rejected by #{submission.reviewed_by_user.try(:name)}"
+      if submission.reviewed_by_user
+        "Rejected by #{submission.reviewed_by_user.try(:name)}"
+      else
+        'Rejected automatically'
+      end
     end
   end
 
@@ -96,9 +101,10 @@ module SubmissionsHelper
   end
 
   def formatted_current_time
-    Time.now.in_time_zone('Eastern Time (US & Canada)').strftime(
-      '%l:%M %Z %B %-d, %Y'
-    )
+    Time
+      .now
+      .in_time_zone('Eastern Time (US & Canada)')
+      .strftime('%l:%M %Z %B %-d, %Y')
   end
 
   def formatted_minimum_price(submission)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -15,24 +15,29 @@ class SubmissionService
       ]
       user = User.find_or_create_by!(gravity_user_id: gravity_user_id)
       create_params = submission_params.merge(user_id: user.id)
+      final_params =
+        create_params.merge(
+          reject_if_non_target_supply_artist(submission_params[:artist_id])
+        )
 
-      artist = Gravity.client.artist(id: submission_params[:artist_id])._get
-      unless artist[:target_supply]
-        create_params =
-          create_params.merge(
-            {
-              state: 'rejected',
-              rejection_reason: 'Not Target Supply',
-              rejected_at: Time.now.utc
-            }
-          )
-      end
-
-      submission = Submission.create!(create_params)
+      submission = Submission.create!(final_params)
       UserService.delay.update_email(user.id)
       submission
     rescue ActiveRecord::RecordInvalid => e
       raise SubmissionError, e.message
+    end
+
+    def reject_if_non_target_supply_artist(artist_id)
+      artist = Gravity.client.artist(id: artist_id)._get
+      params = {}
+      unless artist[:target_supply]
+        params = {
+          state: 'rejected',
+          rejection_reason: 'Not Target Supply',
+          rejected_at: Time.now.utc
+        }
+      end
+      params
     end
 
     def update_submission(submission, params, current_user: nil)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -19,28 +19,7 @@ class SubmissionService
       UserService.delay.update_email(user.id)
 
       artist = Gravity.client.artist(id: submission.artist_id)._get
-
-      # puts artist.to_json
-
-      # below is the Artist
-      # {
-      #   "id": '51e6fda78b3b816d7800010a',
-      #   "slug": 'gina-beavers',
-      #   "created_at": '2013-07-17T20:25:11+00:00',
-      #   "updated_at": '2021-11-06T04:36:13+00:00',
-      #   "name": 'Gina Beavers',
-      #   "sortable_name": 'Beavers Gina',
-      #   "gender": 'female',
-      #   "biography": '',
-      #   "birthday": '1974',
-      #   "deathday": '',
-      #   "hometown": 'Athens, Greece',
-      #   "location": 'Brooklyn, NY, USA',
-      #   "nationality": 'American',
-      #   "image_versions": %w[four_thirds large square tall],
-      # }
-
-      if artist[:target_supply_priority] != 1
+      if artist.target_supply.nil? || artist.target_supply == false
         submission.update!(
           state: 'rejected',
           rejection_reason: 'Not Target Supply',

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -17,6 +17,37 @@ class SubmissionService
       create_params = submission_params.merge(user_id: user.id)
       submission = Submission.create!(create_params)
       UserService.delay.update_email(user.id)
+
+      artist = Gravity.client.artist(id: submission.artist_id)._get
+
+      # puts artist.to_json
+
+      # below is the Artist
+      # {
+      #   "id": '51e6fda78b3b816d7800010a',
+      #   "slug": 'gina-beavers',
+      #   "created_at": '2013-07-17T20:25:11+00:00',
+      #   "updated_at": '2021-11-06T04:36:13+00:00',
+      #   "name": 'Gina Beavers',
+      #   "sortable_name": 'Beavers Gina',
+      #   "gender": 'female',
+      #   "biography": '',
+      #   "birthday": '1974',
+      #   "deathday": '',
+      #   "hometown": 'Athens, Greece',
+      #   "location": 'Brooklyn, NY, USA',
+      #   "nationality": 'American',
+      #   "image_versions": %w[four_thirds large square tall],
+      # }
+
+      if artist[:target_supply_priority] != 1
+        submission.update!(
+          state: 'rejected',
+          rejection_reason: 'Not Target Supply',
+          rejected_at: Time.now.utc
+        )
+      end
+
       submission
     rescue ActiveRecord::RecordInvalid => e
       raise SubmissionError, e.message

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -24,7 +24,9 @@ describe SubmissionsHelper, type: :helper do
       submission =
         Fabricate(
           :submission,
-          location_city: '', location_state: '', location_country: ''
+          location_city: '',
+          location_state: '',
+          location_country: ''
         )
       expect(helper.formatted_location(submission)).to be_blank
     end
@@ -33,7 +35,9 @@ describe SubmissionsHelper, type: :helper do
       submission =
         Fabricate(
           :submission,
-          location_city: '', location_state: 'Tokyo', location_country: 'Japan'
+          location_city: '',
+          location_state: 'Tokyo',
+          location_country: 'Japan'
         )
       expect(helper.formatted_location(submission)).to eq('Tokyo, Japan')
     end
@@ -44,7 +48,10 @@ describe SubmissionsHelper, type: :helper do
       submission =
         Fabricate(
           :submission,
-          width: '10', height: '12', depth: '1.75', dimensions_metric: 'in'
+          width: '10',
+          height: '12',
+          depth: '1.75',
+          dimensions_metric: 'in'
         )
       expect(helper.formatted_dimensions(submission)).to eq '12x10x1.75in'
     end
@@ -59,13 +66,19 @@ describe SubmissionsHelper, type: :helper do
     let(:submission_with_inch) do
       Fabricate(
         :submission,
-        width: '10', height: '12', depth: '1.75', dimensions_metric: 'in'
+        width: '10',
+        height: '12',
+        depth: '1.75',
+        dimensions_metric: 'in'
       )
-      end
+    end
     let(:submission_with_cm) do
       Fabricate(
         :submission,
-        width: '30', height: '40', depth: '2.54', dimensions_metric: 'cm'
+        width: '30',
+        height: '40',
+        depth: '2.54',
+        dimensions_metric: 'cm'
       )
     end
 
@@ -73,21 +86,26 @@ describe SubmissionsHelper, type: :helper do
       submission = Fabricate(:submission, width: nil, height: nil, depth: nil)
       expect(helper.formatted_dimensions_inch_cm(submission)).to eq([])
     end
-    
+
     it 'returns empty array when dimension metric is nil' do
-      submission = Fabricate(:submission, width: 10, height: 10, depth: 1, dimensions_metric: nil)
+      submission =
+        Fabricate(
+          :submission,
+          width: 10,
+          height: 10,
+          depth: 1,
+          dimensions_metric: nil
+        )
       expect(helper.formatted_dimensions_inch_cm(submission)).to eq([])
     end
 
     it 'returns array of formatted dimensions for both metrics' do
-      expect(helper.formatted_dimensions_inch_cm(submission_with_inch)).to match_array [
-        '12 x 10 x 1.75 in',
-        '30.48 x 25.4 x 4.45 cm'
-      ]
-      expect(helper.formatted_dimensions_inch_cm(submission_with_cm)).to match_array [
-        '15.75 x 11.81 x 1.0 in',
-        '40 x 30 x 2.54 cm'
-      ]
+      expect(
+        helper.formatted_dimensions_inch_cm(submission_with_inch)
+      ).to match_array ['12 x 10 x 1.75 in', '30.48 x 25.4 x 4.45 cm']
+      expect(
+        helper.formatted_dimensions_inch_cm(submission_with_cm)
+      ).to match_array ['15.75 x 11.81 x 1.0 in', '40 x 30 x 2.54 cm']
     end
   end
 
@@ -233,29 +251,41 @@ describe SubmissionsHelper, type: :helper do
         Fabricate(:submission, state: 'rejected', rejected_by: 'userid')
       expect(helper.reviewer_byline(submission)).to eq 'Rejected by Jon Jonson'
     end
+    it 'shows the correct label for automatically rejected submissions' do
+      stub_gravity_root
+      stub_gravity_user
+      submission = Fabricate(:submission, state: 'rejected', rejected_by: nil)
+      expect(helper.reviewer_byline(submission)).to eq 'Rejected automatically'
+    end
     it 'shows the correct label for an approved submission with no user' do
       submission = Fabricate(:submission, state: 'approved')
       expect(helper.reviewer_byline(submission)).to eq 'Approved by '
     end
     it 'shows the correct label for a rejected submission with no user' do
       submission = Fabricate(:submission, state: 'rejected')
-      expect(helper.reviewer_byline(submission)).to eq 'Rejected by '
+      expect(helper.reviewer_byline(submission)).to eq 'Rejected automatically'
     end
   end
 
   context 'artist_supply_priority' do
     context 'when is_p1' do
-      subject { helper.artist_supply_priority(is_p1: true, target_supply: true) }
+      subject do
+        helper.artist_supply_priority(is_p1: true, target_supply: true)
+      end
       it { is_expected.to eq 'P1' }
     end
 
     context 'when target_supply/p2' do
-      subject { helper.artist_supply_priority(is_p1: false, target_supply: true) }
+      subject do
+        helper.artist_supply_priority(is_p1: false, target_supply: true)
+      end
       it { is_expected.to eq 'P2' }
     end
 
     context 'none' do
-      subject { helper.artist_supply_priority(is_p1: false, target_supply: false) }
+      subject do
+        helper.artist_supply_priority(is_p1: false, target_supply: false)
+      end
       it { is_expected.to eq nil }
     end
   end
@@ -264,7 +294,11 @@ describe SubmissionsHelper, type: :helper do
     subject { helper.assignable_admin?(user) }
 
     before do
-      AdminUser.create(gravity_user_id: 'admin', name: 'AdminName', assignee: true)
+      AdminUser.create(
+        gravity_user_id: 'admin',
+        name: 'AdminName',
+        assignee: true
+      )
     end
 
     context 'for non-admin user' do

--- a/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
@@ -15,8 +15,7 @@ describe 'createConsignmentSubmission mutation' do
     '{ state: REJECTED, clientMutationId: "2", artistID: "andy", title: "soup", category: JEWELRY, minimumPriceDollars: 50000, currency: "GBP", sourceArtworkID: "gravity_artwork_id" }'
   end
 
-  let(:mutation) do
-    <<-GRAPHQL
+  let(:mutation) { <<-GRAPHQL }
     mutation {
       createConsignmentSubmission(input: #{mutation_inputs}){
         clientMutationId
@@ -31,8 +30,7 @@ describe 'createConsignmentSubmission mutation' do
         }
       }
     }
-    GRAPHQL
-  end
+  GRAPHQL
 
   describe 'invalid requests' do
     context 'with an unauthorized request' do
@@ -92,6 +90,7 @@ describe 'createConsignmentSubmission mutation' do
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
+      stub_gravity_artist({ id: 'andy' })
 
       expect {
         post '/api/graphql', params: { query: mutation }, headers: headers
@@ -140,6 +139,7 @@ describe 'createConsignmentSubmission mutation' do
         stub_gravity_root
         stub_gravity_user
         stub_gravity_user_detail(email: 'michael@bluth.com')
+        stub_gravity_artist({ id: 'andy' })
 
         post '/api/graphql', params: { query: mutation }, headers: headers
 

--- a/spec/requests/api/submissions/create_spec.rb
+++ b/spec/requests/api/submissions/create_spec.rb
@@ -36,6 +36,7 @@ describe 'POST /api/submissions' do
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
+      stub_gravity_artist({ id: 'artistid' })
 
       params = { title: 'my sartwork', artist_id: 'artistid' }
 
@@ -52,6 +53,7 @@ describe 'POST /api/submissions' do
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
+      stub_gravity_artist({ id: 'artistid' })
 
       params = {
         artist_id: 'artistid',
@@ -78,6 +80,7 @@ describe 'POST /api/submissions' do
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
+      stub_gravity_artist({ id: 'artistid' })
 
       params = {
         artist_id: 'artistid',
@@ -111,6 +114,7 @@ describe 'POST /api/submissions' do
       stub_gravity_root
       stub_gravity_user
       stub_gravity_user_detail(email: 'michael@bluth.com')
+      stub_gravity_artist({ id: 'artistid' })
 
       params = {
         artist_id: 'artistid',
@@ -147,6 +151,8 @@ describe 'POST /api/submissions' do
     end
 
     it 'uses the anonymous user' do
+      stub_gravity_artist({ id: 'artistid' })
+
       params = {
         artist_id: 'artistid',
         gravity_user_id: 'anonymous',

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -18,11 +18,13 @@ describe PartnerSubmissionService do
     allow(Convection.config).to receive(:gravity_xapp_token).and_return(
       'xapp_token'
     )
-    stub_gravql_artists(body:{
-      data: {
-        artists: [{ id: 'artistid', name: 'Andy Warhol' }]
+    stub_gravql_artists(
+      body: {
+        data: {
+          artists: [{ id: 'artistid', name: 'Andy Warhol' }]
+        }
       }
-    })
+    )
     stub_gravity_partner_communications
     stub_gravity_partner_contacts
     allow(Time).to receive(:now).and_return(
@@ -50,12 +52,13 @@ describe PartnerSubmissionService do
       submission =
         Fabricate(
           :submission,
-          state: 'submitted', user: @user, artist_id: 'artistid'
+          state: 'submitted',
+          user: @user,
+          artist_id: 'artistid'
         )
-      expect(NotificationService).to receive(:post_submission_event).once.with(
-        submission.id,
-        'published'
-      )
+      expect(NotificationService).to receive(:post_submission_event)
+        .once
+        .with(submission.id, 'published')
       SubmissionService.update_submission(submission, state: 'published')
       expect(partner.partner_submissions.count).to eq 1
       expect(partner.partner_submissions.first.submission).to eq submission
@@ -116,7 +119,8 @@ describe PartnerSubmissionService do
             minimum_price_cents: 50_000_00,
             currency: 'USD'
           )
-        expect(NotificationService).to receive(:post_submission_event).once
+        expect(NotificationService).to receive(:post_submission_event)
+          .once
           .with(@approved1.id, 'published')
         SubmissionService.update_submission(@approved1, state: 'published')
         PartnerSubmissionService.daily_digest
@@ -141,7 +145,8 @@ describe PartnerSubmissionService do
             title: 'Approved artwork with minimum price',
             year: '1992'
           )
-        expect(NotificationService).to receive(:post_submission_event).once
+        expect(NotificationService).to receive(:post_submission_event)
+          .once
           .with(@approved1.id, 'published')
         SubmissionService.update_submission(@approved1, state: 'published')
       end
@@ -185,11 +190,14 @@ describe PartnerSubmissionService do
             year: '1997'
           )
         Fabricate(:submission, state: 'rejected')
-        expect(NotificationService).to receive(:post_submission_event).once
+        expect(NotificationService).to receive(:post_submission_event)
+          .once
           .with(@approved1.id, 'published')
-        expect(NotificationService).to receive(:post_submission_event).once
+        expect(NotificationService).to receive(:post_submission_event)
+          .once
           .with(@approved2.id, 'published')
-        expect(NotificationService).to receive(:post_submission_event).once
+        expect(NotificationService).to receive(:post_submission_event)
+          .once
           .with(@approved3.id, 'published')
         SubmissionService.update_submission(@approved1, state: 'published')
         SubmissionService.update_submission(@approved2, state: 'published')
@@ -217,7 +225,7 @@ describe PartnerSubmissionService do
           expect(emails.length).to eq 1
           email = emails.first
           expect(email.subject).to include(
-            'New Artsy Consignments September 27: 3 works'
+            'New Artsy Consignments September 26: 3 works'
           )
           expect(email.bcc).to eq(%w[consignments-archive@artsymail.com])
           expect(email.from).to eq(%w[consign@artsy.net])
@@ -283,21 +291,24 @@ describe PartnerSubmissionService do
             :image,
             submission: @approved1,
             image_urls: {
-              'square' => 'http://square1.jpg', 'large' => 'http://foo1.jpg'
+              'square' => 'http://square1.jpg',
+              'large' => 'http://foo1.jpg'
             }
           )
           Fabricate(
             :image,
             submission: @approved1,
             image_urls: {
-              'square' => 'http://square2.jpg', 'large' => 'http://foo2.jpg'
+              'square' => 'http://square2.jpg',
+              'large' => 'http://foo2.jpg'
             }
           )
           Fabricate(
             :image,
             submission: @approved1,
             image_urls: {
-              'square' => 'http://square3.jpg', 'large' => 'http://foo3.jpg'
+              'square' => 'http://square3.jpg',
+              'large' => 'http://foo3.jpg'
             }
           )
           PartnerSubmissionService.daily_digest
@@ -358,7 +369,8 @@ describe PartnerSubmissionService do
             Fabricate(:partner, gravity_partner_id: 'phillips')
           stub_gravity_partner(name: 'Phillips Auctions', id: 'phillips')
           stub_gravity_partner_contacts(
-            partner_id: 'phillips', override_body: []
+            partner_id: 'phillips',
+            override_body: []
           )
           PartnerSubmissionService.daily_digest
 
@@ -372,7 +384,7 @@ describe PartnerSubmissionService do
           expect(emails.length).to eq 1
           email = emails.first
           expect(email.subject).to include(
-            'New Artsy Consignments September 27: 3 works'
+            'New Artsy Consignments September 26: 3 works'
           )
           expect(email.html_part.body).to include(
             '<i>First approved artwork</i><span>, 1992</span>'
@@ -388,10 +400,13 @@ describe PartnerSubmissionService do
         it 'sends to a gallery partner' do
           gallery_partner = Fabricate(:partner, gravity_partner_id: 'gagosian')
           stub_gravity_partner(
-            name: 'Gagosian Gallery', id: 'gagosian', type: 'Gallery'
+            name: 'Gagosian Gallery',
+            id: 'gagosian',
+            type: 'Gallery'
           )
           stub_gravity_partner_contacts(
-            partner_id: 'gagosian', override_body: []
+            partner_id: 'gagosian',
+            override_body: []
           )
           PartnerSubmissionService.generate_for_new_partner(gallery_partner)
           PartnerSubmissionService.deliver_digest(gallery_partner.id)
@@ -402,7 +417,7 @@ describe PartnerSubmissionService do
           expect(emails.length).to eq 1
           email = emails.first
           expect(email.subject).to include(
-            'New Artsy Consignments September 27: 3 works'
+            'New Artsy Consignments September 26: 3 works'
           )
           expect(email.html_part.body).to_not include('Submit Proposal')
           expect(email.html_part.body).to include(

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -225,7 +225,7 @@ describe PartnerSubmissionService do
           expect(emails.length).to eq 1
           email = emails.first
           expect(email.subject).to include(
-            'New Artsy Consignments September 26: 3 works'
+            'New Artsy Consignments September 27: 3 works'
           )
           expect(email.bcc).to eq(%w[consignments-archive@artsymail.com])
           expect(email.from).to eq(%w[consign@artsy.net])
@@ -384,7 +384,7 @@ describe PartnerSubmissionService do
           expect(emails.length).to eq 1
           email = emails.first
           expect(email.subject).to include(
-            'New Artsy Consignments September 26: 3 works'
+            'New Artsy Consignments September 27: 3 works'
           )
           expect(email.html_part.body).to include(
             '<i>First approved artwork</i><span>, 1992</span>'
@@ -417,7 +417,7 @@ describe PartnerSubmissionService do
           expect(emails.length).to eq 1
           email = emails.first
           expect(email.subject).to include(
-            'New Artsy Consignments September 26: 3 works'
+            'New Artsy Consignments September 27: 3 works'
           )
           expect(email.html_part.body).to_not include('Submit Proposal')
           expect(email.html_part.body).to include(

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -45,7 +45,7 @@ describe SubmissionService do
       stub_gravity_artist
 
       new_submission = SubmissionService.create_submission(params, 'userid')
-      expect(new_submission.reload.state).to eq 'draft'
+      expect(new_submission.reload.state).to eq 'rejected'
       expect(new_submission.user_id).to eq user.id
       expect(new_submission.user.email).to eq 'michael@bluth.com'
     end


### PR DESCRIPTION
Ticket: [SWA-82](https://artsyproduct.atlassian.net/browse/SWA-82)

### Description 
This ticket implements that submissions that belong to an artist who's not target supply are automatically rejected. 

### Note 
Please do NOT MERGE before Gravity deployment: https://github.com/artsy/gravity/pull/14639

### Video 
First submission is by a non-target supply artist, the second is by a target supply artist

https://user-images.githubusercontent.com/42584148/141269198-10e533e9-ba33-45ad-a002-f1778ce428d1.mov

