### PR TITLE
[SWA-226] Fix detailed rejection emails with rejection reason are not being sent

### DIFF
--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -239,13 +239,19 @@ a.make-primary-link {
   pointer-events: none;
 }
 
-.offer-type-radio {
+.offer-type-radio,
+.submission-reason-radio{
   display: flex;
   justify-content: flex-start;
   align-items: center;
 
   input {
     width: 30px;
+  }
+
+  label {
+    margin-top: 10px;
+    margin-left: 5px;
   }
 }
 

--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -334,3 +334,9 @@ a.make-primary-link {
 .align-center {
   text-align: center;
 }
+
+@media (min-width: $screen-sm-min) {
+  .smaller-modal {
+    height: 500px !important;
+  }
+}

--- a/app/views/admin/submissions/_rejection_reasons_modal.html.erb
+++ b/app/views/admin/submissions/_rejection_reasons_modal.html.erb
@@ -16,7 +16,7 @@
           <div class='row'>
             <div class='col-md-12'>
               <% Submission::REJECTION_REASONS.each do |rejection_reason| %>
-                <div class='offer-type-radio'>
+                <div class='submission-reason-radio'>
                   <%= f.radio_button :rejection_reason, rejection_reason, checked: (rejection_reason == @submission.rejection_reason), class: 'form-control', required: true %>
                   <%= f.label :rejection_reason, rejection_reason, value: rejection_reason, class: 'control-label' %>
                 </div>

--- a/app/views/admin/submissions/_rejection_reasons_modal.html.erb
+++ b/app/views/admin/submissions/_rejection_reasons_modal.html.erb
@@ -1,0 +1,35 @@
+<div class='modal remodal' data-remodal-id='reject-reasons-modal'>
+  <div class='modal-header'>
+    <h3>
+      Please select a rejection reason
+    </h3>
+  </div>
+  <div class='modal-close'>
+    <%= link_to '', '#', id: 'reject-reason-close'%>
+  </div>
+  <div class='modal-content'>
+    <div class='single-padding-top'>
+      <p>An email will be sent to the consignor, letting them know that we are not accepting their submission. This action cannot be undone.</p>
+      <div class='col-sm-12'>
+        <%= form_for(@submission, url: admin_submission_path, method: :put) do |f| %>
+          <%= f.hidden_field :state, value: 'rejected' %>
+          <div class='row'>
+            <div class='col-md-12'>
+              <% Submission::REJECTION_REASONS.each do |rejection_reason| %>
+                <div class='offer-type-radio'>
+                  <%= f.radio_button :rejection_reason, rejection_reason, checked: (rejection_reason == @submission.rejection_reason), class: 'form-control' %>
+                  <%= f.label :rejection_reason, rejection_reason, value: rejection_reason, class: 'control-label' %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+          <div class='row triple-padding-top'>
+            <div class='col-md-12'>
+              <%= f.submit 'Save and Send', class: 'btn btn-primary btn-full-width' %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/submissions/_rejection_reasons_modal.html.erb
+++ b/app/views/admin/submissions/_rejection_reasons_modal.html.erb
@@ -17,7 +17,7 @@
             <div class='col-md-12'>
               <% Submission::REJECTION_REASONS.each do |rejection_reason| %>
                 <div class='offer-type-radio'>
-                  <%= f.radio_button :rejection_reason, rejection_reason, checked: (rejection_reason == @submission.rejection_reason), class: 'form-control' %>
+                  <%= f.radio_button :rejection_reason, rejection_reason, checked: (rejection_reason == @submission.rejection_reason), class: 'form-control', required: true %>
                   <%= f.label :rejection_reason, rejection_reason, value: rejection_reason, class: 'control-label' %>
                 </div>
               <% end %>

--- a/app/views/admin/submissions/_rejection_reasons_modal.html.erb
+++ b/app/views/admin/submissions/_rejection_reasons_modal.html.erb
@@ -1,4 +1,4 @@
-<div class='modal remodal' data-remodal-id='reject-reasons-modal'>
+<div class='modal remodal smaller-modal' data-remodal-id='reject-reasons-modal'>
   <div class='modal-header'>
     <h3>
       Please select a rejection reason

--- a/app/views/admin/submissions/_state_actions.html.erb
+++ b/app/views/admin/submissions/_state_actions.html.erb
@@ -5,7 +5,11 @@
     <% end %>
     <% @actions.each do |action| %>
       <div class='single-padding-top'>
-        <%= link_to(action[:text], admin_submission_path(@submission, submission: { state: action[:state] }), method: :put, class: action[:class], data: { confirm: action[:confirm] }) %>
+        <% if action[:state] == 'rejected' %>
+          <%= link_to(action[:text], '#', { 'data-remodal-target' => 'reject-reasons-modal', class: action[:class] }) %>
+        <% else %>
+          <%= link_to(action[:text], admin_submission_path(@submission, submission: { state: action[:state] }), method: :put, class: action[:class], data: { confirm: action[:confirm] }) %>
+        <% end %>
       </div>
     <% end %>
     <% if @submission.reviewed? %>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -64,6 +64,7 @@
                 <div class='bold-label single-padding-top'>Rejection reason:</div>
                 <div class='single-padding-top'>
                   <div id="update_rejection_reason" style="display: <%= @submission.rejection_reason.nil? ? 'block' : 'none' %>">
+                    <p>Sellers will not be notified of changes to rejection reasons.</p>
                     <%= form_with model: [:admin, @submission] do |f| %>
                       <% options = ['Please select one'] + Submission::REJECTION_REASONS %>
                       <div class="col-md-9">

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -53,6 +53,7 @@
             </div>
           </div>
           <%= render 'state_actions' %>
+          <%= render 'rejection_reasons_modal'%>
           <div class='overview-section'>
             <div class='bold-label'>State</div>
             <div class='single-padding-top'>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -66,9 +66,8 @@
                   <div id="update_rejection_reason" style="display: <%= @submission.rejection_reason.nil? ? 'block' : 'none' %>">
                     <p>Sellers will not be notified of changes to rejection reasons.</p>
                     <%= form_with model: [:admin, @submission] do |f| %>
-                      <% options = ['Please select one'] + Submission::REJECTION_REASONS %>
                       <div class="col-md-9">
-                        <%= f.select :rejection_reason, options, {}, class: 'form-control'%>
+                        <%= f.select :rejection_reason, Submission::REJECTION_REASONS, {}, class: 'form-control'%>
                       </div>
                       <div class="col-md-3">
                         <%= f.submit 'Update', id: 'update_rejection_reason', style: "height: 36px", onclick:"switchVisible('update_rejection_reason', 'edit_rejection_reason')"%>

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -365,10 +365,14 @@ describe 'admin/submissions/show.html.erb', type: :feature do
       it 'rejects a submission when the Reject button is clicked' do
         expect(page).to have_content('submitted')
         click_link 'Reject'
+        within('[data-remodal-id="reject-reasons-modal"]') do
+          choose('Fake')
+          click_button('Save and Send')
+        end
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
         expect(emails.first.html_part.body).to include(
-          'Our team of Specialists carefully review each submission'
+          'After extensive research, we are unable to find a record'
         )
         expect(page).to have_content 'Rejected by Jon Jonson'
         expect(page).to_not have_content 'Approve'


### PR DESCRIPTION
### What is the problem?
Convection has several templates for rejection emails that each correspond to a reason for which a submission can be rejected (artist submission, fake artwork, etc.)

In the current manual rejection flow, an email is sent before an admin has a chance to select a rejection reason. As a result, collectors receive the default rejection email template, which does not explain why their submission was rejected.

### Why does this matter?
One of our quarterly goals is to improve the NPS (net promoter score) of the Sell with Artsy flow, and user research shows that the shock of being rejected is a contributing factor to that low score.

### What is the solution?
When an admin manually rejects a submission, do not immediately schedule the email to be sent.

Send a rejection email when the rejection reason is updated on a submission instead.

### What should happen if an admin never selects a rejection reason?
We will update the rejection flow in Convection to show the rejection reasons after “Rejection” is clicked, and only send an email after one of the reasons is selected.

If an admin later updates the rejection reason after the initial rejection, we won’t send an email to the user, but we will update the submission in the database.
<hr/>

The solution we found after some iterations is to replace the current rejection flow with a modal. The modal will prevent us from having a rejected submission without a rejection reason.

https://user-images.githubusercontent.com/554507/153185815-d0510b16-0ec0-4be9-abe0-4867e357f4b2.mov

