### PR TITLE
feat: link Assigned To to SF

### DIFF
--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -29,8 +29,8 @@ class SalesforceService
       api.query("select Id from Contact where Email = '#{user_email}'").first&.Id
     end
 
-    def find_owner_id(submission)
-      api.select('User', submission.approved_by, ['Id'], 'Admin_User_ID__c').Id
+    def find_sf_user_id(gravity_id)
+      api.select('User', gravity_id, ['Id'], 'Admin_User_ID__c').Id
     rescue Restforce::NotFoundError
       nil
     end
@@ -68,7 +68,8 @@ class SalesforceService
         COA_by_Authenticating_Body__c: submission.coa_by_authenticating_body || false,
         Cataloguer__c: submission.cataloguer,
         Primary_Image_URL__c: submission.primary_image&.image_urls&.dig('thumbnail'),
-        Convection_ID__c: submission.id
+        Convection_ID__c: submission.id,
+        Assigned_To__c: find_sf_user_id(submission.assigned_to)
         # Other fields we could sync in the future:
         # Artwork_Status__c: submission.state,
         # Materials: ???
@@ -77,7 +78,7 @@ class SalesforceService
         # FramedDimensions: ???
       }
       # Owner can't be nil, if we can't find it the API will succeed using the default user
-      owner_id = find_owner_id(submission)
+      owner_id = find_sf_user_id(submission.approved_by)
       artwork_rep = artwork_rep.merge(OwnerId: owner_id) if owner_id
       artwork_rep
     end

--- a/spec/lib/salesforce_service_spec.rb
+++ b/spec/lib/salesforce_service_spec.rb
@@ -49,7 +49,8 @@ describe SalesforceService do
           Cataloguer__c: submission.cataloguer,
           Primary_Image_URL__c: submission.primary_image&.image_urls&.dig('thumbnail'),
           Convection_ID__c: submission.id,
-          OwnerId: 'SF_User_ID'
+          OwnerId: 'SF_User_ID',
+          Assigned_To__c: 'SF_User_ID'
         }
       end
       let(:contact_as_salesforce_representation) do
@@ -72,6 +73,10 @@ describe SalesforceService do
 
         expect(restforce_double).to receive(:select).with(
           'User', submission.approved_by, ['Id'], 'Admin_User_ID__c'
+        ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
+
+        expect(restforce_double).to receive(:select).with(
+          'User', submission.assigned_to, ['Id'], 'Admin_User_ID__c'
         ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
 
         expect(restforce_double).to receive(:create!).with(
@@ -103,6 +108,10 @@ describe SalesforceService do
             expect(restforce_double).to receive(:select).with(
               'User', submission.approved_by, ['Id'], 'Admin_User_ID__c'
             ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
+
+            expect(restforce_double).to receive(:select).with(
+              'User', submission.assigned_to, ['Id'], 'Admin_User_ID__c'
+            ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
   
             expect(restforce_double).to receive(:create!).with(
               'Artwork__c', artwork_as_salesforce_representation,
@@ -129,6 +138,10 @@ describe SalesforceService do
             expect(restforce_double).to receive(:select).with(
               'User', submission.approved_by, ['Id'], 'Admin_User_ID__c'
             ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
+
+            expect(restforce_double).to receive(:select).with(
+              'User', submission.assigned_to, ['Id'], 'Admin_User_ID__c'
+            ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
   
             expect(restforce_double).to receive(:create!).with(
               'Artwork__c', artwork_as_salesforce_representation,
@@ -140,7 +153,7 @@ describe SalesforceService do
       end
 
       context 'when the submission does not have a user' do
-        let(:submission) { Fabricate(:submission, user: nil) }
+        let(:submission) { Fabricate(:submission, user: nil, assigned_to: SecureRandom.uuid) }
 
         context 'when the salesforce contact is found by email' do
           it 'assigns it to the artwork when creating it' do
@@ -154,6 +167,10 @@ describe SalesforceService do
 
             expect(restforce_double).to receive(:select).with(
               'User', submission.approved_by, ['Id'], 'Admin_User_ID__c'
+            ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
+
+            expect(restforce_double).to receive(:select).with(
+              'User', submission.assigned_to, ['Id'], 'Admin_User_ID__c'
             ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
   
             expect(restforce_double).to receive(:create!).with(
@@ -181,6 +198,10 @@ describe SalesforceService do
             expect(restforce_double).to receive(:select).with(
               'User', submission.approved_by, ['Id'], 'Admin_User_ID__c'
             ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
+
+            expect(restforce_double).to receive(:select).with(
+              'User', submission.assigned_to, ['Id'], 'Admin_User_ID__c'
+            ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
   
             expect(restforce_double).to receive(:create!).with(
               'Artwork__c', artwork_as_salesforce_representation,
@@ -203,6 +224,10 @@ describe SalesforceService do
             expect(restforce_double).to receive(:select).with(
               'User', submission.approved_by, ['Id'], 'Admin_User_ID__c'
             ).and_raise(Restforce::NotFoundError, 'TestError')
+
+            expect(restforce_double).to receive(:select).with(
+              'User', submission.assigned_to, ['Id'], 'Admin_User_ID__c'
+            ).and_return(OpenStruct.new({ Id: 'SF_User_ID'}))
   
             expect(restforce_double).to receive(:create!).with(
               'Artwork__c', artwork_as_salesforce_representation.except(:OwnerId),


### PR DESCRIPTION
Part 2 of https://artsyproduct.atlassian.net/browse/PX-5264

To make it a smoother and more organised experience in SF, we are now linking the assignee of the artwork to the user who lives in Salesforce

Note: Specs are getting a bit bulky with all the mock calls, I'm considering a follow up PR to perhaps use some shared contexts