### PR TITLE
[feat]: AlicanAkyuz/swa 296/update receipt email with link to artsy.net for anonymous subs

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -6,6 +6,8 @@ class UserMailer < ApplicationMailer
   def submission_receipt(submission:, artist:)
     @submission = submission
     @artist = artist
+    @inject_create_account_section = Convection.config.send_new_receipt_email
+
     @utm_params =
       utm_params(
         source: 'consignment-receipt',

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -20,6 +20,17 @@
                   <p>Our team of specialists will review your work to evaluate whether we currently have a suitable market for it. If your work is accepted, we’ll send you a sales offer and guide you in choosing the best option for selling it.</p>
                 </td>
               </tr>
+
+              <%# inject section with a link to Artsy web with submission ID for anonymous visitors %>
+              <% if @submission.user_id.nil? && Convection.config.send_new_receipt_email %>
+                <tr>
+                  <td class='email-sub-title'>
+                    <p>You’ll need an Artsy account in order to find your artwork in My Collection, along with related art market insights.</p>
+                    <p>Simply <%= link_to 'sign up or log in to Artsy', "https://www.artsy.net?submissionId=#{@submission.id}", target: :_blank %> with the same email you used for this submission and visit our app.</p>
+                  </td>
+                </tr>
+              <% end %>
+
               <tr>
                 <td>
                   <%= render 'shared/email/submission_block', submission: @submission %>

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -26,7 +26,7 @@
                 <tr>
                   <td class='email-sub-title'>
                     <p>You’ll need an Artsy account in order to find your artwork in My Collection, along with related art market insights.</p>
-                    <p>Simply <%= link_to 'sign up or log in to Artsy', "https://www.artsy.net?submissionId=#{@submission.id}", target: :_blank %> with the same email you used for this submission and visit our app.</p>
+                    <p>Simply <%= link_to 'sign up or log in to Artsy', "https://www.artsy.net/signup?submissionId=#{@submission.id}", target: :_blank %> with the same email you used for this submission and visit our app.</p>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -26,7 +26,7 @@
                 <tr>
                   <td class='email-sub-title'>
                     <p>You’ll need an Artsy account in order to find your artwork in My Collection, along with related art market insights.</p>
-                    <p>Simply <%= link_to 'sign up or log in to Artsy', "https://www.artsy.net/signup?submissionId=#{@submission.id}", target: :_blank %> with the same email you used for this submission and visit our app.</p>
+                    <p>Simply <%= link_to 'sign up', "https://www.artsy.net/signup?submissionId=#{@submission.id}", target: :_blank %> or <%= link_to 'sign up', "https://www.artsy.net/login?submissionId=#{@submission.id}", target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -22,7 +22,7 @@
               </tr>
 
               <%# inject section with a link to Artsy web with submission ID for anonymous visitors %>
-              <% if @submission.user_id.nil? && Convection.config.send_new_receipt_email %>
+              <% if @submission.user_id.nil? && @inject_create_account_section %>
                 <tr>
                   <td class='email-sub-title'>
                     <p>You’ll need an Artsy account in order to find your artwork in My Collection, along with related art market insights.</p>

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -26,7 +26,7 @@
                 <tr>
                   <td class='email-sub-title'>
                     <p>You’ll need an Artsy account in order to find your artwork in My Collection, along with related art market insights.</p>
-                    <p>Simply <%= link_to 'sign up', "https://www.artsy.net/signup?submissionId=#{@submission.id}", target: :_blank %> or <%= link_to 'sign up', "https://www.artsy.net/login?submissionId=#{@submission.id}", target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
+                    <p>Simply <%= link_to 'sign up', "https://www.artsy.net/signup?submissionId=#{@submission.id}", target: :_blank %> or <%= link_to 'log in', "https://www.artsy.net/login?submissionId=#{@submission.id}", target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
                   </td>
                 </tr>
               <% end %>


### PR DESCRIPTION
### Description 

Ticket: [[SWA-296](https://artsyproduct.atlassian.net/browse/SWA-296)]

This PR adds a conditionally rendered section to the receipt email. The section is added to the email body if the submission is by an anonymous visitor and the required ENV configured to allow it. The section includes a link to our frontend with the submissionID in the params. 