### PR TITLE
[SWA-320] Instrument convections sidekiq jobs for datadog

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -15,4 +15,5 @@ Datadog.configure do |c|
         cache_service: 'convection.cache'
   c.use :redis, service_name: 'convection.redis'
   c.use :http, service_name: 'convection.http', distributed_tracing: true
+  c.use :sidekiq, service_name: 'convection.sidekiq'
 end

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -203,7 +203,7 @@ spec:
         env:
         - name: MALLOC_ARENA_MAX
           value: '2'
-        - name: DD_TRACE_AGENT_HOSTNAME
+        - name: DATADOG_TRACE_AGENT_HOSTNAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName


### PR DESCRIPTION
Let's see if this is enough to send Sidekiq data to datadog.
From what I saw in other repos, this is enough, but we may need to install and configure `gem install dogstatsd-ruby` 
https://artsyproduct.atlassian.net/browse/SWA-320