### PR TITLE
Ensure trusted apps have that role

### DIFF
--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -21,7 +21,7 @@ class BaseResolver
   private
 
   def trusted_application?
-    @context[:current_application].present?
+    @context[:current_application].present? && @context[:current_user_roles].include?(:trusted)
   end
 
   def user?

--- a/spec/requests/api/graphql/mutations/create_consignment_offer_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_offer_spec.rb
@@ -8,7 +8,7 @@ describe 'createConsignmentOffer mutation' do
   let!(:submission) { Fabricate :submission, state: 'approved' }
 
   let(:token) do
-    payload = { aud: 'gravity', sub: 'userid', roles: 'user' }
+    payload = { aud: 'gravity', sub: 'userid', roles: 'admin' }
     JWT.encode(payload, Convection.config.jwt_secret)
   end
 


### PR DESCRIPTION
Unless I'm missing something I believe we are not checking for the `trusted` role for the GQL api on convection when the request comes from a client application. These two tests demonstrate my concerns.