### PR TITLE
[SWA-212] Trigger braze email campaign after a user completes a submission

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'artsy-eventservice' # for posting events to artsy event stream
 gem 'bootsnap', require: false # Speed up boot time by caching expensive operations.
 gem 'bootstrap-sass' # required for watt
 gem 'bourbon', '4.2.3' # required for watt
+gem 'braze_ruby'
 gem 'coffee-rails' # required for watt
 gem 'console_color'
 gem 'ddtrace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     bourbon (4.2.3)
       sass (~> 3.4)
       thor
+    braze_ruby (0.8.0)
+      faraday
     builder (3.2.4)
     bunny (2.17.0)
       amq-protocol (~> 2.3, >= 2.3.1)
@@ -505,6 +507,7 @@ DEPENDENCIES
   bootsnap
   bootstrap-sass
   bourbon (= 4.2.3)
+  braze_ruby
   capybara
   coffee-rails
   console_color

--- a/app/services/braze_service.rb
+++ b/app/services/braze_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class BrazeService
+  class << self
+    def send_swa_my_collection_email(submission_id)
+      submission = Submission.find(submission_id)
+      raise 'Still processing images.' unless submission.ready?
+
+      raise 'User lacks email.' if submission.email.blank?
+
+      recipient = [
+        {
+          external_user_id: submission.user.gravity_user_id,
+          trigger_properties: {
+            email_subject: '[TESTING] SWA Braze integration'
+          }
+        }
+      ]
+      braze_campaign_id = Convection.config.braze_campaign_id
+
+      BrazeApi.trigger_campaign_send(braze_campaign_id, recipient)
+    end
+  end
+end

--- a/app/workers/swa_my_collection_email_worker.rb
+++ b/app/workers/swa_my_collection_email_worker.rb
@@ -1,0 +1,7 @@
+class SwaMyCollectionEmailWorker
+  include Sidekiq::Worker
+
+  def perform(submission_id)
+    BrazeService.send_swa_my_collection_email(submission_id)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,7 @@ module Convection
         #{Rails.root.join('app', 'controllers', 'concerns')}
         #{Rails.root.join('app', 'models', 'concerns')}
         #{Rails.root.join('app', 'queries')}
+        #{Rails.root.join('app', 'workers')}
       ]
 
     # include JWT middleware

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -16,6 +16,9 @@ Convection.config =
       ENV['OFFER_RESPONSE_FORM_URL'] || 'https://foo.com',
     bcc_email_address:
       ENV['BCC_EMAIL_ADDRESS'] || 'consignments-archive@artsymail.com',
+    braze_api_key: ENV['BRAZE_API_KEY'],
+    braze_api_url: ENV['BRAZE_API_URL'],
+    braze_campaign_id: ENV['BRAZE_CAMPAIGN_ID'],
     cloudfront_url: ENV['CLOUDFRONT_URL'],
     consignment_communication_name:
       ENV['CONSIGNMENT_COMMUNICATION_NAME'] || 'Consignment Submissions',

--- a/lib/braze_api.rb
+++ b/lib/braze_api.rb
@@ -1,0 +1,47 @@
+class BrazeApi
+  class TryAgainError < StandardError
+  end
+
+  def self.generate_client
+    api_key = Convection.config.braze_api_key
+    api_url = Convection.config.braze_api_url
+
+    return unless api_key && api_url
+
+    BrazeRuby::API.new(api_key, api_url)
+  end
+
+  def self.client
+    @client ||= generate_client
+  end
+
+  def self.trigger_campaign_send(campaign_id, recipients)
+    return nil unless client
+
+    response =
+      client.trigger_campaign_send(
+        campaign_id: campaign_id,
+        recipients: recipients
+      )
+
+    handle_response(response)
+  end
+
+  def self.handle_response(response)
+    raise TryAgainError if (500...600).include?(response.status)
+
+    body =
+      begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError
+        { 'errors' => 'unable to parse response as json' }.freeze
+      end
+
+    if body['errors']
+      error_message = "Braze API Errors: #{body['errors']}"
+      Raven.capture_message(error_message)
+    end
+
+    body
+  end
+end

--- a/spec/lib/braze_api_spec.rb
+++ b/spec/lib/braze_api_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe BrazeApi do
+  describe '.handle_response' do
+    let(:response) do
+      double(:mock_response, body: response_body, status: response_status)
+    end
+
+    context 'with a 5xx response' do
+      let(:response_status) { 500 }
+      let(:response_body) { '' }
+
+      it 'raises TryAgainError' do
+        expect { BrazeApi.handle_response(response) }.to raise_error(
+          BrazeApi::TryAgainError
+        )
+      end
+    end
+
+    context 'with invalid json' do
+      let(:response_status) { 200 }
+      let(:response_body) { 'invalid json' }
+      let(:error_body) { { 'errors' => 'unable to parse response as json' } }
+
+      it 'rescues, sends error to Raven and returns an error hash' do
+        message = 'Braze API Errors: unable to parse response as json'
+        expect(Raven).to receive(:capture_message).with(message)
+        body = BrazeApi.handle_response(response)
+        expect(body).to eq(error_body)
+      end
+    end
+
+    context 'with valid json that includes an error' do
+      let(:response_status) { 200 }
+      let(:response_body) { { 'errors' => 'invalid API call' }.to_json }
+
+      it 'sends error to Raven and returns an error hash' do
+        message = 'Braze API Errors: invalid API call'
+        expect(Raven).to receive(:capture_message).with(message)
+        body = BrazeApi.handle_response(response)
+        expect(body.to_json).to eq response_body
+      end
+    end
+
+    context 'with valid json and no errors' do
+      let(:response_status) { 200 }
+      let(:response_body) { { 'message' => 'success' }.to_json }
+
+      it 'returns the parsed body' do
+        expect(Raven).to_not receive(:capture_message)
+        body = BrazeApi.handle_response(response)
+        expect(body.to_json).to eq response_body
+      end
+    end
+  end
+end

--- a/spec/services/braze_service_spec.rb
+++ b/spec/services/braze_service_spec.rb
@@ -31,7 +31,7 @@ describe BrazeService do
     context 'when submission is valid' do
       let(:gravity_user_id) { 'userid' }
       let(:email_subject) { '[TESTING] SWA Braze integration' }
-      let(:braze_campaign_id) { '244d6288-4f71-4c49-a6fb-9df00826550a' }
+      let(:braze_campaign_id) { Convection.config.braze_campaign_id }
       let(:submission) do
         Fabricate(
           :submission,

--- a/spec/services/braze_service_spec.rb
+++ b/spec/services/braze_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe BrazeService do
+  describe '#send_swa_my_collection_email' do
+    context 'when submission is not ready' do
+      let(:submission) { Fabricate(:submission) }
+
+      before do
+        allow_any_instance_of(Submission).to receive(:ready?).and_return(false)
+      end
+
+      it 'raises a Still processing images error' do
+        expect {
+          BrazeService.send_swa_my_collection_email(submission.id)
+        }.to raise_error('Still processing images.')
+      end
+    end
+
+    context 'when submission has no email' do
+      let(:submission) { Fabricate(:submission, user: nil, user_email: nil) }
+
+      it 'raises a User lacks email error' do
+        expect {
+          BrazeService.send_swa_my_collection_email(submission.id)
+        }.to raise_error('User lacks email.')
+      end
+    end
+
+    context 'when submission is valid' do
+      let(:gravity_user_id) { 'userid' }
+      let(:email_subject) { '[TESTING] SWA Braze integration' }
+      let(:braze_campaign_id) { '244d6288-4f71-4c49-a6fb-9df00826550a' }
+      let(:submission) do
+        Fabricate(
+          :submission,
+          user: Fabricate(:user, gravity_user_id: gravity_user_id)
+        )
+      end
+
+      let(:expected_recipient) do
+        [
+          {
+            external_user_id: gravity_user_id,
+            trigger_properties: {
+              email_subject: email_subject
+            }
+          }
+        ]
+      end
+
+      before do
+        allow(BrazeApi).to receive(:trigger_campaign_send).and_return(true)
+      end
+
+      it 'calls BrazeApi#trigger_campaign_send with the expected values' do
+        expect(BrazeApi).to receive(:trigger_campaign_send).with(
+          braze_campaign_id,
+          expected_recipient
+        )
+
+        BrazeService.send_swa_my_collection_email(submission.id)
+      end
+    end
+  end
+end

--- a/spec/workers/swa_my_collection_email_worker_spec.rb
+++ b/spec/workers/swa_my_collection_email_worker_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SwaMyCollectionEmailWorker, type: :workers do
+  describe 'perform' do
+    let(:submission_id) { '0' }
+
+    before do
+      allow(BrazeService).to receive(:send_swa_my_collection_email).and_return(
+        true
+      )
+    end
+
+    it 'calls BrazeService#send_swa_my_collection_email with the given submission_id' do
+      expect(BrazeService).to receive(:send_swa_my_collection_email).with(
+        submission_id
+      )
+
+      SwaMyCollectionEmailWorker.new.perform(submission_id)
+    end
+  end
+end


### PR DESCRIPTION
Note: _**This is a POC code, it should not be used in production. We don't have copies of the email subject and body yet.**_

This should cover the first case:

When an authenticated user submits an artwork
- and they have opted-in to receive marketing emails
  - and they already have the app, then they **receive** an email 24 hours after the submission was submitted that reminds them to see their artwork in My Collection.
  - and they do not have the app, then they **receive** an email 24 hours after the submission was submitted that reminds them to download the app and see their artwork in My Collection.
- and they have not opted-in to receive marketing emails, then they **never** receive an email that reminds them to download the app or see their artwork in My Collection.

TODO:

- [ ] Test on staging
  - [ ] Test a case where Braze doesn't yet have the user in the DB
- [ ] Upload the new `.env.shared` on both environments