### PR TITLE
fix: exec probes without timeout setting

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -300,6 +300,7 @@ spec:
             - pgrep
             - -f
             - sidekiq
+            timeoutSeconds: 3
           initialDelaySeconds: 30
           periodSeconds: 30
         resources:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -300,7 +300,7 @@ spec:
             - pgrep
             - -f
             - sidekiq
-            timeoutSeconds: 3
+          timeoutSeconds: 3
           initialDelaySeconds: 30
           periodSeconds: 30
         resources:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -228,6 +228,7 @@ spec:
             - pgrep
             - -f
             - sidekiq
+            timeoutSeconds: 3
           initialDelaySeconds: 30
           periodSeconds: 30
         resources:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -228,7 +228,7 @@ spec:
             - pgrep
             - -f
             - sidekiq
-            timeoutSeconds: 3
+          timeoutSeconds: 3
           initialDelaySeconds: 30
           periodSeconds: 30
         resources:


### PR DESCRIPTION
fix: exec probes without timeout setting