### PR TITLE
[SWA-323] chore: remove swa_my_collection unleash flag

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,13 +37,6 @@ class User < ApplicationRecord
     user_detail&.phone
   end
 
-  def save_submission_to_my_collection?
-    Convection.unleash.enabled?(
-      'swa_my_collection',
-      Unleash::Context.new(user_id: gravity_user_id.to_s)
-    )
-  end
-
   def user_detail
     gravity_user&.user_detail&._get
   rescue Faraday::ResourceNotFound

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -92,8 +92,7 @@ class SubmissionService
           submission.assign_attributes(
             reject_non_target_supply_artist(submission.artist_id)
           )
-          if !submission.draft? && submission.user && !access_token.nil? &&
-               submission.user&.save_submission_to_my_collection?
+          if !submission.draft? && submission.user && !access_token.nil?
             create_or_update_my_collection_artwork(submission, access_token)
           end
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,25 +89,4 @@ describe User do
       end
     end
   end
-
-  describe '#save_submission_to_my_collection?' do
-    it 'returns the result of the swa_my_collection feature toggle' do
-      expect(Unleash::Context).to receive(:new)
-        .with(user_id: user.gravity_user_id.to_s)
-        .and_return('unleash_context_mock')
-        .twice
-
-      expect(Convection.unleash).to receive(:enabled?)
-        .with('swa_my_collection', 'unleash_context_mock')
-        .and_return(true)
-        .once
-      expect(user.save_submission_to_my_collection?).to eq(true)
-
-      expect(Convection.unleash).to receive(:enabled?)
-        .with('swa_my_collection', 'unleash_context_mock')
-        .and_return(false)
-        .once
-      expect(user.save_submission_to_my_collection?).to eq(false)
-    end
-  end
 end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -560,9 +560,6 @@ describe SubmissionService do
           .and_return(true)
         stub_gravity_artist(target_supply: true)
         allow(Metaql::Schema).to receive(:execute).and_return(response)
-        allow_any_instance_of(User).to receive(
-          :save_submission_to_my_collection?
-        ).and_return(true)
       end
 
       it 'create my collection artwork if artwork rejected(target supply)' do
@@ -624,23 +621,6 @@ describe SubmissionService do
 
       it 'does not create my collection artwork if no user' do
         submission.user = nil
-
-        SubmissionService.update_submission(
-          submission,
-          { state: 'submitted' },
-          current_user: 'userid',
-          is_convection: false,
-          access_token: access_token
-        )
-
-        expect(submission.state).to eq 'submitted'
-        expect(submission.my_collection_artwork_id).to eq nil
-      end
-
-      it 'does not create my collection artwork if user cannot save submission to my collection' do
-        allow_any_instance_of(User).to receive(
-          :save_submission_to_my_collection?
-        ).and_return(false)
 
         SubmissionService.update_submission(
           submission,
@@ -758,8 +738,6 @@ describe SubmissionService do
 
     it 'updates submission to Submitted state when submission state changed and artist is in target supply' do
       stub_gravity_artist(target_supply: true)
-      allow(submission.user).to receive(:save_submission_to_my_collection?)
-        .and_return(nil)
 
       expect(NotificationService).to receive(:post_submission_event)
         .once


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/SWA-323

Remove all code related to the swa_my_collection unleash flag.

> Remove the environment variable from Convection
Remove code associated with the environment variable from Convection

The unleash env vars are related to the integration, there is no env var for this specific flag.

- [ ] archive the flag in unleash once this is merged