### PR TITLE
fix: Use image url instead of original image when creating My Collection artwork

### DIFF
--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -209,7 +209,7 @@ module GraphqlHelper
       editionSize: submission.edition_size,
       externalImageUrls:
         submission.images.map do |image|
-          image.original_image&.split('?')&.first
+          image.image_urls["large"]
         end,
       height: submission.height,
       attributionClass:


### PR DESCRIPTION
Addresses [CX-2983]

🔴 Do not merge, depends on https://github.com/artsy/metaphysics/pull/4443

## Description

To fix issues with image formats that can't be handled (like `.png`) we should use the large image version instead of the original image when adding the artwork to My Collection artwork from a submission. The large image version will always be a `jpg` and adding it to the the My Collection artwork should always work.

I hope this will fix the issue.

[CX-2983]: https://artsyproduct.atlassian.net/browse/CX-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ