### PR TITLE
chore(onyx-468): revoke 'admin' access

### DIFF
--- a/lib/artsy_admin_auth.rb
+++ b/lib/artsy_admin_auth.rb
@@ -13,9 +13,8 @@ class ArtsyAdminAuth
       decoded_token = decode_token(token)
       return false if decoded_token.nil?
 
-      # TODO: remove 'admin' once the connsignments team all have this new role
       roles = decoded_token['roles']
-      roles.include?('consignments_manager') || roles.include?('admin')
+      roles.include?('consignments_manager')
     end
 
     def decode_user(token)


### PR DESCRIPTION
[Jira ticket](https://artsyproduct.atlassian.net/browse/ONYX-468)

> [!WARNING]  
> Do not merge until [data migration ](https://artsyproduct.atlassian.net/browse/ONYX-468?focusedCommentId=59567)takes place.

Revoking "admin" users access. Users have to have "consignments_manager" role to access Convection.

This is a part of [the product-wide initiative to improve our product permissions](https://www.notion.so/artsy/Product-permission-improvements-d1e0b8bee5464700b68344841020fac7).


