### PR TITLE
fix: Allow partner users to access their submissions by ID

### DIFF
--- a/app/graphql/resolvers/submissions_resolver.rb
+++ b/app/graphql/resolvers/submissions_resolver.rb
@@ -89,7 +89,6 @@ class SubmissionsResolver < BaseResolver
 
   def not_allowed_ids?
     return false if admin? || !@arguments.key?(:ids)
-    return true if partner?
 
     current_user = User.find_by(gravity_user_id: @context[:current_user])
     user_submissions = base_submissions.select(:user_id).distinct

--- a/spec/requests/api/graphql/queries/submissions_spec.rb
+++ b/spec/requests/api/graphql/queries/submissions_spec.rb
@@ -87,6 +87,28 @@ describe 'submissions query' do
         expect(error_message).to eq "Can't load other people's submissions."
       end
     end
+
+    context 'with a request from a partner and wrong submission id' do
+      let(:token) do
+        JWT.encode(
+          { aud: 'gravity', sub: 'partner_id', roles: 'partner' },
+          Convection.config.jwt_secret
+        )
+      end
+
+      it 'returns an error for that request' do
+        post '/api/graphql', params: { query: query }, headers: headers
+
+        expect(response.status).to eq 200
+        body = JSON.parse(response.body)
+
+        submissions_response = body['data']['submissions']
+        expect(submissions_response).to eq nil
+
+        error_message = body['errors'][0]['message']
+        expect(error_message).to eq "Can't load other people's submissions."
+      end
+    end
   end
 
   describe 'valid requests' do


### PR DESCRIPTION
Addresses [ONYX-22]

[Slack Thread](https://artsy.slack.com/archives/C04KVDZU6/p1688570832817819)

## Description

When loading artworks in My Collection MP does the following request to Vortex in order to get the submission status for submissions that are associated with artworks in the user's collection:

```graphql
query {
  submissions(ids: ["123", "456"]) {
    edges {
      node {
        id
      }
    }
  }
}
```

The query fails if the requesting user also has partner access (e.g., a partner also using their account for My Collection). This is because we restrict the query to users who are not partners if the `ids` param is passed ([GitHub](https://github.com/artsy/convection/blob/27f9ce605d4e1535a68290656b3588eaebd73cf0/app/graphql/resolvers/submissions_resolver.rb#L92)).

This PR adjusts authorization to give users who are also partners access to their submissions by removing the line `return true if partner?`. Removing this line means that partners can use the query, passing the `ids` parameter, to access **only** submissions associated with their (user) account. This is ensured by the following check ([GitHub](https://github.com/artsy/convection/blob/27f9ce605d4e1535a68290656b3588eaebd73cf0/app/graphql/resolvers/submissions_resolver.rb#L98)):

```ruby
user_submissions.map { |s| s.user_id } != [
  current_user&.id
]
```

**Follow Up:**

In addition to this fix, we might want to adjust the MP resolver to recover from a possible failure when querying Convection to fetch the submission metadata.
([GitHub](https://github.com/artsy/metaphysics/blob/54c326e3991f6533623a8001b1332eb7b695f253/src/schema/v2/me/myCollection.ts#L117)).

[ONYX-22]: https://artsyproduct.atlassian.net/browse/ONYX-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ