### PR TITLE
feat: Set artwork submission ID when submitting artworks from My Collection

### DIFF
--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -194,7 +194,7 @@ module GraphqlHelper
   def my_collection_create_artwork_mutation_params(submission)
     {
       submissionId: submission.id.to_s,
-      importSource: 'convection',
+      importSource: 'CONVECTION',
       artistIds: [submission.artist_id],
       artworkLocation:
         [

--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -39,6 +39,32 @@ module GraphqlHelper
     GQL
   end
 
+  def my_collection_update_artwork_mutation_builder
+    <<~GQL
+      mutation myCollectionUpdateArtworkMutation(
+        $input: MyCollectionUpdateArtworkInput!
+      ) {
+        myCollectionUpdateArtwork(input: $input) {
+          artworkOrError {
+            __typename
+            ... on MyCollectionArtworkMutationSuccess {
+              artworkEdge {
+                node {
+                  internalID
+                }
+              }
+            }
+            ... on MyCollectionArtworkMutationFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    GQL
+  end
+
   def create_my_collection_artwork(submission, access_token)
     response =
       Metaql::Schema.execute(
@@ -75,6 +101,32 @@ module GraphqlHelper
           :internalID
         )
     )
+  end
+
+  def update_my_collection_artwork(submission, access_token)
+    response =
+      Metaql::Schema.execute(
+        query: my_collection_update_artwork_mutation_builder,
+        access_token: access_token,
+        variables: {
+          input: my_collection_update_artwork_mutation_params(submission)
+        }
+      )
+
+    if response[:errors].present?
+      Rails
+        .logger.error "API error updating submission artwork in My Collection: #{response[:errors]}"
+
+      return nil
+    end
+
+    # prettier-ignore
+    if response.dig(:data, :myCollectionUpdateArtwork, :artworkOrError, :mutationError)
+      error_message = response.dig(:data, :myCollectionUpdateArtwork, :artworkOrError, :mutationError, :message)
+      Rails.logger.error "GraphQL error updating submission artwork in My Collection: #{error_message}"
+
+      nil
+    end
   end
 
   MATCH_PARTNERS_QUERY =
@@ -142,6 +194,7 @@ module GraphqlHelper
   def my_collection_create_artwork_mutation_params(submission)
     {
       submissionId: submission.id.to_s,
+      importSource: 'convection',
       artistIds: [submission.artist_id],
       artworkLocation:
         [
@@ -165,6 +218,13 @@ module GraphqlHelper
       provenance: submission.provenance,
       title: submission.title,
       width: submission.width
+    }
+  end
+
+  def my_collection_update_artwork_mutation_params(submission)
+    {
+      artworkId: submission.my_collection_artwork_id,
+      submissionId: submission.id.to_s,
     }
   end
 end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -93,11 +93,12 @@ class SubmissionService
             reject_non_target_supply_artist(submission.artist_id)
           )
           if !submission.draft? && submission.user && !access_token.nil? &&
-               !submission.my_collection_artwork_id &&
                submission.user&.save_submission_to_my_collection?
-            create_my_collection_artwork(submission, access_token)
-          elsif submission.source == "my_collection"
-            update_my_collection_artwork(submission, access_token)
+            if !submission.my_collection_artwork_id
+              create_my_collection_artwork(submission, access_token)
+            elsif submission.source == "my_collection"
+              update_my_collection_artwork(submission, access_token)
+            end
           end
         end
 

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -94,17 +94,21 @@ class SubmissionService
           )
           if !submission.draft? && submission.user && !access_token.nil? &&
                submission.user&.save_submission_to_my_collection?
-            if !submission.my_collection_artwork_id
-              create_my_collection_artwork(submission, access_token)
-            elsif submission.source == "my_collection"
-              update_my_collection_artwork(submission, access_token)
-            end
+            create_or_update_my_collection_artwork(submission, access_token)
           end
         end
 
         update_submission_state(submission, current_user)
       end
       submission.save!
+    end
+
+    def create_or_update_my_collection_artwork(submission, access_token)
+      if !submission.my_collection_artwork_id
+        create_my_collection_artwork(submission, access_token)
+      elsif submission.source == "my_collection"
+        update_my_collection_artwork(submission, access_token)
+      end
     end
 
     def update_submission_state(submission, current_user)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -99,7 +99,6 @@ class SubmissionService
           elsif submission.source == "my_collection"
             update_my_collection_artwork(submission, access_token)
           end
-
         end
 
         update_submission_state(submission, current_user)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -96,7 +96,10 @@ class SubmissionService
                !submission.my_collection_artwork_id &&
                submission.user&.save_submission_to_my_collection?
             create_my_collection_artwork(submission, access_token)
+          elsif submission.source == "my_collection"
+            update_my_collection_artwork(submission, access_token)
           end
+
         end
 
         update_submission_state(submission, current_user)

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -593,19 +593,47 @@ describe SubmissionService do
         expect(submission.my_collection_artwork_id).to eq nil
       end
 
-      it 'does not create my collection artwork if my collection artwork already exists' do
-        submission.my_collection_artwork_id = '2'
+      context 'when my collection artwork already exists' do
+        subject(:update_submission) do
+          SubmissionService.update_submission(
+            submission,
+            { state: 'submitted' },
+            current_user: 'userid',
+            is_convection: false,
+            access_token: access_token
+          )
+        end
 
-        SubmissionService.update_submission(
-          submission,
-          { state: 'submitted' },
-          current_user: 'userid',
-          is_convection: false,
-          access_token: access_token
-        )
+        before do
+          submission.update(my_collection_artwork_id: '2')
+        end
 
-        expect(submission.state).to eq 'submitted'
-        expect(submission.my_collection_artwork_id).to eq '2'
+        it 'does not create my collection artwork' do
+          update_submission
+
+          expect(submission.state).to eq 'submitted'
+          expect(submission.my_collection_artwork_id).to eq '2'
+        end
+
+        context 'when source is my collection' do
+          before do
+            submission.update(source: 'my_collection')
+          end
+
+          it 'sets submission_id for my collection artwork' do
+            expect(SubmissionService).to receive(:update_my_collection_artwork)
+
+            update_submission
+          end
+        end
+
+        context 'when source is not my collection' do
+          it 'does not set submission_id for my collection artwork' do
+            expect(SubmissionService).to_not receive(:update_my_collection_artwork)
+
+            update_submission
+          end
+        end
       end
 
       context 'with errors from gravity' do

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -593,7 +593,7 @@ describe SubmissionService do
         expect(submission.my_collection_artwork_id).to eq nil
       end
 
-      context 'when my collection artwork already exists' do
+      context 'when a My Collection artwork already exists' do
         subject(:update_submission) do
           SubmissionService.update_submission(
             submission,
@@ -608,27 +608,27 @@ describe SubmissionService do
           submission.update(my_collection_artwork_id: '2')
         end
 
-        it 'does not create my collection artwork' do
+        it 'does not create a My Collection artwork' do
           update_submission
 
           expect(submission.state).to eq 'submitted'
           expect(submission.my_collection_artwork_id).to eq '2'
         end
 
-        context 'when source is my collection' do
+        context 'when the submission source is my_collection' do
           before do
             submission.update(source: 'my_collection')
           end
 
-          it 'sets submission_id for my collection artwork' do
+          it 'updates the My Collection artwork to set the submission ID' do
             expect(SubmissionService).to receive(:update_my_collection_artwork)
 
             update_submission
           end
         end
 
-        context 'when source is not my collection' do
-          it 'does not set submission_id for my collection artwork' do
+        context 'when source is not my_collection' do
+          it 'does not updates the My Collection artwork ' do
             expect(SubmissionService).to_not receive(:update_my_collection_artwork)
 
             update_submission


### PR DESCRIPTION
Addresses [CX-2454]

## Description

We need to set the submission ID on My Collection artworks when the submission was created from a My Collectio artwork.

**Note to reviewers:** Could you please test the change locally as well? Thanks :)

[CX-2454]: https://artsyproduct.atlassian.net/browse/CX-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ