### PR TITLE
feat(SWA-231): add source field to the submission model

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -506,6 +506,7 @@ input CreateSubmissionMutationInput {
   provenance: String
   sessionID: String
   signature: Boolean
+  source: SubmissionSource
 
   """
   If this artwork exists in Gravity, its ID
@@ -1923,6 +1924,16 @@ enum SubmissionSort {
   SOURCE_ARTWORK_ID_DESC
 
   """
+  sort by source in ascending order
+  """
+  SOURCE_ASC
+
+  """
+  sort by source in descending order
+  """
+  SOURCE_DESC
+
+  """
   sort by state in ascending order
   """
   STATE_ASC
@@ -2061,6 +2072,14 @@ enum SubmissionSort {
   sort by year in descending order
   """
   YEAR_DESC
+}
+
+enum SubmissionSource {
+  ADMIN
+  APP_INBOUND
+  MY_COLLECTION
+  PARTNER
+  WEB_INBOUND
 }
 
 """

--- a/app/graphql/mutations/create_submission_mutation.rb
+++ b/app/graphql/mutations/create_submission_mutation.rb
@@ -47,6 +47,7 @@ module Mutations
     argument :utm_medium, String, required: false
     argument :utm_term, String, required: false
     argument :sessionID, String, required: false
+    argument :source, Types::SubmissionSourceType, required: false
 
     field :consignment_submission, Types::SubmissionType, null: true
 

--- a/app/graphql/types/submission_source_type.rb
+++ b/app/graphql/types/submission_source_type.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  class SubmissionSourceType < Types::BaseEnum
+    Submission::SOURCES.map do |source|
+      value(source.upcase, nil, value: source)
+    end
+  end
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -32,6 +32,14 @@ class Submission < ApplicationRecord
     CLOSED = 'closed'
   ].freeze
 
+  SOURCES = [
+    WEB_INBOUND = 'web_inbound',
+    APP_INBOUND = 'app_inbound',
+    ADMIN = 'admin',
+    PARTNER = 'partner',
+    MY_COLLECTION = 'my_collection'
+  ].freeze
+
   enum attribution_class: {
          unique: 0,
          limited_edition: 1,
@@ -81,6 +89,7 @@ class Submission < ApplicationRecord
   belongs_to :consigned_partner_submission, class_name: 'PartnerSubmission'
 
   validates :state, inclusion: { in: STATES }
+  validates :source, inclusion: { in: SOURCES }, allow_nil: true
   validates :category, inclusion: { in: CATEGORIES }, allow_nil: true
   validates :dimensions_metric,
             inclusion: {

--- a/db/migrate/20220310110820_add_source_to_submissions.rb
+++ b/db/migrate/20220310110820_add_source_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddSourceToSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :submissions, :source, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_31_105557) do
+ActiveRecord::Schema.define(version: 2022_03_10_110820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pg_trgm'
   enable_extension 'pgcrypto'
@@ -223,9 +223,10 @@ ActiveRecord::Schema.define(version: 2022_01_31_105557) do
     t.string 'user_name'
     t.string 'user_phone'
     t.string 'session_id'
+    t.bigint 'admin_id'
     t.string 'my_collection_artwork_id'
     t.uuid 'uuid', default: -> { 'gen_random_uuid()' }, null: false
-    t.bigint 'admin_id'
+    t.string 'source'
     t.index ['consigned_partner_submission_id'],
             name: 'index_submissions_on_consigned_partner_submission_id'
     t.index ['ext_user_id'], name: 'index_submissions_on_ext_user_id'

--- a/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
@@ -139,5 +139,18 @@ describe 'createConsignmentSubmission mutation' do
         expect(submission.user_agent).to eq 'something, something'
       end
     end
+
+    context 'with provided source' do
+      let(:mutation_inputs) { '{ artistID: "andy", source: WEB_INBOUND }' }
+
+      it 'creates a submission with correct source' do
+        post '/api/graphql', params: { query: mutation }, headers: headers
+
+        expect(response.status).to eq 200
+        submission = Submission.first
+
+        expect(submission.source).to eq 'web_inbound'
+      end
+    end
   end
 end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -29,8 +29,19 @@ describe SubmissionService do
         title: 'My Artwork',
         user_name: 'michael',
         user_email: 'michael@bluth.com',
-        user_phone: '555-5555'
+        user_phone: '555-5555',
+        source: 'web_inbound'
       }
+    end
+
+    it 'creates a submission with correct source' do
+      new_submission =
+        SubmissionService.create_submission(
+          params,
+          'userid',
+          is_convection: false
+        )
+      expect(new_submission.reload.source).to eq 'web_inbound'
     end
 
     it 'creates a submission with state Rejected when artist is not in target supply' do


### PR DESCRIPTION
This PR adds `source` field to help data team identify the place of where submission was created. 

JIRA - https://artsyproduct.atlassian.net/browse/SWA-231, https://artsyproduct.atlassian.net/browse/SWA-232

![image](https://user-images.githubusercontent.com/79979820/157673651-dcd08a64-404a-4403-9102-5eca47aba4d9.png)
