### PR TITLE
feat(CX-3233): Use BSV, NSV template for all rejection emails

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -120,7 +120,10 @@ class UserMailer < ApplicationMailer
             unique_args: {
               submission_id: submission.id
             }
-    mail(to: submission.email, subject: 'An update about your submission')
+    title = submission.title ||= 'Unknown'
+    artist_name = artist.name 
+    subject = "Update on #{"#{title}"} #{artist_name ? "by #{artist_name}" : '' }" #rubocop:disable Style/RedundantInterpolation
+    mail(to: submission.email, subject: subject)
   end
 
   def non_target_supply_artist_rejected(submission:, artist:)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -122,7 +122,7 @@ class UserMailer < ApplicationMailer
             }
     title = submission.title ||= 'Unknown'
     artist_name = artist.name 
-    subject = "Update on #{"#{title}"} #{artist_name ? "by #{artist_name}" : '' }" #rubocop:disable Style/RedundantInterpolation
+    subject = "Update on \"#{title}\" #{artist_name ? "by #{artist_name}" : '' }"
     mail(to: submission.email, subject: subject)
   end
 

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -291,20 +291,8 @@ class SubmissionService
       submission = Submission.find(submission_id)
       artist = Gravity.client.artist(id: submission.artist_id)._get
 
-      rejection_reason_template =
-        case submission.rejection_reason
-        when 'Fake'
-          'fake_submission_rejected'
-        when 'Artist Submission'
-          'artist_submission_rejected'
-        when 'NSV', 'BSV'
-          'nsv_bsv_submission_rejected'
-        when 'Not Target Supply'
-          'non_target_supply_artist_rejected'
-        else
-          'other_submission_rejected'
-        end
-
+      rejection_reason_template = 'nsv_bsv_submission_rejected'
+        
       UserMailer.send(
         rejection_reason_template,
         submission: submission,

--- a/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
+++ b/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
@@ -11,7 +11,11 @@
         </tr>
         <tr>
           <td class='email-sub-title'>
-            <p>Dear <%= @submission.name %>,</p>
+            <% if @submission.user_name %>
+              <p>Hi <%= @submission.user_name %>,</p>
+            <% else %>
+              <p>Hi there,</p>
+            <% end %>
             <p>Thank you for submitting <%= @submission.title %> by <%= @artist.name %> to us for evaluation. </p>
             <p>Unfortunately, we don’t have a selling opportunity for this work right now. However, we have uploaded it to <%= link_to 'My Collection', 'https://www.artsy.net/settings/my-collection', target: :_blank %> in Artsy to help you track demand.</p>
             <p>My Collection is your personal space to manage your collection, track demand for your artwork and see updates about the artist. To find this artwork in My Collection, use this email address when you sign up or log in to Artsy.</p>

--- a/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
+++ b/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
@@ -17,7 +17,7 @@
               <p>Hi there,</p>
             <% end %>
             <p>Thank you for submitting <%= @submission.title %> by <%= @artist.name %> to us for evaluation. </p>
-            <p>Unfortunately, we don’t have a selling opportunity for this work right now. However, we have uploaded it to <%= link_to 'My Collection', 'https://www.artsy.net/settings/my-collection', target: :_blank %> in Artsy to help you track demand.</p>
+            <p>Unfortunately, we don’t have a selling opportunity for this work right now. However, we have uploaded it to <%= link_to 'My Collection', 'https://www.artsy.net/my-collection', target: :_blank %> in Artsy to help you track demand.</p>
             <p>My Collection is your personal space to manage your collection, track demand for your artwork and see updates about the artist. To find this artwork in My Collection, use this email address when you sign up or log in to Artsy.</p>
             <p>We will be in touch if there is an opportunity to sell this work with us in the future. If you have other works you are looking to buy or sell, or have questions about managing your collection, please don’t hesitate to reach out to our team directly at <%= link_to 'sell@artsy.net', 'mailto:sell@artsy.net', target: :_blank %>.</p>
             <p>

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -92,7 +92,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        'we unfortunately don’t have demand for this artwork on Artsy at the moment'
+        "Unfortunately, we don’t have a selling opportunity for this work right now"
       )
     end
 
@@ -448,7 +448,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        'we unfortunately don’t have demand for this artwork on Artsy at the moment.'
+        "Unfortunately, we don’t have a selling opportunity for this work right now"
       )
       expect(submission.state).to eq 'rejected'
       expect(submission.rejected_by).to eq 'userid'
@@ -469,7 +469,7 @@ describe SubmissionService do
       expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
-      expect(emails.first.html_part.body).to include('After extensive research')
+      expect(emails.first.html_part.body).to include("Unfortunately, we don’t have a selling opportunity for this work right now")
       expect(submission.state).to eq 'rejected'
       expect(submission.rejected_by).to eq 'userid'
       expect(submission.rejected_at).to_not be_nil
@@ -490,7 +490,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        'If you’re looking for gallery representation'
+        "Unfortunately, we don’t have a selling opportunity for this work right now"
       )
       expect(submission.state).to eq 'rejected'
       expect(submission.rejected_by).to eq 'userid'
@@ -566,7 +566,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        'we unfortunately don’t have demand for this artwork on Artsy at the moment.'
+        "Unfortunately, we don’t have a selling opportunity for this work right now"
       )
     end
 

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -372,7 +372,7 @@ describe 'admin/submissions/show.html.erb', type: :feature do
         emails = ActionMailer::Base.deliveries
         expect(emails.length).to eq 1
         expect(emails.first.html_part.body).to include(
-          'After extensive research, we were unable to verify this artwork'
+          "Unfortunately, we don’t have a selling opportunity for this work right now"
         )
         expect(page).to have_content 'Rejected by Jon Jonson'
         expect(page).to_not have_content 'Approve'


### PR DESCRIPTION
This PR resolves [CX-3233]

### Description
- With this PR, all rejection emails will now default to the BSV, NSV template.

[CX-3233]: https://artsyproduct.atlassian.net/browse/CX-3233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ