### PR TITLE
chore: update salesforce synced primary image quality to large

### DIFF
--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -66,7 +66,7 @@ class SalesforceService
         COA_by_Gallery__c: submission.coa_by_gallery || false,
         COA_by_Authenticating_Body__c: submission.coa_by_authenticating_body || false,
         Cataloguer__c: submission.cataloguer,
-        Primary_Image_URL__c: submission.primary_image&.image_urls&.dig("thumbnail"),
+        Primary_Image_URL__c: submission.primary_image&.image_urls&.dig("large"),
         Convection_ID__c: submission.id,
         Assigned_To__c: find_sf_user_id(submission.assigned_to)
         # Other fields we could sync in the future:

--- a/spec/lib/salesforce_service_spec.rb
+++ b/spec/lib/salesforce_service_spec.rb
@@ -46,7 +46,7 @@ describe SalesforceService do
           COA_by_Gallery__c: submission.coa_by_gallery || false,
           COA_by_Authenticating_Body__c: submission.coa_by_authenticating_body || false,
           Cataloguer__c: submission.cataloguer,
-          Primary_Image_URL__c: submission.primary_image&.image_urls&.dig("thumbnail"),
+          Primary_Image_URL__c: submission.primary_image&.image_urls&.dig("large"),
           Convection_ID__c: submission.id,
           OwnerId: "SF_User_ID",
           Assigned_To__c: "SF_User_ID"


### PR DESCRIPTION
Update the image URL synced to Salesforce for a submission artwork. Right now send the URL representing a thumbnail-sized image. We've heard that Salesforce can accommodate a larger image and it would be useful for sales reps to have a large version synced instead.

Jira 🔒: [ONYX-920](https://artsyproduct.atlassian.net/browse/ONYX-920)