### PR TITLE
fix: require a gravity user ID for submissions when contact information is not provided

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,25 +3,26 @@
 class User < ApplicationRecord
   include PgSearch::Model
 
+  validates :gravity_user_id, presence: true, unless: :contact_information?
+
   has_many :submissions, dependent: :nullify
   has_many :notes, dependent: :nullify
 
   pg_search_scope :search, against: :email, using: { tsearch: { prefix: true } }
 
   def gravity_user
-    if defined?(@gravity_user)
-      @gravity_user
-    elsif gravity_user_id
-      @gravity_user =
-        gravity_user_id &&
-          (
-            begin
-              Gravity.client.user(id: gravity_user_id)._get
-            rescue Faraday::ResourceNotFound
-              nil
-            end
-          )
-    end
+    return @gravity_user if defined?(@gravity_user)
+    return nil unless gravity_user_id
+
+    @gravity_user =
+      gravity_user_id &&
+        (
+          begin
+            Gravity.client.user(id: gravity_user_id)._get
+          rescue Faraday::ResourceNotFound
+            nil
+          end
+        )
   end
 
   def name
@@ -48,5 +49,9 @@ class User < ApplicationRecord
 
   def self.anonymous
     User.find_or_create_by(gravity_user_id: 'anonymous')
+  end
+
+  def contact_information?
+    self[:name].present? && self[:email].present? && self[:phone].present?
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,6 +23,74 @@ describe User do
     end
   end
 
+  context 'active record validation' do
+    context 'contact information has not been provided' do
+      let(:user) { Fabricate(:user, name: nil, email: nil, phone: nil) }
+      it 'fails if gravity_user_id is nil' do
+        user.gravity_user_id = nil
+        user.validate
+        expect(user.errors[:gravity_user_id]).to include("can't be blank")
+      end
+      it 'fails if gravity_user_id is empty' do
+        user.gravity_user_id = ''
+        user.validate
+        expect(user.errors[:gravity_user_id]).to include("can't be blank")
+      end
+      it 'passes if gravity_user_id has a value' do
+        user.gravity_user_id = 'user-1'
+        user.validate
+        expect(user.errors[:gravity_user_id]).to_not include("can't be blank")
+      end
+    end
+    context 'contact information has been provided' do
+      let(:user) do
+        Fabricate(
+          :user,
+          name: 'user',
+          email: 'user@example.com',
+          phone: '+1 (212) 555-5555'
+        )
+      end
+      it 'passes if gravity_user_id is nil' do
+        user.gravity_user_id = nil
+        user.validate
+        expect(user.errors[:gravity_user_id]).to_not include("can't be blank")
+      end
+      it 'passes if gravity_user_id is empty' do
+        user.gravity_user_id = ''
+        user.validate
+        expect(user.errors[:gravity_user_id]).to_not include("can't be blank")
+      end
+    end
+  end
+
+  context 'contact_information?' do
+    let(:user) do
+      Fabricate(
+        :user,
+        name: 'user',
+        email: 'user@example.com',
+        phone: '+1 (212) 555-5555'
+      )
+    end
+
+    it 'returns true if name, email, and phone have values' do
+      expect(user.contact_information?).to be true
+    end
+    it 'returns false if name is nil' do
+      user.name = nil
+      expect(user.contact_information?).to be false
+    end
+    it 'returns false if email is nil' do
+      user.name = nil
+      expect(user.contact_information?).to be false
+    end
+    it 'returns false if phone is nil' do
+      user.name = nil
+      expect(user.contact_information?).to be false
+    end
+  end
+
   context 'gravity_user' do
     it 'returns nil if it cannot find the object' do
       stub_gravity_root


### PR DESCRIPTION
This PR addresses an issue where admins were able to manually create submissions without a user in the admin UI. This caused the submission list page (`/submissions`) to crash when it tried to render submissions with neither a `gravity_user_id` nor any contact information (name, email, or phone).

This was resolved by re-introducing validation for the `presence` of a `gravity_user_id`, on the condition that it is only required when contact information is not provided.

<img width="1030" alt="Screen Shot 2021-11-22 at 9 40 43 AM" src="https://user-images.githubusercontent.com/44589599/142881365-03edd67c-edcc-4a0c-9bcf-f3b0a41a0e55.png">
