### PR TITLE
feat: more conveniently distinguish between admins, users, and visitors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,28 @@ module ApplicationHelper
   def super_admin_user?(user_id)
     AdminUser.exists?(gravity_user_id: user_id, super_admin: true)
   end
+
+  def creator_label(submission)
+    content_tag(:span, title: creator_title(submission)) { creator_icon(submission) }
+  end
+
+  def creator_icon(submission)
+    if submission.admin
+      "🛡️"
+    elsif submission.user
+      "👤"
+    else
+      "✉️"
+    end
+  end
+
+  def creator_title(submission)
+    if submission.admin
+      "Administrator"
+    elsif submission.user
+      "User"
+    else
+      "Visitor"
+    end
+  end
 end

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -31,6 +31,10 @@ module UrlHelper
     url.gsub("PARTNER_NAME", partner_name)
   end
 
+  def user_management_url(gravity_user_id)
+    "#{Convection.config.forque_url}/users/#{gravity_user_id}"
+  end
+
   private
 
   def utm_url(url, utm_params)

--- a/app/views/admin/submissions/_created_by.html.erb
+++ b/app/views/admin/submissions/_created_by.html.erb
@@ -1,19 +1,12 @@
 <div class='overview-section'>
   <div class='bold-label'>Created By</div>
   <div class='single-padding-top'>
+    <%= creator_icon(@submission) %>
+    <%= creator_title(@submission) %>
     <% if @submission.admin %>
-      <div class="consigned-partner-name">
-        Admin
-      </div>
-      <% if @submission.admin.email.present? %>   
-        <div class="consigned-partner-name">
-          Email: <%= @submission.admin.email%>
-        </div>
-      <% end %>
-     <% else %>
-     <div class="consigned-partner-name">
-        User
-      </div>
+      <%= mail_to @submission.admin.email, @submission.admin.email, class: "smaller-sidebar-link" %>
+    <% elsif @submission.user&.gravity_user_id.present? %>
+      <%= link_to @submission.user&.gravity_user_id, user_management_url(@submission.user&.gravity_user_id), class: "smaller-sidebar-link" %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/submissions/_submission.html.erb
+++ b/app/views/admin/submissions/_submission.html.erb
@@ -10,7 +10,7 @@
     <%= submission.state %>
   </div>
   <div class='list-group-item-info'>
-    <%= submission.admin ? 'Admin' : 'User' %>
+    <%= creator_label(submission) %>
   </div>
   <div class='list-group-item-info list-group-item-info--id'>
     <%= submission.id %>

--- a/app/views/admin/submissions/index.html.erb
+++ b/app/views/admin/submissions/index.html.erb
@@ -65,7 +65,7 @@
           Status
         </div>
          <div class='list-group-item-info bold-label'>
-          Created By
+          By
         </div>
         <div class='list-group-item-info bold-label list-group-item-info--id'>
           <%= render 'admin/shared/sort_label', filters: filters, sort_field: 'id', label: 'ID' %>

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -10,7 +10,7 @@ Convection.config =
     admin_names: (ENV["ADMIN_NAMES"] || "Alice Betty Cindy").split,
     admin_email_address: ENV["ADMIN_EMAIL_ADDRESS"] || "sell@artsy.net",
     artsy_url: ENV["ARTSY_URL"] || "https://staging.artsy.net",
-    artsy_cms_url: "https://cms.artsy.net",
+    artsy_cms_url: ENV["ARTSY_CMS_URL"] || "https://cms-staging.artsy.net",
     auction_offer_form_url: ENV["AUCTION_OFFER_FORM_URL"] || "https://foo.com",
     offer_response_form_url:
       ENV["OFFER_RESPONSE_FORM_URL"] || "https://foo.com",
@@ -26,6 +26,7 @@ Convection.config =
     datadog_trace_agent_hostname: ENV["DATADOG_TRACE_AGENT_HOSTNAME"],
     datadog_debug: ENV["DATADOG_DEBUG"] == "true",
     debug_email_address: ENV["DEBUG_EMAIL_ADDRESS"] || "sarah@artsymail.com",
+    forque_url: ENV["FORQUE_URL"] || "https://tools-staging.artsy.net",
     gemini_account_key: ENV["GEMINI_ACCOUNT_KEY"] || "convection-staging",
     gemini_app: ENV["GEMINI_APP"] || "https://media.artsy.net",
     metaphysics_api_url:

--- a/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/create_consignment_submission_spec.rb
@@ -38,7 +38,7 @@ describe "createConsignmentSubmission mutation" do
     context "with an unauthorized request" do
       let(:token) { "foo.bar.baz" }
 
-      it "create user with gravity_auser_id eq nil if contact information is not provided" do
+      it "create user with gravity_user_id eq nil if contact information is not provided" do
         post "/api/graphql", params: {query: mutation}, headers: headers
 
         expect(User.last).to eq nil

--- a/spec/services/partner_submission_service_spec.rb
+++ b/spec/services/partner_submission_service_spec.rb
@@ -234,7 +234,7 @@ describe PartnerSubmissionService do
           expect(email.html_part.body).to include(
             "<i>Third approved artwork</i><span>, 1997</span>"
           )
-          expect(email.html_part.body).to include("https://cms.artsy.net")
+          expect(email.html_part.body).to include("https://cms-staging.artsy.net")
 
           expect(emails.first.html_part.body).to include("utm_source=sendgrid")
           expect(emails.first.html_part.body).to include("utm_medium=email")


### PR DESCRIPTION
It's currently difficult to determine what Artsy accounts, if any, are associated with consignment submissions. All recent submissions are described as "Created by User," and one has to inspect the raw data to identify the relevant user ids ([example discussion](https://artsy.slack.com/archives/C05EQL4R5N0/p1713452377953389)).

This PR replaces the unhelpful content with an icon (and tooltip) in the list view. It looks like:

<img width="357" alt="Screenshot 2024-04-18 at 5 52 01 PM" src="https://github.com/artsy/convection/assets/28120/d56a5382-b763-43da-9ed2-28135f46776a">

It also employs the same icon and label on the submission detail page, and adds a link to the relevant user-management destination in Forque when applicable. Looks like:

<img width="322" alt="Screenshot 2024-04-18 at 5 52 32 PM" src="https://github.com/artsy/convection/assets/28120/ae68bf71-f365-44de-ab34-02df2acb62c9">

Or:

<img width="285" alt="Screenshot 2024-04-18 at 5 52 39 PM" src="https://github.com/artsy/convection/assets/28120/a58a44de-1589-4034-a238-79870d3ac274">

Or:

<img width="263" alt="Screenshot 2024-04-18 at 5 53 27 PM" src="https://github.com/artsy/convection/assets/28120/f49cd095-1149-4fa5-9f5f-229b7096fe2e">


### Migration (already complete)

```bash
hokusai staging env set FORQUE_URL=https://tools-staging.artsy.net
```