### PR TITLE
feat: check user email from gravity instead of args

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -67,7 +67,6 @@ input AddUserToSubmissionMutationInput {
   """
   clientMutationId: String
   id: ID!
-  userEmail: String!
 }
 
 """

--- a/app/graphql/mutations/add_user_to_submission_mutation.rb
+++ b/app/graphql/mutations/add_user_to_submission_mutation.rb
@@ -2,7 +2,6 @@
 
 module Mutations
   class AddUserToSubmissionMutation < Mutations::BaseMutation
-    argument :user_email, String, required: true
     argument :id, ID, required: true
 
     field :consignment_submission, Types::SubmissionType, null: true

--- a/app/graphql/resolvers/add_user_to_submission_resolver.rb
+++ b/app/graphql/resolvers/add_user_to_submission_resolver.rb
@@ -6,8 +6,8 @@ class AddUserToSubmissionResolver < BaseResolver
   def run
     check_submission_presence!
 
-    # check if user_email in incoming args matches to the one on the submission
-    unless matching_email(submission, @arguments&.[](:user_email))
+    # check if user's email in Gravity matches the one on the submission
+    unless matching_email(submission)
       raise(GraphQL::ExecutionError, 'Submission not found for this user')
     end
 

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -42,8 +42,9 @@ class BaseResolver
       submitted_by_current_session?(submission, session_id)
   end
 
-  def matching_email(submission, user_email)
-    submission.user_email.downcase == user_email.downcase
+  def matching_email(submission)
+    user = Gravity.client.user(id: @context[:current_user]).user_detail._get
+    submission.user_email.downcase == user.email
   end
 
   def submitted_by_current_user?(submission)

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -47,7 +47,7 @@ class BaseResolver
       user = Gravity.client.user(id: @context[:current_user]).user_detail._get
       submission.user_email.downcase == user.email
     rescue StandardError
-      Rails.logger.info 'Unable match user email with submission email'
+      Rails.logger.info 'Unable to match user email with submission email'
       nil
     end
   end

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -43,8 +43,13 @@ class BaseResolver
   end
 
   def matching_email(submission)
-    user = Gravity.client.user(id: @context[:current_user]).user_detail._get
-    submission.user_email.downcase == user.email
+    begin
+      user = Gravity.client.user(id: @context[:current_user]).user_detail._get
+      submission.user_email.downcase == user.email
+    rescue StandardError
+      Rails.logger.info 'Unable match user email with submission email'
+      nil
+    end
   end
 
   def submitted_by_current_user?(submission)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -320,11 +320,12 @@ class SubmissionService
     end
 
     def add_user_to_submission(submission, gravity_user_id, access_token)
+      # add user to submission when user is present and ENV for the feature allows
       if gravity_user_id.present? && Convection.config.send_new_receipt_email
         user = User.find_or_create_by(gravity_user_id: gravity_user_id)
         submission.update!(user_id: user&.id)
 
-        # "send_new_receipt_email" is here for us to test the feature on staging
+        # create artwork in user's collection
         if !access_token.nil? && !submission.my_collection_artwork_id
           create_my_collection_artwork(submission, access_token)
         end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -320,13 +320,12 @@ class SubmissionService
     end
 
     def add_user_to_submission(submission, gravity_user_id, access_token)
-      if gravity_user_id.present?
+      if gravity_user_id.present? && Convection.config.send_new_receipt_email
         user = User.find_or_create_by(gravity_user_id: gravity_user_id)
         submission.update!(user_id: user&.id)
 
         # "send_new_receipt_email" is here for us to test the feature on staging
-        if !access_token.nil? && !submission.my_collection_artwork_id &&
-             Convection.config.send_new_receipt_email
+        if !access_token.nil? && !submission.my_collection_artwork_id
           create_my_collection_artwork(submission, access_token)
         end
       end


### PR DESCRIPTION
### Description 

This PR improves on security concerns with regards to adding a user to anonymously submitted submissions by: 
- checking the match between the email address on the submission and user's gravity record