### PR TITLE
chore: update rejection email

### DIFF
--- a/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
+++ b/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
@@ -23,9 +23,7 @@
             <p>
               All the best, 
               <br />
-              Caroline
-              <br />
-              Sell with Artsy
+              Sell with Artsy Team
             </p>
             
           </td>


### PR DESCRIPTION
This PR resolves [ONYX-250]


This PR updates the rejection email to not include C* as the default person signing emails. This comes as a request from the Sell with Artsy team. 

[ONYX-250]: https://artsyproduct.atlassian.net/browse/ONYX-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ