### PR TITLE
Relax rate of requests to Unleash backend

### DIFF
--- a/config/initializers/unleash.rb
+++ b/config/initializers/unleash.rb
@@ -9,5 +9,10 @@ Convection.unleash =
     custom_http_headers: {
       'Authorization': Convection.config[:unleash_token]
     },
-    disable_client: Convection.config[:unleash_url].blank?
+    disable_client: Convection.config[:unleash_url].blank?,
+    instance_id: Socket.gethostname,
+    logger: Rails.logger,
+    environment: Rails.env,
+    metrics_interval: 60,
+    refresh_interval: 60
   )


### PR DESCRIPTION
After [incident #141](https://artsy.app.opsgenie.com/incident/detail/0f3fd6e1-9e57-40a5-a41b-92bc54a86356), we looked closely at the rate of requests between Unleash clients and the back-end, and were surprised at how aggressive the defaults were. This PR updates the Unleash client integration to re-fetch toggles at most every 60 seconds (per process) and send metrics back to the server at most every 60 seconds (as opposed to 10 and 30).

This PR also adds some identifying information, so logs and metrics can be associated back to the correct client and environment.

Similar updates elsewhere:
* https://github.com/artsy/gravity/pull/15028
* https://github.com/artsy/volt/pull/5744