### PR TITLE
check uuid before it to prevent submission find by match between uuid…

### DIFF
--- a/app/graphql/resolvers/concerns/resolvers/submissionable.rb
+++ b/app/graphql/resolvers/concerns/resolvers/submissionable.rb
@@ -12,9 +12,9 @@ module Resolvers::Submissionable
 
   def submission
     @submission ||=
-      Submission.find_by(id: submission_id) ||
-        Submission.find_by(uuid: external_submission_id) ||
-        Submission.find_by(uuid: submission_id)
+      Submission.find_by(uuid: submission_id) ||
+        Submission.find_by(id: submission_id) ||
+        Submission.find_by(uuid: external_submission_id)
   end
 
   def valid?


### PR DESCRIPTION
### Description 

This PR attempts to find a submission by UUID before trying to find it by ID. 

The reason is that when a client makes a request with UUID to find the submission, and part of the UUID matches submission_id of another submission, the code returns that submission. 