### PR TITLE
fix[SWA-122]: Displaying the correct cataloguer name

### DIFF
--- a/app/views/admin/submissions/_cataloguer.html.erb
+++ b/app/views/admin/submissions/_cataloguer.html.erb
@@ -1,4 +1,4 @@
 <div class='col-md-9' id='cataloguer'>
-  <%= @submission.cataloguer == '' ?  'Unassigned' : AdminUser.find_by(id: @submission.cataloguer)&.name %>
+  <%= @submission.cataloguer == '' ?  'Unassigned' : AdminUser.find_by(gravity_user_id: @submission.cataloguer)&.name %>
 </div>
 <button class="col-md-3" id="edit_cataloguer" onclick="switchVisible('update_cataloguer', 'edit_cataloguer')"> Edit </button>


### PR DESCRIPTION
Resolve [SWA-122](https://artsyproduct.atlassian.net/browse/SWA-122)

### Description:
Whenever any cataloguer is selected, it defaults to Emily's name, which isn't on the list

![37f85920-62b4-478c-b51d-62b001776544](https://user-images.githubusercontent.com/21379857/141301039-32676dc9-1416-4b92-9292-438bac3c53f4.gif)

------------
### Why?
We save the gravity_user_id in the cataloguer field, but when displaying it on the view, we looked for cataloguer.name by id

<img width="1676" alt="Screen Shot 2021-11-11 at 3 28 04 PM" src="https://user-images.githubusercontent.com/21379857/141299067-ac4886f6-645f-4775-99fb-36b2b7ab03d6.png">

