### PR TITLE
[SWA-226] fix: disable hash tracking for the submission reject reason modal

### DIFF
--- a/app/views/admin/submissions/_rejection_reasons_modal.html.erb
+++ b/app/views/admin/submissions/_rejection_reasons_modal.html.erb
@@ -1,4 +1,4 @@
-<div class='modal remodal smaller-modal' data-remodal-id='reject-reasons-modal'>
+<div class='modal remodal smaller-modal' data-remodal-id='reject-reasons-modal' data-remodal-options="hashTracking: false">
   <div class='modal-header'>
     <h3>
       Please select a rejection reason


### PR DESCRIPTION
With this option enabled, when the user clicks to go back, there is no modal appearing anymore.

https://user-images.githubusercontent.com/554507/153845122-5c746e16-06eb-4c26-9b5d-07f8e9dcccde.mov

