### PR TITLE
fix: Calls SF after saving approval

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -178,9 +178,9 @@ class SubmissionService
     end
 
     def approve!(submission, current_user)
-      SalesforceService.delay.add_artwork(submission.id)
-      
       submission.update!(approved_by: current_user, approved_at: Time.now.utc)
+
+      SalesforceService.delay.add_artwork(submission.id)
       NotificationService.delay.post_submission_event(
         submission.id,
         SubmissionEvent::APPROVED


### PR DESCRIPTION
We're not receiving the proper owner in SF when approving for convection, changing the order of the service calls should solve the issue