### PR TITLE
Feat(CX-3410): Add Recipient Email to Consignments Inquiries

### DIFF
--- a/app/events/consignment_inquiry_event.rb
+++ b/app/events/consignment_inquiry_event.rb
@@ -13,6 +13,7 @@ class ConsignmentInquiryEvent < Events::BaseEvent
   def properties
     {
       email: @object.email,
+      recipient_email: @object.recipient_email,
       gravity_user_id: @object.gravity_user_id,
       message: @object.message,
       name: @object.name,

--- a/app/events/consignment_inquiry_event.rb
+++ b/app/events/consignment_inquiry_event.rb
@@ -12,8 +12,8 @@ class ConsignmentInquiryEvent < Events::BaseEvent
 
   def properties
     {
-      email: @object.email,
-      recipient_email: @object.recipient_email,
+      email: @object.email, # the email of user sending the inquiry
+      recipient_email: @object.recipient_email, # an optional email of a collector services team member to deliver the inquiry. On Pulse if this is absent, the inquiry will be delivered to sell@artsy.net
       gravity_user_id: @object.gravity_user_id,
       message: @object.message,
       name: @object.name,

--- a/app/models/consignment_inquiry.rb
+++ b/app/models/consignment_inquiry.rb
@@ -1,5 +1,6 @@
 class ConsignmentInquiry < ApplicationRecord
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :recipient_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
   validates :name, presence: { message: "is required" }
   validates :message, presence: { message: "is required" }
 end

--- a/app/models/consignment_inquiry.rb
+++ b/app/models/consignment_inquiry.rb
@@ -1,5 +1,7 @@
 class ConsignmentInquiry < ApplicationRecord
+  # the email of user sending the inquiry
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
+   # recipient_email is an optional email of a collector services team member to deliver the inquiry to. On Pulse if this is absent, the inquiry will be delivered to sell@artsy.net
   validates :recipient_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
   validates :name, presence: { message: "is required" }
   validates :message, presence: { message: "is required" }

--- a/db/migrate/20230302151711_add_recipient_email_to_consignment_inquiry.rb
+++ b/db/migrate/20230302151711_add_recipient_email_to_consignment_inquiry.rb
@@ -1,0 +1,6 @@
+class AddRecipientEmailToConsignmentInquiry < ActiveRecord::Migration[6.1]
+  def change
+    add_column :consignment_inquiries, :recipient_email, :string
+    add_index :consignment_inquiries, [:recipient_email], unique: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_05_131817) do
+ActiveRecord::Schema.define(version: 2023_03_02_151711) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -61,8 +61,10 @@ ActiveRecord::Schema.define(version: 2022_12_05_131817) do
     t.string "phone_number"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "recipient_email"
     t.index ["email"], name: "index_consignment_inquiries_on_email"
     t.index ["gravity_user_id"], name: "index_consignment_inquiries_on_gravity_user_id"
+    t.index ["recipient_email"], name: "index_consignment_inquiries_on_recipient_email"
   end
 
   create_table "notes", force: :cascade do |t|

--- a/spec/models/consignment_inquiry_spec.rb
+++ b/spec/models/consignment_inquiry_spec.rb
@@ -13,6 +13,16 @@ describe ConsignmentInquiry do
         )
       end.to raise_error "Validation failed: Email is invalid"
     end
+    it 'validates recipient email format' do
+      expect do
+        ConsignmentInquiry.create!(
+          email: "validemail@email.com",
+          message: "Is a valid message",
+          name: "Valid Name",
+          recipient_email: "notavalidemail"
+        )
+      end.to raise_error "Validation failed: Recipient email is invalid"
+    end
     it 'requires name' do
       expect do
         ConsignmentInquiry.create!(


### PR DESCRIPTION
Co-authored-by: Daria Koslova <daria.Kozlova@artsymail.com>

This PR partly resolves [CX-3410]

### Description
- We have added an optional recipient_email column to consignment_inquiries. This allows clients to specify the particular collector services team employee that they want to contact in particular. 
- The field also accepts nil. In the event of nil value, we fallback to "sell@artsy.net" on Pulse, thereby not breaking the existing Get in touch flow.



[CX-3410]: https://artsyproduct.atlassian.net/browse/CX-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ