### PR TITLE
chore: sync submission edition number and size to Salesforce

### DIFF
--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -68,7 +68,9 @@ class SalesforceService
         Cataloguer__c: submission.cataloguer,
         Primary_Image_URL__c: submission.primary_image&.image_urls&.dig("thumbnail"),
         Convection_ID__c: submission.id,
-        Assigned_To__c: find_sf_user_id(submission.assigned_to)
+        Assigned_To__c: find_sf_user_id(submission.assigned_to),
+        Size_of_edition__c: submission.edition_size,
+        Available_works__c: submission.edition_number
         # Other fields we could sync in the future:
         # Artwork_Status__c: submission.state,
         # Materials: ???

--- a/spec/lib/salesforce_service_spec.rb
+++ b/spec/lib/salesforce_service_spec.rb
@@ -49,7 +49,9 @@ describe SalesforceService do
           Primary_Image_URL__c: submission.primary_image&.image_urls&.dig("thumbnail"),
           Convection_ID__c: submission.id,
           OwnerId: "SF_User_ID",
-          Assigned_To__c: "SF_User_ID"
+          Assigned_To__c: "SF_User_ID",
+          Size_of_edition__c: submission.edition_size,
+          Available_works__c: submission.edition_number
         }
       end
       let(:contact_as_salesforce_representation) do


### PR DESCRIPTION
Add a couple more fields (edition number and edition size) to the existing Salesforce sync for an artwork associated with a submission.

Jira 🔒 : [ONYX-919](https://artsyproduct.atlassian.net/browse/ONYX-919)

[ONYX-919]: https://artsyproduct.atlassian.net/browse/ONYX-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ