### PR TITLE
Fix: remove session_id from assets creation resolver

### DIFF
--- a/app/graphql/resolvers/add_asset_to_submission_resolver.rb
+++ b/app/graphql/resolvers/add_asset_to_submission_resolver.rb
@@ -17,7 +17,7 @@ class AddAssetToSubmissionResolver < BaseResolver
 
     @arguments[:asset_type] ||= 'image'
 
-    asset = submission.assets.create!(@arguments)
+    asset = submission.assets.create!(@arguments.except(:session_id))
     SubmissionService.notify_user(submission.id) if submission.submitted?
 
     { asset: asset }


### PR DESCRIPTION
Error [here](https://sentry.io/organizations/artsynet/issues/2822536000/?project=270333&query=is%3Aunresolved)

happened due to the fact that the resolver is trying to create an Assets object by passing a session_id to it, while the session_id field is only in submission -> we get UnknownAttributeError

Solution: remove `session_id` from `Asset.create! `params

Same request right now worked for me:
<img width="1017" alt="Screen Shot 2021-12-03 at 4 17 53 PM" src="https://user-images.githubusercontent.com/21379857/144608864-ac75cfb5-2e69-4833-a5fd-affd32df456d.png">

