### PR TITLE
[Feat]: SWA-100 - Update addAsset mutations

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -9,6 +9,7 @@ input AddAssetToConsignmentSubmissionInput {
   """
   clientMutationId: String
   geminiToken: String!
+  sessionID: String
   submissionID: ID!
 }
 
@@ -35,6 +36,7 @@ input AddAssetsToConsignmentSubmissionInput {
   """
   clientMutationId: String
   geminiTokens: [String!]!
+  sessionID: String
   submissionID: ID!
 }
 

--- a/app/graphql/mutations/add_asset_to_consignment_submission.rb
+++ b/app/graphql/mutations/add_asset_to_consignment_submission.rb
@@ -5,13 +5,17 @@ module Mutations
     argument :gemini_token, String, required: true
     argument :submissionID, ID, required: true
 
+    argument :sessionID, String, required: false
+
     argument :asset_type, String, required: false
 
     field :asset, Types::AssetType, null: true
 
     def resolve(arguments)
       resolve_options = {
-        arguments: arguments, context: context, object: object
+        arguments: arguments,
+        context: context,
+        object: object
       }
       resolver = AddAssetToSubmissionResolver.new(resolve_options)
       raise resolver.error unless resolver.valid?

--- a/app/graphql/mutations/add_assets_to_consignment_submission.rb
+++ b/app/graphql/mutations/add_assets_to_consignment_submission.rb
@@ -5,6 +5,8 @@ module Mutations
     argument :gemini_tokens, [String], required: true
     argument :submissionID, ID, required: true
 
+    argument :sessionID, String, required: false
+
     argument :asset_type, String, required: false
 
     field :assets, [Types::AssetType], null: true

--- a/app/graphql/resolvers/add_asset_to_submission_resolver.rb
+++ b/app/graphql/resolvers/add_asset_to_submission_resolver.rb
@@ -11,10 +11,8 @@ class AddAssetToSubmissionResolver < BaseResolver
       raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
     end
 
-    matching_user = submission.user&.gravity_user_id == @context[:current_user]
-
-    unless matching_user || admin?
-      raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
+    unless matching_user(submission, @arguments&.[](:session_id)) || admin?
+      raise(GraphQL::ExecutionError, 'Submission Not Found')
     end
 
     @arguments[:asset_type] ||= 'image'

--- a/app/graphql/resolvers/add_assets_to_submission_resolver.rb
+++ b/app/graphql/resolvers/add_assets_to_submission_resolver.rb
@@ -11,8 +11,8 @@ class AddAssetsToSubmissionResolver < BaseResolver
       raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
     end
 
-    unless submission.user&.gravity_user_id == @context[:current_user] || admin?
-      raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
+    unless matching_user(submission, @arguments&.[](:session_id)) || admin?
+      raise(GraphQL::ExecutionError, 'Submission Not Found')
     end
 
     assets = create_assets(@arguments[:gemini_tokens], @arguments[:asset_type])

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -35,4 +35,9 @@ class BaseResolver
   def admin?
     @context[:current_user_roles].include?(:admin)
   end
+
+  def matching_user(submission, session_id)
+    submission.user&.gravity_user_id == @context&.[](:current_user) ||
+      submission.user&.session_id == session_id
+  end
 end

--- a/app/graphql/resolvers/update_submission_resolver.rb
+++ b/app/graphql/resolvers/update_submission_resolver.rb
@@ -8,7 +8,7 @@ class UpdateSubmissionResolver < BaseResolver
       raise(GraphQL::ExecutionError, 'Submission from ID Not Found')
     end
 
-    unless matching_user(submission) || admin?
+    unless matching_user(submission, @arguments&.[](:session_id)) || admin?
       raise(GraphQL::ExecutionError, 'Submission Not Found')
     end
 
@@ -23,10 +23,5 @@ class UpdateSubmissionResolver < BaseResolver
     )
 
     { consignment_submission: submission }
-  end
-
-  def matching_user(submission)
-    submission.user&.gravity_user_id == @context&.[](:current_user) ||
-      submission.user&.session_id == @arguments&.[](:session_id)
   end
 end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -5,5 +5,4 @@ Fabricator(:user) do
     Fabricate.sequence(:gravity_user_id) { |i| "user-id-#{i}" }
   end
   email { Fabricate.sequence(:email) { |i| "jon-jonson#{i}@test.com" } }
-  session_id { Fabricate.sequence(:session_id) { |i| "session_id#{i}" } }
 end

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -5,4 +5,5 @@ Fabricator(:user) do
     Fabricate.sequence(:gravity_user_id) { |i| "user-id-#{i}" }
   end
   email { Fabricate.sequence(:email) { |i| "jon-jonson#{i}@test.com" } }
+  session_id { Fabricate.sequence(:session_id) { |i| "session_id#{i}" } }
 end

--- a/spec/requests/api/graphql/mutations/add_asset_to_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/add_asset_to_consignment_submission_spec.rb
@@ -20,8 +20,7 @@ describe 'addAssetToConsignmentSubmission mutation' do
     }, geminiToken: \"gemini-token-hash\" }"
   end
 
-  let(:mutation) do
-    <<-GRAPHQL
+  let(:mutation) { <<-GRAPHQL }
       mutation {
         addAssetToConsignmentSubmission(input: #{mutation_inputs}){
           clientMutationId
@@ -31,8 +30,7 @@ describe 'addAssetToConsignmentSubmission mutation' do
           }
         }
       }
-    GRAPHQL
-  end
+  GRAPHQL
 
   describe 'valid requests' do
     it 'creates an asset' do
@@ -47,6 +45,35 @@ describe 'addAssetToConsignmentSubmission mutation' do
       asset_response = body['data']['addAssetToConsignmentSubmission']['asset']
       expect(asset_response['id']).not_to be_nil
       expect(asset_response['submissionId'].to_i).to eq submission.id
+    end
+  end
+
+  describe 'requests with a wrong userID and sessionId' do
+    let(:token) do
+      payload = { aud: 'gravity', sub: '', roles: 'user' }
+      JWT.encode(payload, Convection.config.jwt_secret)
+    end
+
+    let(:mutation_inputs) do
+      "{
+        clientMutationId: \"test\",
+        submissionID: #{submission.id},
+        sessionID: \"test-id\"
+        geminiToken: \"gemini-token-hash\"
+      }"
+    end
+
+    it 'does not alter the assets count and resolves with an error message' do
+      expect {
+        post '/api/graphql', params: { query: mutation }, headers: headers
+      }.to change(Asset, :count).by(0)
+
+      expect(response.status).to eq 200
+
+      body = JSON.parse(response.body)
+
+      error_message = body['errors'][0]['message']
+      expect(error_message).to eq 'Submission Not Found'
     end
   end
 end

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -14,7 +14,7 @@ describe 'Submission Flow' do
     expect(NotificationService).to receive(:post_submission_event).once
   end
 
-  it 'Completes 3' do
+  it 'Completes a submission from Tokyo' do
     stub_gravity_root
     stub_gravity_user
     stub_gravity_artist


### PR DESCRIPTION
### Description

Ticket: [SWA-100](https://artsyproduct.atlassian.net/browse/SWA-100)

This PR adds additional validation to addAsset mutations. The validation is done though sessionId associated with a user so that a user cannot add assets to another user's submission. 

### Implementation 

- matching_user method is moved from update_submission_resolver to the base resolver 
- matching_user is then utilised in add_asset and add_assets to_submission_resolver
- sessionId is added to those mutations as an argument
