### PR TITLE
Fix[SWA-262]: My collection artwork is not created if submission state is rejected

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -90,7 +90,8 @@ class SubmissionService
           submission.assign_attributes(
             reject_non_target_supply_artist(submission.artist_id)
           )
-          if submission.submitted? && submission.user && !access_token.nil? &&
+          if !submission.draft? && submission.user && !access_token.nil? &&
+               !submission.my_collection_artwork_id &&
                submission.user&.save_submission_to_my_collection?
             create_my_collection_artwork(submission, access_token)
           end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -461,6 +461,8 @@ describe SubmissionService do
       let(:access_token) { 'access_token' }
 
       before do
+        allow(SubmissionService).to receive(:deliver_rejection_notification)
+          .and_return(true)
         stub_gravity_artist(target_supply: true)
         allow(Metaql::Schema).to receive(:execute).and_return(response)
         allow_any_instance_of(User).to receive(

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -461,7 +461,7 @@ describe SubmissionService do
       let(:access_token) { 'access_token' }
 
       before do
-        allow(SubmissionService).to receive(:deliver_rejection_notification)
+        allow(NotificationService).to receive(:post_submission_event)
           .and_return(true)
         stub_gravity_artist(target_supply: true)
         allow(Metaql::Schema).to receive(:execute).and_return(response)


### PR DESCRIPTION
Resolve [SWA-262](https://artsyproduct.atlassian.net/browse/SWA-262)

My collection artwork must be created after the user is done with it, no matter what state it is in after the draft state.

Also added a check that if the artwork has already been created, then the next time the submission is updated, we will not create a second artwork

Add tests