### PR TITLE
fix: Authorization workaround for users that exist multiple times in the User table

### DIFF
--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -95,9 +95,9 @@ class SubmissionsResolver < BaseResolver
     # TODO: Remove duplicates
     current_users = User.where(gravity_user_id: @context[:current_user])
 
-    !current_users.pluck(:id).include?(
-      base_submissions.select(:user_id).distinct.map { |s| s.user_id }
-    )
+    base_submissions.select(:user_id).distinct.select do |submission|
+      !current_users.pluck(:id).include?(submission.user_id)
+    end.any?
   end
 
   def not_allowed_all_submissions?

--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -91,11 +91,13 @@ class SubmissionsResolver < BaseResolver
     return false if admin? || !@arguments.key?(:ids)
     return true if partner?
 
-    current_user = User.find_by(gravity_user_id: @context[:current_user])
+    # Because there can by more than one user for the currenty user in the DB
+    # TODO: Remove duplicates
+    current_users = User.where(gravity_user_id: @context[:current_user])
 
-    base_submissions.select(:user_id).distinct.map { |s| s.user_id } != [
-      current_user&.id
-    ]
+    !current_users.pluck(:id).include?(
+      base_submissions.select(:user_id).distinct.map { |s| s.user_id }
+    )
   end
 
   def not_allowed_all_submissions?

--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -95,8 +95,8 @@ class SubmissionsResolver < BaseResolver
     # TODO: Remove duplicates
     current_users = User.where(gravity_user_id: @context[:current_user])
 
-    base_submissions.select(:user_id).distinct.select do |submission|
-      !current_users.pluck(:id).include?(submission.user_id)
+    base_submissions.select(:user_id).distinct.reject do |submission|
+      current_users.pluck(:id).include?(submission.user_id)
     end.any?
   end
 


### PR DESCRIPTION
Addresses [CX-3058]
## Description

This is an authorization workaround for users that exist multiple times in the User table.

If a user exists twice in Convection’s User table it can break the authentication in the submissions resolver. This PR is just a workaround. We still have to find out why users get created twice and how we can prevent it

[CX-3058]: https://artsyproduct.atlassian.net/browse/CX-3058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ