### PR TITLE
fix: remove not signed from SF sync

### DIFF
--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -63,7 +63,6 @@ class SalesforceService
         Literature__c: submission.literature,
         Signature_Inscription__c: submission.signature_detail,
         Certificate_Of_Authenticity__c: submission.coa_by_authenticating_body || submission.coa_by_gallery || false,
-        Not_Signed__c: !submission.signature,
         COA_by_Gallery__c: submission.coa_by_gallery || false,
         COA_by_Authenticating_Body__c: submission.coa_by_authenticating_body || false,
         Cataloguer__c: submission.cataloguer,

--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -75,6 +75,8 @@ class SalesforceService
         # Diameter: ???
         # Framed: ???
         # FramedDimensions: ???
+        # Previoulsly synced fields:
+        # Not_Signed__c: !submission.signature, removed due to cataloguing issues
       }
       # Owner can't be nil, if we can't find it the API will succeed using the default user
       owner_id = find_sf_user_id(submission.approved_by)

--- a/spec/lib/salesforce_service_spec.rb
+++ b/spec/lib/salesforce_service_spec.rb
@@ -43,7 +43,6 @@ describe SalesforceService do
           Literature__c: submission.literature,
           Signature_Inscription__c: submission.signature_detail,
           Certificate_Of_Authenticity__c: submission.coa_by_authenticating_body || submission.coa_by_gallery || false,
-          Not_Signed__c: !submission.signature,
           COA_by_Gallery__c: submission.coa_by_gallery || false,
           COA_by_Authenticating_Body__c: submission.coa_by_authenticating_body || false,
           Cataloguer__c: submission.cataloguer,


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PX-5401

It was reported that syncing the "Not Signed" field based on the signature field in Convection causes issues in the cataloguing process since we end up issuing contracts stating the works are ‘not signed’ when indeed they are, the consignor just didn’t input that into Convection when submitting.
Since that information will be validated later, we are skipping that from our sync.