### PR TITLE
Feat: send a slighly different template for non-target rejection emails

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -125,6 +125,23 @@ class UserMailer < ApplicationMailer
     mail(to: user.email, subject: 'An update about your submission')
   end
 
+  def non_target_supply_artist_rejected(submission:, user:, artist:)
+    @submission = submission
+    @user = user
+    @artist = artist
+    @utm_params =
+      utm_params(
+        source: 'consignment-rejected',
+        campaign: 'consignment-complete'
+      )
+
+    smtpapi category: %w[non_target_supply_artist_rejected],
+            unique_args: {
+              submission_id: submission.id
+            }
+    mail(to: user.email, subject: 'An update about your submission')
+  end
+
   def other_submission_rejected(submission:, user:, artist:)
     @submission = submission
     @user = user

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -265,6 +265,8 @@ class SubmissionService
           'artist_submission_rejected'
         when 'NSV', 'BSV'
           'nsv_bsv_submission_rejected'
+        when 'Not Target Supply'
+          'non_target_supply_artist_rejected'
         else
           'other_submission_rejected'
         end

--- a/app/views/user_mailer/non_target_supply_artist_rejected.html.erb
+++ b/app/views/user_mailer/non_target_supply_artist_rejected.html.erb
@@ -1,0 +1,40 @@
+<%= stylesheet_link_tag 'emails', media: 'all' %>
+
+<table class='padded-email'>
+  <tr>
+    <td>
+      <table class='email-content' align='left'>
+        <tr>
+          <td>
+            <%= render 'shared/email/email_header' %>
+          </td>
+        </tr>
+        <tr>
+          <td class='email-sub-title'>
+            <p>Dear <%= @user.name %>,</p>
+            <p>Thank you for submission and interest in our
+              <%= link_to 'Sell with Artsy program', 'https://www.artsy.net/consign', target: :_blank %>!
+              Our team of Specialists carefully review each submission with the commercial
+              behavior of Artsy users and our network of auction partners in mind. </p>
+            <p>Upon reviewing your submission, our Specialists have determined we cannot accept this artwork at this time, 
+            because there is minimal to no demand for <%= @artist.name %> on Artsy. For more information about how our Specialists review
+              submissions, please visit our Collector Help Center article
+              <%= link_to 'What do we look for in consignment submissions?',
+                'https://support.artsy.net/hc/en-us/articles/1500006366381', target: :_blank %>.</p>
+            <p>Of course, if you have works by other artists that you would be
+              interested in consigning at any point, please kindly
+              <%= link_to 'submit a work', 'https://www.artsy.net/consign', target: :_blank %>
+              for another artist or email our team directly at <%= link_to 'consign@artsymail.com', 'mailto:consign@artsymail.com', target: :_blank %>.</p>
+            <p>We will be in touch if anything changes in the future.</p>
+            <p>Sincerely,<br />The Sell with Artsy Team</p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= render 'shared/email/submission_block', submission: @submission %>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -62,7 +62,9 @@ describe SubmissionService do
       expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[consign@artsy.net])
-      expect(emails.first.html_part.body).to include('we cannot accept it')
+      expect(emails.first.html_part.body).to include(
+        'Specialists have determined we cannot accept'
+      )
     end
 
     it 'does not reject a submission automatically, when created by Convection' do


### PR DESCRIPTION
### Description 

This one implements that we send a slightly different email to the user for non-target supply artist rejections. For details, see the comments in the ticket: [SWA-81](https://artsyproduct.atlassian.net/browse/SWA-81)