### PR TITLE
chore: rename master to main 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ not_staging_or_release: &not_staging_or_release
         - staging
         - release
 
-only_master: &only_master
+only_main: &only_main
   context: hokusai
   filters:
     branches:
-      only: master
+      only: main
 
 only_release: &only_release
   context: hokusai
@@ -30,7 +30,7 @@ only_dev: &only_dev
   filters:
     branches:
       ignore:
-        - master
+        - main
         - staging
         - release
 
@@ -72,12 +72,12 @@ workflows:
 
       - hokusai/push:
           name: push-staging-image
-          <<: *only_master
+          <<: *only_main
           requires:
             - hokusai/test
 
       - hokusai/deploy-staging:
-          <<: *only_master
+          <<: *only_main
           project-name: convection
           requires:
             - push-staging-image

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Convection is the application that powers our consignments workflow, enabling us
 - **Staging:** [https://convection-staging.artsy.net][staging] | [Kubernetes][staging_k8]
 - **GitHub:** [https://github.com/artsy/convection](https://github.com/artsy/convection)
 - **Point People:** [@jonallured]
-- **CI/Deploys:** [CircleCi](https://circleci.com/gh/artsy/convection); PRs merged to `artsy/convection#master` are automatically deployed to staging; PRs from `staging` to `release` are automatically deployed to production. Create such a PR with [`deploy_pr`][deploy_pr] or [this handy link][deploy].
+- **CI/Deploys:** [CircleCi](https://circleci.com/gh/artsy/convection); PRs merged to `artsy/convection#main` are automatically deployed to staging; PRs from `staging` to `release` are automatically deployed to production. Create such a PR with [`deploy_pr`][deploy_pr] or [this handy link][deploy].
 - **Cron Tasks:** A daily digest is sent to partners at 10am EST. The production database is exported Sunday mornings at 12am EST, and imported to staging Sunday mornings at 1am EST.
 
 ## Contributing Pull Requests
@@ -70,7 +70,7 @@ Step 1: In convection, run:
 $ rake graphql:schema:idl
 ```
 
-Step 2: Copy the generated `_schema.graphql` file to the [convection.graphql](https://github.com/artsy/metaphysics/blob/master/src/data/convection.graphql) file in [metaphysics](https://github.com/artsy/metaphysics).
+Step 2: Copy the generated `_schema.graphql` file to the [convection.graphql](https://github.com/artsy/metaphysics/blob/main/src/data/convection.graphql) file in [metaphysics](https://github.com/artsy/metaphysics).
 
 This file is used for stitching. See [docs/schema-stitching.md][schema-doc] for additional step you might need to do.
 

--- a/bin/update
+++ b/bin/update
@@ -25,8 +25,8 @@ END
 )
 
 current_branch=$(git branch --show-current)
-if [ "$current_branch" != "master" ]; then
-  echo "must be on master branch"
+if [ "$current_branch" != "main" ]; then
+  echo "must be on main branch"
   exit 1
 fi
 


### PR DESCRIPTION
https://www.notion.so/artsy/tricksy-rename-convection-f40d79cb71964ba8aed05dd3be9d2aee

As per [docs](https://github.com/artsy/README/blob/main/playbooks/rename-master-to-main.md).

To update local checkouts, developers should do:

```
git checkout master
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

---

Skipping [watt](https://github.com/artsy/convection/blob/c117481bc106887adcc9bb7ba5b14f87dd8bd029/Gemfile#L12) gem for now.