### PR TITLE
Revert "fix: Authorization workaround for users that exist multiple times in the User table"

### DIFF
--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -91,13 +91,11 @@ class SubmissionsResolver < BaseResolver
     return false if admin? || !@arguments.key?(:ids)
     return true if partner?
 
-    # Because there can by more than one user for the currenty user in the DB
-    # TODO: Remove duplicates
-    current_users = User.where(gravity_user_id: @context[:current_user])
+    current_user = User.find_by(gravity_user_id: @context[:current_user])
 
-    base_submissions.select(:user_id).distinct.reject do |submission|
-      current_users.pluck(:id).include?(submission.user_id)
-    end.any?
+    base_submissions.select(:user_id).distinct.map { |s| s.user_id } != [
+      current_user&.id
+    ]
   end
 
   def not_allowed_all_submissions?


### PR DESCRIPTION
The workaround is not needed anymore because we merged all duplicated users.

Reverts artsy/convection#1349