### PR TITLE
[dev]: add new env var to the config

### DIFF
--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -53,5 +53,5 @@ Convection.config =
       ENV['VIBRATIONS_URL'] || 'https://admin-partners-staging.artsy.net',
     unleash_url: ENV['UNLEASH_URL'],
     unleash_token: ENV['UNLEASH_TOKEN'],
-    send_new_receipt_email: ENV['SEND_NEW_RECEIPT_EMAIL'] || 'false'
+    send_new_receipt_email: ENV['SEND_NEW_RECEIPT_EMAIL'] == 'true'
   )

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -53,5 +53,5 @@ Convection.config =
       ENV['VIBRATIONS_URL'] || 'https://admin-partners-staging.artsy.net',
     unleash_url: ENV['UNLEASH_URL'],
     unleash_token: ENV['UNLEASH_TOKEN'],
-    send_new_receipt_email: ENV['SEND_NEW_RECEIPT_EMAIL'] || ‘false’
+    send_new_receipt_email: ENV['SEND_NEW_RECEIPT_EMAIL'] || 'false'
   )

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -52,5 +52,6 @@ Convection.config =
     vibrations_url:
       ENV['VIBRATIONS_URL'] || 'https://admin-partners-staging.artsy.net',
     unleash_url: ENV['UNLEASH_URL'],
-    unleash_token: ENV['UNLEASH_TOKEN']
+    unleash_token: ENV['UNLEASH_TOKEN'],
+    send_new_receipt_email: ENV[‘SEND_NEW_RECEIPT_EMAIL’] || ‘false’
   )

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -53,5 +53,5 @@ Convection.config =
       ENV['VIBRATIONS_URL'] || 'https://admin-partners-staging.artsy.net',
     unleash_url: ENV['UNLEASH_URL'],
     unleash_token: ENV['UNLEASH_TOKEN'],
-    send_new_receipt_email: ENV[‘SEND_NEW_RECEIPT_EMAIL’] || ‘false’
+    send_new_receipt_email: ENV['SEND_NEW_RECEIPT_EMAIL'] || ‘false’
   )


### PR DESCRIPTION
### Description 

This PR adds our new ENV variable to the config file. This new ENV is set to true on staging and false on production, and it will be utilised to determine whether or not we send a new version of receipt email (which'll encourage anonymous visitor to create an account with Artsy) after a submission is completed. 