### PR TITLE
fix(CX-3189): Fix Unintended Convection Error when Submissions are deleted

### DIFF
--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -92,8 +92,10 @@ class SubmissionsResolver < BaseResolver
     return true if partner?
 
     current_user = User.find_by(gravity_user_id: @context[:current_user])
+    user_submissions = base_submissions.select(:user_id).distinct
+    return false if user_submissions.empty?
 
-    base_submissions.select(:user_id).distinct.map { |s| s.user_id } != [
+    user_submissions.map { |s| s.user_id } != [
       current_user&.id
     ]
   end


### PR DESCRIPTION
This PR resolves [CX-3189]

### Description
- This PR fixes unable to load errors happening in clients due to deleted Submissions. In summary we do not throw when the base_submissions are empty, because in this situation the user is not actually trying to load other people's submissions.

[CX-3189]: https://artsyproduct.atlassian.net/browse/CX-3189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ