### PR TITLE
feat: swap submission Id with uuid in email templates sent to users

### DIFF
--- a/app/views/user_mailer/non_target_supply_artist_rejected.html.erb
+++ b/app/views/user_mailer/non_target_supply_artist_rejected.html.erb
@@ -17,7 +17,7 @@
 
             <% if Convection.config.send_new_receipt_email %>
               <p>To keep an eye on demand for this piece, you’ll need an Artsy account, so you can access <span style="text-decoration:underline">My Collection.</span></p>
-              <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.id }), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.id }), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
+              <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.uuid }), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.uuid }), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
               <p>You’ll find the artwork in My Collection, along with related art market insights.</p>
             <% end %>
 

--- a/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
+++ b/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
@@ -17,7 +17,7 @@
 
             <% if Convection.config.send_new_receipt_email %>
               <p>To keep an eye on demand for this piece, you’ll need an Artsy account, so you can access <span style="text-decoration:underline">My Collection.</span></p>
-              <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.id }), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.id }), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
+              <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.uuid }), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.uuid }), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
               <p>You’ll find the artwork in My Collection, along with related art market insights.</p>
             <% end %>
 

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -21,7 +21,7 @@
                 
                   <% if Convection.config.send_new_receipt_email %>
                     <p>You’ll need an Artsy account in order to find your artwork in <span style="text-decoration:underline">My Collection</span>, along with related art market insights.</p>
-                    <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.id }), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.id }), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
+                    <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.uuid }), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.uuid }), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
                   <% end %>
                 </td>
               </tr>


### PR DESCRIPTION
### Description 

This PR is replacing submissionId with submission's uuid in 3 transactional email templates that invite users to sign up or log in to Artsy in order to associate anonymous submission with the user. 