### PR TITLE
fix: Add UTM params to all links in email templates

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -9,8 +9,10 @@ class UserMailer < ApplicationMailer
 
     @utm_params =
       utm_params(
-        source: 'consignment-receipt',
-        campaign: 'consignment-complete'
+        source: 'sendgrid',
+        campaign: 'sell',
+        term: 'cx',
+        content: 'received'
       )
 
     smtpapi category: %w[submission_receipt],
@@ -129,8 +131,8 @@ class UserMailer < ApplicationMailer
               submission_id: submission.id
             }
     title = submission.title || 'Unknown'
-    artist_name = artist&.name 
-    subject = "Update on \"#{title}\" #{artist_name ? "by #{artist_name}" : '' }"
+    artist_name = artist&.name
+    subject = "Update on \"#{title}\" #{artist_name ? "by #{artist_name}" : ''}"
     mail(to: submission.email, subject: subject)
   end
 

--- a/app/views/partner_mailer/submission_digest.html.erb
+++ b/app/views/partner_mailer/submission_digest.html.erb
@@ -60,7 +60,7 @@
                       <table class='full-width-button'>
                         <tr>
                             <td class='submit-proposal-button'>
-                              <%= link_to('Send Proposal', Convection.config.artsy_cms_url) %>
+                              <%= link_to('Send Proposal', utm_url(Convection.config.artsy_cms_url, @utm_params)) %>
                             </td>
                         </tr>
                       </table>

--- a/app/views/user_mailer/artist_submission_rejected.html.erb
+++ b/app/views/user_mailer/artist_submission_rejected.html.erb
@@ -14,8 +14,8 @@
             <p>Dear <%= @submission.name %>,</p>
             <p>Thank you for submitting your artwork for Artsy to consider. We always enjoy seeing fresh talent.</p>
             <p>Currently, we don’t work with artists directly. If you are represented by a gallery, you can encourage them to consider partnering with us.</p>
-            <p>If you’re looking for gallery representation, you might be interested in reading our <%= link_to 'Gallery Representation Guide', 'https://www.artsy.net/article/artsy-editorial-artists-gallery-representation', target: :_blank %> 
-               and <%= link_to 'The Working Artist’s Guide', 'https://www.artsy.net/series/working-artists-guide', target: :_blank %>, two resources from our Editorial Team.</p>
+            <p>If you’re looking for gallery representation, you might be interested in reading our <%= link_to 'Gallery Representation Guide', artsy_formatted_url('article/artsy-editorial-artists-gallery-representation', @utm_params), target: :_blank %> 
+               and <%= link_to 'The Working Artist’s Guide', artsy_formatted_url('series/working-artists-guide', @utm_params), target: :_blank %>, two resources from our Editorial Team.</p>
             <p>We wish you all the best in your continued work.</p>
             <p>
               Sincerely,

--- a/app/views/user_mailer/fake_submission_rejected.html.erb
+++ b/app/views/user_mailer/fake_submission_rejected.html.erb
@@ -12,7 +12,7 @@
         <tr>
           <td class='email-sub-title'>
             <p>Dear <%= @submission.name %>,</p>
-            <p>Thank you for your submission to <%= link_to 'Artsy', 'https://www.artsy.net', target: :_blank %>.</p>
+            <p>Thank you for your submission to <%= link_to 'Artsy', artsy_formatted_url('', @utm_params), target: :_blank %>.</p>
             <p>After extensive research, we were unable to verify this artwork and attribute it to the artist. Therefore, we cannot offer this work for sale through Artsy.</p>
             <p>Should you have other works of art you wish to sell with Artsy, we would be happy to assist. You can submit another artwork anytime.</p>
             <p>

--- a/app/views/user_mailer/non_target_supply_artist_rejected.html.erb
+++ b/app/views/user_mailer/non_target_supply_artist_rejected.html.erb
@@ -12,12 +12,12 @@
         <tr>
           <td class='email-sub-title'>
             <p>Dear <%= @submission.name %>,</p>
-            <p>Thank you for your interest in selling with <%= link_to 'Artsy', 'https://www.artsy.net', target: :_blank %> and for giving us a chance to consider your artwork.</p>
+            <p>Thank you for your interest in selling with <%= link_to 'Artsy', artsy_formatted_url('', @utm_params), target: :_blank %> and for giving us a chance to consider your artwork.</p>
             <p>Our specialists have reviewed your submission and while it’s a wonderful piece, we unfortunately don’t have demand for this artwork on Artsy at the moment.</p>
 
             <% if Convection.config.send_new_receipt_email %>
               <p>To keep an eye on demand for this piece, you’ll need an Artsy account, so you can access <span style="text-decoration:underline">My Collection.</span></p>
-              <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.uuid }), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.uuid }), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
+              <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.uuid }.merge(@utm_params)), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.uuid }.merge(@utm_params)), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
               <p>You’ll find the artwork in My Collection, along with related art market insights.</p>
             <% end %>
 

--- a/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
+++ b/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
@@ -17,7 +17,7 @@
               <p>Hi there,</p>
             <% end %>
             <p>Thank you for submitting <%= @submission.title || 'Unknown' %> <%= @artist&.name ? "by #{@artist.name} " : "" %>to us for evaluation. </p>
-            <p>Unfortunately, we don’t have a selling opportunity for this work right now. However, we have uploaded it to <%= link_to 'My Collection', 'https://www.artsy.net/my-collection', target: :_blank %> in Artsy to help you track demand.</p>
+            <p>Unfortunately, we don’t have a selling opportunity for this work right now. However, we have uploaded it to <%= link_to 'My Collection', artsy_formatted_url('my-collection', @utm_params), target: :_blank %> in Artsy to help you track demand.</p>
             <p>My Collection is your personal space to manage your collection, track demand for your artwork and see updates about the artist. To find this artwork in My Collection, use this email address when you sign up or log in to Artsy.</p>
             <p>We will be in touch if there is an opportunity to sell this work with us in the future. If you have other works you are looking to buy or sell, or have questions about managing your collection, please don’t hesitate to reach out to our team directly at <%= link_to 'sell@artsy.net', 'mailto:sell@artsy.net', target: :_blank %>.</p>
             <p>

--- a/app/views/user_mailer/other_submission_rejected.erb
+++ b/app/views/user_mailer/other_submission_rejected.erb
@@ -13,9 +13,9 @@
           <td class='email-sub-title'>
 
             <p>Dear <%= @submission.name %>,</p>
-            <p>Thank you for your interest in selling with <%= link_to 'Artsy', 'https://www.artsy.net', target: :_blank %> and for giving us a chance to consider your artwork.</p>
+            <p>Thank you for your interest in selling with <%= link_to 'Artsy', artsy_formatted_url('', @utm_params), target: :_blank %> and for giving us a chance to consider your artwork.</p>
             <p>Our specialists have reviewed your submission and while it’s a wonderful piece, we unfortunately don’t have demand for this artwork on Artsy at the moment.</p>
-            <p>If you’d like to know more, you can read about what our specialists are looking for in our <%= link_to 'Collector Help Center', 'https://support.artsy.net/hc/en-us/categories/360003689533-Sell', target: :_blank %></p>
+            <p>If you’d like to know more, you can read about what our specialists are looking for in our <%= link_to 'Collector Help Center', utm_url('https://support.artsy.net/hc/en-us/categories/360003689533-Sell', @utm_params), target: :_blank %></p>
             <p>You can submit another artwork anytime. If you have multiple artworks to sell, we’d be happy to assist you at <%= link_to 'consign@artsymail.com', 'mailto:consign@artsymail.com', target: :_blank %>. We look forward to hearing from you.</p>
             <p>
               Sincerely,

--- a/app/views/user_mailer/submission_approved.html.erb
+++ b/app/views/user_mailer/submission_approved.html.erb
@@ -12,7 +12,7 @@
         <tr>
           <td class='email-sub-title'>
             <p>Dear <%= @submission.name %>,</p>
-            <p>We are delighted to work with you to sell your work through <%= link_to 'Artsy', 'https://www.artsy.net', target: :_blank %>.</p>
+            <p>We are delighted to work with you to sell your work through <%= link_to 'Artsy', artsy_formatted_url('', @utm_params), target: :_blank %>.</p>
             <p>Next, our team of specialists will provide auction estimates and potential sale dates and get back to you in 3-5 business days.</p>
           </td>
         </tr>

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -15,13 +15,13 @@
               <tr>
                 <td class='email-sub-title'>
                   <p>Dear <%= @submission.name %>,</p>
-                  <p>Thank you for submitting an artwork to sell with <%= link_to 'Artsy', 'https://www.artsy.net', target: :_blank %>. We’ll reach out to you shortly with an update or if we require additional information.</p>
+                  <p>Thank you for submitting an artwork to sell with <%= link_to 'Artsy', artsy_formatted_url('', @utm_params), target: :_blank %>. We’ll reach out to you shortly with an update or if we require additional information.</p>
                   <p class='email-sub-title-bold'>What happens next?</p>
                   <p>Our team of specialists will review your work to evaluate whether we currently have a suitable market for it. If your work is accepted, we’ll send you a sales offer and guide you in choosing the best option for selling it.</p>
                 
                   <% if Convection.config.send_new_receipt_email %>
                     <p>You’ll need an Artsy account in order to find your artwork in <span style="text-decoration:underline">My Collection</span>, along with related art market insights.</p>
-                    <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.uuid }), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.uuid }), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
+                    <p>Simply <%= link_to 'sign up', artsy_formatted_url('signup', { submissionId: @submission.uuid }.merge(@utm_params)), target: :_blank %> or <%= link_to 'log in', artsy_formatted_url('login', { submissionId: @submission.uuid }.merge(@utm_params)), target: :_blank %> to Artsy with the same email you used for this submission and visit our app.</p>
                   <% end %>
                 </td>
               </tr>

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -235,6 +235,13 @@ describe PartnerSubmissionService do
             '<i>Third approved artwork</i><span>, 1997</span>'
           )
           expect(email.html_part.body).to include('https://cms.artsy.net')
+
+          expect(emails.first.html_part.body).to include('utm_source=sendgrid')
+          expect(emails.first.html_part.body).to include('utm_medium=email')
+          expect(emails.first.html_part.body).to include('utm_campaign=sell')
+          expect(emails.first.html_part.body).to include(
+            'utm_content=sub-digest-auction'
+          )
           expect(
             @partner.partner_submissions.map(&:notified_at).compact.length
           ).to eq 3

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -92,7 +92,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        "Unfortunately, we don’t have a selling opportunity for this work right now"
+        'Unfortunately, we don’t have a selling opportunity for this work right now'
       )
     end
 
@@ -448,7 +448,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        "Unfortunately, we don’t have a selling opportunity for this work right now"
+        'Unfortunately, we don’t have a selling opportunity for this work right now'
       )
       expect(submission.state).to eq 'rejected'
       expect(submission.rejected_by).to eq 'userid'
@@ -469,7 +469,9 @@ describe SubmissionService do
       expect(emails.first.bcc).to eq(%w[consignments-archive@artsymail.com])
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
-      expect(emails.first.html_part.body).to include("Unfortunately, we don’t have a selling opportunity for this work right now")
+      expect(emails.first.html_part.body).to include(
+        'Unfortunately, we don’t have a selling opportunity for this work right now'
+      )
       expect(submission.state).to eq 'rejected'
       expect(submission.rejected_by).to eq 'userid'
       expect(submission.rejected_at).to_not be_nil
@@ -490,7 +492,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        "Unfortunately, we don’t have a selling opportunity for this work right now"
+        'Unfortunately, we don’t have a selling opportunity for this work right now'
       )
       expect(submission.state).to eq 'rejected'
       expect(submission.rejected_by).to eq 'userid'
@@ -514,7 +516,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        "Unfortunately, we don’t have a selling opportunity for this work right now."
+        'Unfortunately, we don’t have a selling opportunity for this work right now.'
       )
       expect(submission.state).to eq 'rejected'
       expect(submission.rejection_reason).to eq 'NSV'
@@ -566,7 +568,7 @@ describe SubmissionService do
       expect(emails.first.to).to eq(%w[michael@bluth.com])
       expect(emails.first.from).to eq(%w[sell@artsy.net])
       expect(emails.first.html_part.body).to include(
-        "Unfortunately, we don’t have a selling opportunity for this work right now"
+        'Unfortunately, we don’t have a selling opportunity for this work right now'
       )
     end
 
@@ -1156,6 +1158,7 @@ describe SubmissionService do
       Fabricate(:unprocessed_image, submission: submission)
       SubmissionService.deliver_submission_receipt(submission.id)
       emails = ActionMailer::Base.deliveries
+
       expect(emails.length).to eq 1
       expect(emails.first.bcc).to include('consignments-archive@artsymail.com')
       expect(emails.first.html_part.body).to include(
@@ -1164,6 +1167,11 @@ describe SubmissionService do
       expect(emails.first.html_part.body).to include(
         'Our team of specialists will review your work to evaluate whether we currently have a suitable market for it'
       )
+
+      expect(emails.first.html_part.body).to include('utm_source=sendgrid')
+      expect(emails.first.html_part.body).to include('utm_medium=email')
+      expect(emails.first.html_part.body).to include('utm_campaign=sell')
+      expect(emails.first.html_part.body).to include('utm_content=received')
     end
   end
 


### PR DESCRIPTION
This PR addresses [CX-3500], [CX-3502], [CX-3507], [CX-3508], [CX-3509], [CX-3510], [CX-3511], and [CX-3512]

This PR adds the UTM params to all the links in the submission email templates

[CX-3500]: https://artsyproduct.atlassian.net/browse/CX-3500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3502]: https://artsyproduct.atlassian.net/browse/CX-3502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3507]: https://artsyproduct.atlassian.net/browse/CX-3507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3508]: https://artsyproduct.atlassian.net/browse/CX-3508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3509]: https://artsyproduct.atlassian.net/browse/CX-3509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3510]: https://artsyproduct.atlassian.net/browse/CX-3510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3511]: https://artsyproduct.atlassian.net/browse/CX-3511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3512]: https://artsyproduct.atlassian.net/browse/CX-3512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ