### PR TITLE
fix: filtering submissions by users doesn't work for all email addresses

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -154,6 +154,26 @@ module Admin
       respond_to { |format| format.json { render json: users || [] } }
     end
 
+    def match_user_by_contact_info
+      if params[:term]
+        term = params[:term]
+
+        # Exclude anonymous submissions from the submissions with a matching email
+        submissions =
+          Submission.where(user_email: term).where.not(user_id: nil).limit(1)
+        if submissions.empty?
+          users = []
+        else
+          user = {
+            id: submissions.first.user_id,
+            email: submissions.first.user_email
+          }
+          users = [user]
+        end
+      end
+      respond_to { |format| format.json { render json: users || [] } }
+    end
+
     private
 
     def set_submission

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails
     get '/match_artist', to: 'admin/submissions#match_artist'
     get '/match_artwork', to: 'admin/submissions#match_artwork'
     get '/match_user', to: 'admin/submissions#match_user'
+    get '/match_user_by_contact_info',
+        to: 'admin/submissions#match_user_by_contact_info'
     get '/match_partner', to: 'admin/partners#match_partner'
     get 'system/up'
 


### PR DESCRIPTION
Paired with @AlicanAkyuz 

This PR fixes a bug where admins were not able to filter the list off submissions (`/admin/submissions`) by a collector's email address. This was only happening for collectors who submitted artworks after we made the change to store contact information on the submission model instead of the user model.

The solution was to include contact information as a search criteria for users, and remove any duplicate users that may be found with the regular user search.