### PR TITLE
[WIP] Launch My Collection Integration for All Users

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -93,8 +93,7 @@ class SubmissionService
             reject_non_target_supply_artist(submission.artist_id)
           )
           if !submission.draft? && submission.user && !access_token.nil? &&
-               !submission.my_collection_artwork_id &&
-               submission.user&.save_submission_to_my_collection?
+               !submission.my_collection_artwork_id
             create_my_collection_artwork(submission, access_token)
           end
         end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -576,7 +576,7 @@ describe SubmissionService do
         expect(submission.my_collection_artwork_id).to eq nil
       end
 
-      it 'does not create my collection artwork if user cannot save submission to my collection' do
+      it 'creates my collection artwork regardless of feature flag' do
         allow_any_instance_of(User).to receive(
           :save_submission_to_my_collection?
         ).and_return(false)
@@ -590,7 +590,7 @@ describe SubmissionService do
         )
 
         expect(submission.state).to eq 'submitted'
-        expect(submission.my_collection_artwork_id).to eq nil
+        expect(submission.my_collection_artwork_id).to_not eq nil
       end
 
       it 'does not create my collection artwork if my collection artwork already exists' do


### PR DESCRIPTION
This PR removes the check for the `swa_my_collection` Unleash feature flag that occurs before Convection asks Gravity to create an artwork in My Collection when a submission is received. This will effectively launch the My Collection integration for all Artsy users.

The feature flag will still remain in Unleash and in the Convection code after this change, and can be removed at a later date.