### PR TITLE
fix: truncate salesforce name due to char limit

### DIFF
--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -40,7 +40,8 @@ class SalesforceService
 
     def map_submission_to_salesforce_artwork(submission, contact_id, artist_id)
       {
-        Name: submission.title,
+        Name: submission.title[0..79],
+        Artwork_Title__c: submission.title,
         Seller_Contact__c: contact_id,
         Primary_Artist__c: artist_id,
         Artwork_Year__c: submission.year,

--- a/spec/lib/salesforce_service_spec.rb
+++ b/spec/lib/salesforce_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe SalesforceService do
   describe '.add_artwork' do
-    let(:submission) { Fabricate(:submission) }
+    let(:submission) { Fabricate(:submission, title: 'reallylongtitlemorethan80charsreallylongtitlemorethan80charsreallylongtitlemorethan80chars') }
 
     context 'when the integration is not enabled' do
       it 'does not call the Salesforce api' do
@@ -26,7 +26,8 @@ describe SalesforceService do
 
       let(:artwork_as_salesforce_representation) do
         {
-          Name: submission.title,
+          Name: submission.title[0..79],
+          Artwork_Title__c: submission.title,
           Seller_Contact__c: 'SF_Contact_ID',
           Primary_Artist__c: 'SF_Artist_ID',
           Artwork_Year__c: submission.year,


### PR DESCRIPTION
Fixes: https://sentry.io/organizations/artsynet/issues/3611567465/?project=270340&query=is%3Aunresolved

The name field has a set 80 char limit in Salesforce. Therefore, we're limiting the name to 80 chars and sending the complete title in the custom Artwork Title field, which does not have this limit.