### PR TITLE
fix: an email parameter is being assigned to a phone field when creating anonymous submissions

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -24,7 +24,7 @@ class SubmissionService
           User.create!(
             name: submission_params[:user_name],
             email: submission_params[:user_email],
-            phone: submission_params[:user_email]
+            phone: submission_params[:user_phone]
           )
         end
       user.session_id = submission_params.delete(:session_id)

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -25,7 +25,14 @@ describe SubmissionService do
 
   context 'create_submission' do
     let(:params) do
-      { artist_id: 'artistid', state: 'submitted', title: 'My Artwork' }
+      {
+        artist_id: 'artistid',
+        state: 'submitted',
+        title: 'My Artwork',
+        user_name: 'michael',
+        user_email: 'michael@bluth.com',
+        user_phone: '555-5555'
+      }
     end
 
     it 'creates a submission with state Rejected when artist is not in target supply' do
@@ -93,6 +100,15 @@ describe SubmissionService do
       expect(new_submission.reload.state).to eq 'submitted'
       expect(new_submission.user_id).to eq user.id
       expect(new_submission.user.email).to eq 'michael@bluth.com'
+    end
+
+    context 'anonymous submission' do
+      it 'adds contact information to the user record' do
+        new_submission = SubmissionService.create_submission(params, nil)
+        expect(new_submission.user.name).to eq 'michael'
+        expect(new_submission.user.email).to eq 'michael@bluth.com'
+        expect(new_submission.user.phone).to eq '555-5555'
+      end
     end
   end
 


### PR DESCRIPTION
I noticed that the value of `user_email` was being assigned to the `phone` field of a user record. This PR fixes that by assigning the value of `user_phone` instead.