### PR TITLE
Feat(CX-3410): Permit Recipient Email in ConsignmentInquiry Controller

### DIFF
--- a/app/controllers/api/consignment_inquiries_controller.rb
+++ b/app/controllers/api/consignment_inquiries_controller.rb
@@ -8,6 +8,7 @@ module Api
       param! :message, String, required: true
       param! :phone_number, String, required: false
       param! :gravity_user_id, String, required: false
+      param! :recipient_email, String, required: false
       consignment_inquiry = ConsignmentInquiry.create!(consignment_inquiry_params)
       ConsignmentInquiryService.post_consignment_created_event(consignment_inquiry)
       render json: consignment_inquiry.to_json, status: :created
@@ -22,7 +23,8 @@ module Api
           :gravity_user_id,
           :message,
           :name,
-          :phone_number
+          :phone_number,
+          :recipient_email
         )
     end
   end


### PR DESCRIPTION
co-authored-by: Daria Kozlova <daria.kozlova@artsymail.com>

This PR partly resolves [CX-3410]

### Description
- This PR adds `recipient_email` in the permitted params for ConsignmentInquiries.
- This is a necessary before we can start sending recipient_email as part of the data from Metaphysics. 

[CX-3410]: https://artsyproduct.atlassian.net/browse/CX-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ