### PR TITLE
chore: update rejection email to not include my collection

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -114,9 +114,10 @@ class UserMailer < ApplicationMailer
     mail(to: submission.email, subject: "Artsy Submission")
   end
 
-  def nsv_bsv_submission_rejected(submission:, artist:)
+  def nsv_bsv_submission_rejected(submission:, artist:, logged_in:)
     @submission = submission
     @artist = artist
+    @logged_in = logged_in
 
     @utm_params =
       utm_params(

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -291,13 +291,15 @@ class SubmissionService
     def deliver_rejection_notification(submission_id)
       submission = Submission.find(submission_id)
       artist = Gravity.client.artist(id: submission.artist_id)._get
+      logged_in = submission.user_id.present?
 
       rejection_reason_template = "nsv_bsv_submission_rejected"
 
       UserMailer.send(
         rejection_reason_template,
         submission: submission,
-        artist: artist
+        artist: artist,
+        logged_in: logged_in
       ).deliver_now
     end
 

--- a/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
+++ b/app/views/user_mailer/nsv_bsv_submission_rejected.html.erb
@@ -16,9 +16,16 @@
             <% else %>
               <p>Hi there,</p>
             <% end %>
+
             <p>Thank you for submitting <%= @submission.title || 'Unknown' %> <%= @artist&.name ? "by #{@artist.name} " : "" %>to us for evaluation. </p>
-            <p>Unfortunately, we don’t have a selling opportunity for this work right now. However, we have uploaded it to <%= link_to 'My Collection', artsy_formatted_url('my-collection', @utm_params), target: :_blank %> in Artsy to help you track demand.</p>
-            <p>My Collection is your personal space to manage your collection, track demand for your artwork and see updates about the artist. To find this artwork in My Collection, use this email address when you sign up or log in to Artsy.</p>
+            <% if @logged_in %>
+              <p>Unfortunately, we don’t have a selling opportunity for this work right now. However, we have uploaded it to <%= link_to 'My Collection', artsy_formatted_url('my-collection', @utm_params), target: :_blank %> in Artsy to help you track demand.</p>
+              <p>My Collection is your personal space to manage your collection, track demand for your artwork and see updates about the artist. To find this artwork in My Collection, use this email address when you sign up or log in to Artsy.</p>
+            <% else %>
+              <p>Unfortunately, we don’t have a selling opportunity for this work right now. We recommend uploading it to My Collection to help you track demand in the future.</p>
+              <p>My Collection is your personal space to manage your collection, track demand for your artwork and see updates about the artist. You can upload your work by following <%= link_to 'these steps', 'https://support.artsy.net/s/article/How-do-I-upload-artworks-to-My-Collection', target: :_blank %>.</p>
+            <% end %>
+
             <p>We will be in touch if there is an opportunity to sell this work with us in the future. If you have other works you are looking to buy or sell, or have questions about managing your collection, please don’t hesitate to reach out to our team directly at <%= link_to 'sell@artsy.net', 'mailto:sell@artsy.net', target: :_blank %>.</p>
             <p>
               All the best, 

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -95,7 +95,7 @@ describe SubmissionService do
         "Unfortunately, we don’t have a selling opportunity for this work right now. However, we have uploaded it to "
       )
     end
-    
+
     it "delivers unauthenticated rejection email to user for non-target supply artist submissions" do
       new_submission =
         SubmissionService.create_submission(
@@ -113,7 +113,7 @@ describe SubmissionService do
       expect(emails.first.html_part.body).to include(
         "Unfortunately, we don’t have a selling opportunity for this work right now. We recommend uploading it to My Collection to help you track demand in the future."
       )
-    end    
+    end
 
     it "does not reject a submission automatically, when created by Convection" do
       new_submission =


### PR DESCRIPTION
This PR solves [ONYX-640]

**Description:**
This PR adds updates our rejection email to depend on the status of the user, if they're logged in or not.

Will test this as well in Mailtrap as soon as this gets merged.

[ONYX-640]: https://artsyproduct.atlassian.net/browse/ONYX-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ