### PR TITLE
chore: update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,5 @@ updates:
       interval: daily
     # Limit to 0 to enable only security updates:
     open-pull-requests-limit: 0
-    assignees:
-      - jonallured
     reviewers:
-      - artsy/sell-with-artsy-devs
+      - artsy/onyx-devs


### PR DESCRIPTION
Update the dependabot.yml file to reflect refreshed project custodians, documented [here in Notion](https://www.notion.so/artsy/17c4b550458a4cb8bcbf1b68060d63e6) 🔒.