### PR TITLE
chore: remove unused orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2.1
 orbs:
   hokusai: artsy/hokusai@volatile
   horizon: artsy/release@volatile
-  node: artsy/node@2.1.0
   slack: circleci/slack@4.9.3
   yarn: artsy/yarn@6.1.0
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ orbs:
   hokusai: artsy/hokusai@volatile
   horizon: artsy/release@volatile
   slack: circleci/slack@4.9.3
-  yarn: artsy/yarn@6.1.0
 
 not_staging_or_release: &not_staging_or_release
   filters:


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4129


Convection CI pipeline is not using either `artsy/node` or `artsy/yarn` orbs. This removes the unused orb refs.