### PR TITLE
chore: upgrade sidekiq from 6.4.0 to 6.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,7 +440,7 @@ GEM
       faraday (>= 1.0)
     sexp_processor (4.15.2)
     shellany (0.0.1)
-    sidekiq (6.4.0)
+    sidekiq (6.4.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)


### PR DESCRIPTION
I am upgrading the version of sidekiq to remove a deprecation warning that is filling up our logs:

```
$ Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.
$ redis.multi do
$   redis.get("key")
$ end
$ should be replaced by
$ redis.multi do |pipeline|
$   pipeline.get("key")
$ end
$ (called from /usr/local/bundle/gems/sidekiq-6.4.0/lib/sidekiq/launcher.rb:164:in `block in ❤'}
```

This was [fixed](https://github.com/mperham/sidekiq/pull/5139) in version 6.4.1 of sidekiq. After upgrading, I confirmed that the deprecation warning was no longer appearing in local logs, and ran the test suite.