### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,5 @@
     "automerge": false
   },
   "extends": ["@artsy:app"],
-  "assignees": ["jonallured", "bhoggard"]
+  "assignees": ["jonallured"]
 }


### PR DESCRIPTION
This PR updates the assignees of the `renovate.json` to only include current members of Artsy. 