### PR TITLE
[Feat]: Replace word consign in user emails

### DIFF
--- a/app/views/shared/email/_email_header.html.erb
+++ b/app/views/shared/email/_email_header.html.erb
@@ -3,8 +3,5 @@
     <td class='artsy-logo'>
       <%= image_tag(image_url('artsy-logo.jpg'), id: 'artsy-logo') %>
     </td>
-    <td class='consignments-label'>
-      Consignments
-    </td>
   </tr>
 </table>

--- a/app/views/user_mailer/first_upload_reminder.html.erb
+++ b/app/views/user_mailer/first_upload_reminder.html.erb
@@ -14,12 +14,12 @@
               </tr>
               <tr>
                 <td class='email-title'>
-                Complete your consignment submission
+                Complete your submission
                 </td>
               </tr>
               <tr>
                 <td class='email-sub-title'>
-                  Upload photos of your work to complete your consignment submission.
+                  Upload photos of your work to complete your submission.
                 </td>
               </tr>
               <tr>

--- a/app/views/user_mailer/other_submission_rejected.erb
+++ b/app/views/user_mailer/other_submission_rejected.erb
@@ -21,8 +21,7 @@
               submissions, please visit our Collector Help Center article
               <%= link_to 'What do we look for in consignment submissions?',
                 'https://support.artsy.net/hc/en-us/articles/1500006366381', target: :_blank %>.</p>
-            <p>Of course, if you have works by other artists that you would be
-              interested in consigning at any point, please kindly
+            <p>Of course, if you have works by other artists that you would be interested in selling at any point, please kindly
               <%= link_to 'submit a work', 'https://www.artsy.net/consign', target: :_blank %>
               for another artist or email our team directly at <%= link_to 'consign@artsymail.com', 'mailto:consign@artsymail.com', target: :_blank %>.</p>
             <p>We will be in touch if anything changes in the future.</p>

--- a/app/views/user_mailer/second_upload_reminder.html.erb
+++ b/app/views/user_mailer/second_upload_reminder.html.erb
@@ -27,7 +27,7 @@
                   <table>
                     <tr>
                       <td class='email-sub-title email-sub-title-bottom'>
-                        Without images, we're unable to accept your submission. Please upload images of the work (front, back, signature) to continue with your consignment.
+                        Please upload images of the work (front, back, signature) to continue with your submission.
                       </td>
                     </tr>
                   </table>

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -476,9 +476,7 @@ describe SubmissionService do
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
         expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
-        expect(emails.first.html_part.body).to include(
-          'Complete your consignment submission'
-        )
+        expect(emails.first.html_part.body).to include('your submission')
         expect(emails.first.html_part.body).to include(
           'utm_campaign=consignment-complete'
         )


### PR DESCRIPTION
### Description 

This PR replaces the references to the word 'consign' or 'consignment' in all emails sent to the user. 

Ticket: [SWA-124](https://artsyproduct.atlassian.net/browse/SWA-124)