### PR TITLE
fix: Correctly url unescape My Collection image URLs

### DIFF
--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -209,7 +209,7 @@ module GraphqlHelper
       editionSize: submission.edition_size,
       externalImageUrls:
         submission.images.map do |image|
-          image.original_image&.split('?')&.first
+          CGI.unescape(image.original_image&.split('?')&.first)
         end,
       height: submission.height,
       attributionClass:


### PR DESCRIPTION
Addresses [CX-2983]

## Description

Correctly url unescape My Collection image URLs to make sure images are added correctly when they contain white spaces.

[CX-2983]: https://artsyproduct.atlassian.net/browse/CX-2983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ