### PR TITLE
fix: revert yarn/node orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 orbs:
   hokusai: artsy/hokusai@volatile
   horizon: artsy/release@volatile
-  node: artsy/node@volatile
+  node: artsy/node@2.1.0
   slack: circleci/slack@4.9.3
-  yarn: artsy/yarn@volatile
+  yarn: artsy/yarn@6.1.0
 
 not_staging_or_release: &not_staging_or_release
   filters:


### PR DESCRIPTION
bumped these orbs version to latest in https://github.com/artsy/convection/pull/1307, not realizing project is still on old node version. undo.