### PR TITLE
Allow ConsignmentInquiry creation with tokens from Metaphysics

### DIFF
--- a/app/controllers/api/consignment_inquiries_controller.rb
+++ b/app/controllers/api/consignment_inquiries_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class ConsignmentInquiriesController < RestController
-    before_action :ensure_trusted_app, only: %i[create]
+    before_action :ensure_trusted_app_or_user, only: %i[create]
 
     def create
       param! :email, String, required: true

--- a/app/controllers/api/rest_controller.rb
+++ b/app/controllers/api/rest_controller.rb
@@ -35,10 +35,10 @@ module Api
       raise ApplicationController::NotAuthorized
     end
 
-    def ensure_trusted_app
+    def ensure_trusted_app_or_user
       has_trusted_app =
         current_app.present? &&
-          current_user_roles.include?(:trusted)
+          (current_user_roles.include?(:trusted) || current_user)
       return if has_trusted_app
 
       raise ApplicationController::NotAuthorized

--- a/spec/controllers/api/consignment_inquiries_spec.rb
+++ b/spec/controllers/api/consignment_inquiries_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe Api::ConsignmentInquiriesController, type: :controller do
   before do
     allow_any_instance_of(Api::ConsignmentInquiriesController).to receive(
-      :ensure_trusted_app
+      :ensure_trusted_app_or_user
     )
   end
 


### PR DESCRIPTION
### Description
At the point of communicating with convection, a logged in user may request a short-lived token from Gravity for requests to other apps. These tokens may not include :trusted in the roles. For these users we want to allow them still be able to create consignment inquiries.