### PR TITLE
Fix: remove sessionId from submission params

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -490,7 +490,7 @@ input CreateSubmissionMutationInput {
   medium: String
   minimumPriceDollars: Int
   provenance: String
-  sessionId: String
+  sessionID: String
   signature: Boolean
 
   """
@@ -2004,7 +2004,7 @@ input UpdateSubmissionMutationInput {
   medium: String
   minimumPriceDollars: Int
   provenance: String
-  sessionId: String
+  sessionID: String
   signature: Boolean
   state: State
   title: String

--- a/app/graphql/mutations/create_submission_mutation.rb
+++ b/app/graphql/mutations/create_submission_mutation.rb
@@ -46,7 +46,7 @@ module Mutations
     argument :utm_source, String, required: false
     argument :utm_medium, String, required: false
     argument :utm_term, String, required: false
-    argument :session_id, String, required: false
+    argument :sessionID, String, required: false
 
     field :consignment_submission, Types::SubmissionType, null: true
 

--- a/app/graphql/mutations/update_submission_mutation.rb
+++ b/app/graphql/mutations/update_submission_mutation.rb
@@ -40,7 +40,7 @@ module Mutations
     argument :utm_source, String, required: false
     argument :utm_medium, String, required: false
     argument :utm_term, String, required: false
-    argument :session_id, String, required: false
+    argument :sessionID, String, required: false
 
     field :consignment_submission, Types::SubmissionType, null: true
 

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -27,6 +27,7 @@ class SubmissionService
             phone: submission_params[:user_email]
           )
         end
+      user.session_id = submission_params.delete(:session_id)
       create_params = submission_params.merge(user_id: user.id)
 
       unless is_convection

--- a/spec/requests/api/graphql/mutations/update_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/update_consignment_submission_spec.rb
@@ -93,7 +93,7 @@ describe 'updateConsignmentSubmission mutation' do
       let(:mutation_inputs) do
         "{ state: DRAFT, category: JEWELRY, clientMutationId: \"test\", id: #{
           submission1.id
-        }, artistID: \"andy-warhol\", title: \"soup\", sessionId: \"diff token\" }"
+        }, artistID: \"andy-warhol\", title: \"soup\", sessionID: \"diff token\" }"
       end
 
       it 'returns an error for that request' do
@@ -117,7 +117,7 @@ describe 'updateConsignmentSubmission mutation' do
       let(:mutation_inputs) do
         "{ state: DRAFT, category: JEWELRY, clientMutationId: \"test\", id: #{
           submission.id
-        }, artistID: \"andy-warhol\", title: \"soup\", sessionId: \"token\" }"
+        }, artistID: \"andy-warhol\", title: \"soup\", sessionID: \"token\" }"
       end
 
       it 'returns updated submission' do


### PR DESCRIPTION
Parameters coming from metaphysics for creating a submission contain sessionId, but the submission does not have such a field, so i need to save it in the user and remove it from the submission parameters

Also rename sessionId to sessionID
CreateMutation:
<img width="1026" alt="Screen Shot 2021-11-19 at 6 00 15 PM" src="https://user-images.githubusercontent.com/21379857/142643768-9983667a-1892-43e3-9366-2a802279c93f.png">
UpdateMutation:
<img width="1015" alt="Screen Shot 2021-11-19 at 6 02 52 PM" src="https://user-images.githubusercontent.com/21379857/142644218-172c5502-af68-43ce-90f3-f968d068f84e.png">

