### PR TITLE
feat: save contact information for authenticated submissions

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -19,7 +19,14 @@ class SubmissionService
       ]
       user =
         if gravity_user_id
-          User.find_or_create_by!(gravity_user_id: gravity_user_id)
+          convection_user =
+            User.find_or_create_by!(gravity_user_id: gravity_user_id)
+          convection_user.update(
+            name: submission_params[:user_name],
+            email: submission_params[:user_email],
+            phone: submission_params[:user_phone]
+          )
+          convection_user
         else
           User.create!(
             name: submission_params[:user_name],

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -17,6 +17,7 @@ describe 'Submission Flow' do
   it 'Completes 3' do
     stub_gravity_root
     stub_gravity_user
+    stub_gravity_user_detail(email: 'michael@bluth.com')
     stub_gravity_artist
 
     # first create the submission, without a location_city
@@ -67,7 +68,8 @@ describe 'Submission Flow' do
   describe 'Creating a submission without a photo initially' do
     it 'sends an initial reminder and a delayed reminder' do
       stub_gravity_root
-      stub_gravity_user(email: 'michael@bluth.com')
+      stub_gravity_user
+      stub_gravity_user_detail(email: 'michael@bluth.com')
       stub_gravity_artist
 
       # first create the submission

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -110,6 +110,15 @@ describe SubmissionService do
         expect(new_submission.user.phone).to eq '555-5555'
       end
     end
+
+    context 'authenticated submission' do
+      it 'adds contact information to the user record' do
+        new_submission = SubmissionService.create_submission(params, 'userid')
+        expect(new_submission.user.name).to eq 'michael'
+        expect(new_submission.user.email).to eq 'michael@bluth.com'
+        expect(new_submission.user.phone).to eq '555-5555'
+      end
+    end
   end
 
   context 'update_submission' do


### PR DESCRIPTION
This PR updates the `create_submission` service method to save contact information (name, email, phone) for authenticated submissions.

In the new web submission flow, users are asked to enter their contact information. We are currently saving this information for anonymous submissions, but we would also like to save it for authenticated submissions.