### PR TITLE
Fix: Timezone specs

### DIFF
--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -24,7 +24,7 @@ describe PartnerSubmissionService do
     stub_gravity_partner_communications
     stub_gravity_partner_contacts
     allow(Time).to receive(:now).and_return(
-      Time.new(2_017, 9, 27).in_time_zone('UTC')
+      Time.new(2_017, 9, 27, 12).in_time_zone('UTC')
     ) # stub time for email subject lines
     allow(Convection.config).to receive(:auction_offer_form_url).and_return(
       'https://google.com/auction'


### PR DESCRIPTION
I opened this PR due to timezone issues in tests, because my timezone is +3, the email send time becomes 26 Sept 21:00, while the expected date is 27 Sept, so I changed the send time to 12 hours of the day.
<img width="1586" alt="Screen Shot 2022-02-01 at 6 28 36 PM" src="https://user-images.githubusercontent.com/21379857/151998557-76f6cae3-b1cd-4344-9d7d-b0b3e5cb2632.png">

