### PR TITLE
feat: create listed artworks directly from consignment submission

### DIFF
--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -39,6 +39,7 @@ $green: #0eda83;
 
 .locked {
   padding-bottom: 5px;
+
   img {
     width: 16px;
     height: 16px;
@@ -70,6 +71,7 @@ $green: #0eda83;
       }
     }
   }
+
   .overview-item-title {
     font-family: $serif;
     text-transform: none;
@@ -97,6 +99,7 @@ $green: #0eda83;
 .asset-thumb {
   display: flex;
   align-items: center;
+
   img {
     width: 60px;
     max-height: 60px;
@@ -159,19 +162,24 @@ a.make-primary-link {
     flex: 1;
   }
 }
+
 .notes-section {
   margin-left: -15px;
   margin-right: -15px;
+
   .new-note {
     margin-bottom: 30px;
+
     h4 {
       margin-left: 20px;
     }
+
     form {
-      > * {
+      >* {
         margin-left: 20px;
         margin-right: 20px;
       }
+
       textarea {
         width: 100%;
       }
@@ -181,6 +189,7 @@ a.make-primary-link {
   .notes-section-title {
     font-size: 25px;
   }
+
   .list-group-item--note {
     .list-group-item--byline {
       font-family: $serif;
@@ -191,11 +200,13 @@ a.make-primary-link {
       text-overflow: ellipsis;
       overflow: hidden;
     }
+
     .list-group-item--body {
       margin-left: 20px;
       margin-right: 20px;
     }
   }
+
   .user-note-badge {
     padding: .2em .6em .3em;
     background: #d9534f;
@@ -226,6 +237,7 @@ a.make-primary-link {
   padding: 4px;
 }
 
+.submissions_show,
 .partners_index {
   .ui-autocomplete.ui-menu {
     z-index: 10000;
@@ -240,7 +252,7 @@ a.make-primary-link {
 }
 
 .offer-type-radio,
-.submission-reason-radio{
+.submission-reason-radio {
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -310,7 +322,7 @@ a.make-primary-link {
   text-decoration: underline;
 }
 
-.dashboard_category_row  {
+.dashboard_category_row {
   .section-header {
     margin-bottom: 20px;
 
@@ -324,7 +336,7 @@ a.make-primary-link {
   margin-bottom: 20px;
   padding: 10px;
 
-  > div {
+  >div {
     padding: 0;
   }
 

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -13,6 +13,7 @@ module Admin
         undo_publish
         undo_rejection
         undo_close
+        list_artwork
       ]
     before_action :set_submission_artist, only: %i[show edit]
 
@@ -129,6 +130,15 @@ module Admin
 
     def undo_close
       SubmissionService.undo_close(@submission)
+      redirect_to admin_submission_path(@submission)
+    end
+
+    def list_artwork
+      artwork = SubmissionService.list_artwork(@submission, session[:access_token])
+      flash[:success] = "Created artwork #{artwork["_id"]}"
+      redirect_to admin_submission_path(@submission)
+    rescue SubmissionService::SubmissionError => e
+      flash[:error] = e.message
       redirect_to admin_submission_path(@submission)
     end
 

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -134,7 +134,7 @@ module Admin
     end
 
     def list_artwork
-      artwork = SubmissionService.list_artwork(@submission, session[:access_token])
+      artwork = SubmissionService.list_artwork(@submission, params[:gravity_partner_id], session[:access_token])
       flash[:success] = "Created artwork #{artwork["_id"]}"
       redirect_to admin_submission_path(@submission)
     rescue SubmissionService::SubmissionError => e

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -137,7 +137,7 @@ module Admin
       artwork = SubmissionService.list_artwork(@submission, params[:gravity_partner_id], session[:access_token])
       flash[:success] = "Created artwork #{artwork["_id"]}"
       redirect_to admin_submission_path(@submission)
-    rescue SubmissionService::SubmissionError => e
+    rescue SubmissionService::SubmissionError, GravityV1::GravityError => e
       flash[:error] = e.message
       redirect_to admin_submission_path(@submission)
     end

--- a/app/graphql/types/submission_sort_type.rb
+++ b/app/graphql/types/submission_sort_type.rb
@@ -2,6 +2,6 @@
 
 module Types
   class SubmissionSortType < SortType
-    generate_values(Submission.column_names)
+    generate_values(Submission.column_names - ["listed_artwork_ids"])
   end
 end

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -35,6 +35,10 @@ module UrlHelper
     "#{Convection.config.forque_url}/users/#{gravity_user_id}"
   end
 
+  def artwork_url(artwork_id)
+    "#{Convection.config.artsy_url}/artwork/#{artwork_id}"
+  end
+
   private
 
   def utm_url(url, utm_params)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -241,4 +241,34 @@ class Submission < ApplicationRecord
     created_at.to_i % 100_000 + (user_id || id) +
       (count_submissions_of_user || 0)
   end
+
+  def to_listing_params
+    {
+      title: title,
+      artists: [artist_id],
+      category: category,
+      medium: medium,
+      date: year,
+      height: height,
+      width: width,
+      depth: depth,
+      metric: dimensions_metric,
+      signed_by_artist: signature,
+      certificate_of_authenticity: authenticity_certificate,
+      provenance: provenance,
+      # location_city, location_state, location_country
+      additional_information: additional_info,
+      # edition, edition_number, edition_size
+      attribution_class: attribution_class&.humanize&.downcase,
+      publisher: publisher,
+      # artist_proofs
+      literature: literature,
+      exhibition_history: exhibition,
+      condition_description: condition_report,
+      signature: signature_detail,
+      coa_by_authenticating_body: coa_by_authenticating_body,
+      coa_by_gallery: coa_by_gallery,
+      # import_source / external_id (set to streamline Gravity's listed_artwork_ids?)
+    }
+  end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -268,7 +268,8 @@ class Submission < ApplicationRecord
       signature: signature_detail,
       coa_by_authenticating_body: coa_by_authenticating_body,
       coa_by_gallery: coa_by_gallery,
-      # import_source / external_id (set to streamline Gravity's listed_artwork_ids?)
+      import_source: "convection",
+      external_id: id
     }
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -242,7 +242,7 @@ class Submission < ApplicationRecord
       (count_submissions_of_user || 0)
   end
 
-  def to_listing_params
+  def to_artwork_params
     {
       title: title,
       artists: [artist_id],
@@ -256,12 +256,9 @@ class Submission < ApplicationRecord
       signed_by_artist: signature,
       certificate_of_authenticity: authenticity_certificate,
       provenance: provenance,
-      # location_city, location_state, location_country
       additional_information: additional_info,
-      # edition, edition_number, edition_size
       attribution_class: attribution_class&.humanize&.downcase,
       publisher: publisher,
-      # artist_proofs
       literature: literature,
       exhibition_history: exhibition,
       condition_description: condition_report,
@@ -270,6 +267,18 @@ class Submission < ApplicationRecord
       coa_by_gallery: coa_by_gallery,
       import_source: "convection",
       external_id: id
+    }
+  end
+
+  def to_edition_set_params
+    {
+      edition_size: edition_size,
+      available_editions: [edition_number],
+      artist_proofs: artist_proofs,
+      height: height,
+      width: width,
+      depth: depth,
+      metric: dimensions_metric
     }
   end
 end

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -343,11 +343,12 @@ class SubmissionService
       # TODO: add edition sets if applicable
 
       # Add images, primary image first
-      submission.assets.
-        sort_by.with_index {|a, i| submission.primary_image && a == submission.primary_image ? -1 : i }.
-        map {|a| a.original_image }.
-        each do |url|
-        GravityV1.post("/api/v1/artwork/#{artwork["_id"]}/image",
+      submission.assets
+        .sort_by.with_index { |a, i| submission.primary_image && a == submission.primary_image ? -1 : i }
+        .map { |a| a.original_image }
+        .each do |url|
+        GravityV1.post(
+          "/api/v1/artwork/#{artwork["_id"]}/image",
           params: {
             remote_image_url: url,
             low_priority: true

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -328,8 +328,8 @@ class SubmissionService
       submission
     end
 
-    def list_artwork(submission, access_token)
-      # TODO: Validate/prompt for partner
+    def list_artwork(submission, gravity_partner_id, access_token)
+      raise SubmissionError, "Partner is required" unless gravity_partner_id.present?
       # Validate artist is set and public
       raise SubmissionError, "Must have an artist to list" if submission.artist_id.blank?
       artist = GravityV1.get("/api/v1/artist/#{submission.artist_id}")
@@ -338,7 +338,9 @@ class SubmissionService
       # TODO: Source additional data from Salesforce artwork as desired
 
       # Create artwork
-      artwork = GravityV1.post("/api/v1/artwork", params: submission.to_listing_params, token: access_token)
+      artwork = GravityV1.post("/api/v1/artwork",
+        params: submission.to_listing_params.merge(partner: gravity_partner_id),
+        token: access_token)
 
       # TODO: add edition sets if applicable
 

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -335,7 +335,7 @@ class SubmissionService
       artist = GravityV1.get("/api/v1/artist/#{submission.artist_id}")
       raise SubmissionError, "Artist must be public" unless artist["public"]
 
-      # TODO: Source additional data from Salesforce artwork as desired
+      # TODO: Source data from Salesforce or MyCollection artworks as desired
 
       # Create artwork
       artwork = GravityV1.post("/api/v1/artwork",
@@ -354,14 +354,9 @@ class SubmissionService
         .sort_by.with_index { |a, i| submission.primary_image && a == submission.primary_image ? -1 : i }
         .map { |a| a.original_image }
         .each do |url|
-        GravityV1.post(
-          "/api/v1/artwork/#{artwork["_id"]}/image",
-          params: {
-            remote_image_url: url,
-            low_priority: true
-          },
-          token: access_token
-        )
+        GravityV1.post("/api/v1/artwork/#{artwork["_id"]}/image",
+          params: {remote_image_url: url, low_priority: true},
+          token: access_token)
       end
 
       # Record newly listed artwork

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -339,10 +339,15 @@ class SubmissionService
 
       # Create artwork
       artwork = GravityV1.post("/api/v1/artwork",
-        params: submission.to_listing_params.merge(partner: gravity_partner_id),
+        params: submission.to_artwork_params.merge(partner: gravity_partner_id),
         token: access_token)
 
-      # TODO: add edition sets if applicable
+      # Add edition set if applicable
+      if submission.edition?
+        GravityV1.post("/api/v1/artwork/#{artwork["_id"]}/edition_set",
+          params: submission.to_edition_set_params,
+          token: access_token)
+      end
 
       # Add images, primary image first
       submission.assets

--- a/app/views/admin/submissions/_list_artwork_modal.html.erb
+++ b/app/views/admin/submissions/_list_artwork_modal.html.erb
@@ -1,0 +1,27 @@
+<div class='modal remodal smaller-modal' data-remodal-id='list-artwork-modal'
+  data-remodal-options="hashTracking: false">
+  <div class='modal-header'>
+    <h3>
+      Please select a partner
+    </h3>
+  </div>
+  <div class='modal-close'>
+    <%= link_to '' , '#' , id: 'list-artwork-close' %>
+  </div>
+  <div class='modal-content'>
+    <div class='single-padding-top'>
+      <p>A new artwork listing will be created in the partner's inventory.</p>
+      <div class='col-sm-12' id='partner-selections-form'>
+        <%= form_tag list_artwork_admin_submission_path, method: 'put' do %>
+          <div class='form-group'>
+            <%= text_field_tag 'gravity_partner', '', class: 'form-control', id: 'partner-search' %>
+            <%= hidden_field_tag 'gravity_partner_id' %>
+            <div class='single-padding-top'>
+              <%= submit_tag 'Create Artwork', class: 'btn btn-primary btn-full-width', id: 'partner-search-submit' %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/submissions/_listed_artworks.html.erb
+++ b/app/views/admin/submissions/_listed_artworks.html.erb
@@ -2,7 +2,7 @@
   <div class='overview-section'>
     <div class='bold-label'>Listed Artworks</div>
     <% @submission.listed_artwork_ids.each do |artwork_id| %>
-      <div class='single-padding-top'>
+      <div class='single-padding-top smaller-sidebar-link'>
         <%= link_to artwork_id, artwork_url(artwork_id) %>
       </div>
     <% end %>

--- a/app/views/admin/submissions/_listed_artworks.html.erb
+++ b/app/views/admin/submissions/_listed_artworks.html.erb
@@ -1,0 +1,10 @@
+<% if @submission.listed_artwork_ids.any? %>
+  <div class='overview-section'>
+    <div class='bold-label'>Listed Artworks</div>
+    <% @submission.listed_artwork_ids.each do |artwork_id| %>
+      <div class='single-padding-top'>
+        <%= link_to artwork_id, artwork_url(artwork_id) %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/admin/submissions/_state_actions.html.erb
+++ b/app/views/admin/submissions/_state_actions.html.erb
@@ -3,7 +3,7 @@
     <% if @submission.approved? || @submission.published? %>
       <%= link_to 'Create Offer', new_step_0_admin_offers_path(submission_id: @submission.id), class: 'btn btn-primary btn-small btn-full-width' %>
       <div class='single-padding-top'>
-        <%= link_to 'List Artwork', list_artwork_admin_submission_path(submission_id: @submission.id), method: :put, class: 'btn btn-secondary btn-small btn-full-width', data: { confirm: "This will create a new artwork from this consignment." } %>
+        <%= link_to 'List Artwork', '#', class: 'btn btn-secondary btn-small btn-full-width', data: { 'remodal-target' => 'list-artwork-modal' } %>
       </div>
     <% end %>
     <% @actions.each do |action| %>

--- a/app/views/admin/submissions/_state_actions.html.erb
+++ b/app/views/admin/submissions/_state_actions.html.erb
@@ -2,6 +2,9 @@
   <div class='bold-label'>Actions</div>
     <% if @submission.approved? || @submission.published? %>
       <%= link_to 'Create Offer', new_step_0_admin_offers_path(submission_id: @submission.id), class: 'btn btn-primary btn-small btn-full-width' %>
+      <div class='single-padding-top'>
+        <%= link_to 'List Artwork', list_artwork_admin_submission_path(submission_id: @submission.id), method: :put, class: 'btn btn-secondary btn-small btn-full-width', data: { confirm: "This will create a new artwork from this consignment." } %>
+      </div>
     <% end %>
     <% @actions.each do |action| %>
       <div class='single-padding-top'>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -53,6 +53,7 @@
             </div>
           </div>
           <%= render 'state_actions' %>
+          <%= render 'listed_artworks' %>
           <%= render 'rejection_reasons_modal'%>
           <div class='overview-section'>
             <div class='bold-label'>State</div>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -55,6 +55,7 @@
           <%= render 'state_actions' %>
           <%= render 'listed_artworks' %>
           <%= render 'rejection_reasons_modal'%>
+          <%= render 'list_artwork_modal'%>
           <div class='overview-section'>
             <div class='bold-label'>State</div>
             <div class='single-padding-top'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails
           put "undo_publish"
           put "undo_rejection"
           put "undo_close"
+          put "list_artwork"
         end
         resources :assets do
           post :multiple, on: :collection

--- a/db/migrate/20240508215653_add_listed_artwork_ids_to_submissions.rb
+++ b/db/migrate/20240508215653_add_listed_artwork_ids_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddListedArtworkIdsToSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :submissions, :listed_artwork_ids, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_02_151711) do
+ActiveRecord::Schema.define(version: 2024_05_08_215653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -236,6 +236,7 @@ ActiveRecord::Schema.define(version: 2023_03_02_151711) do
     t.string "source"
     t.string "location_postal_code"
     t.string "location_country_code"
+    t.string "listed_artwork_ids", default: [], null: false, array: true
     t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
     t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
     t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,7 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+Submission.create([
+  {artist_id: "4dc98ef49a96300001003179", title: "Foo", category: "Print", state: "submitted"},
+])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
@@ -8,5 +7,5 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
 Submission.create([
-  {artist_id: "4dc98ef49a96300001003179", title: "Foo", category: "Print", state: "submitted"},
+  {artist_id: "4dc98ef49a96300001003179", title: "Foo", category: "Print", state: "submitted"}
 ])

--- a/lib/gravity_v1.rb
+++ b/lib/gravity_v1.rb
@@ -1,0 +1,39 @@
+class GravityV1
+  class GravityError < StandardError; end
+
+  def self.get(url, params: {}, token: nil)
+    base_url = "#{Convection.config.gravity_url}#{url}"
+    uri = URI.parse(base_url)
+    uri.query = URI.encode_www_form(params)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    req = Net::HTTP::Get.new(uri.request_uri, headers(token))
+    response = http.request(req)
+    raise GravityV1::GravityError, response.body unless response.is_a? Net::HTTPSuccess
+
+    JSON.parse(response.body)
+  end
+
+  def self.post(url, params: {}, token: nil)
+    base_url = "#{Convection.config.gravity_url}#{url}"
+    uri = URI.parse(base_url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    req = Net::HTTP::Post.new("#{uri.path}?#{uri.query}", headers(token))
+    req.body = params.to_json
+    response = http.request(req)
+    raise GravityV1::GravityError, response.body unless response.is_a? Net::HTTPSuccess
+
+    JSON.parse(response.body)
+  end
+
+  def self.headers(token)
+    {
+      "X-XAPP-TOKEN" => Convection.config.gravity_xapp_token,
+      "X-ACCESS-TOKEN" => token,
+      "Accept" => "application/json",
+      "User-Agent" => "Convection",
+      "Content-Type" => "application/json"
+    }
+  end
+end

--- a/spec/support/gravity_helper.rb
+++ b/spec/support/gravity_helper.rb
@@ -68,10 +68,10 @@ def stub_gravity_root
   stub_gravity_request("", GRAVITY_ROOT)
 end
 
-def stub_gravity_request(gravity_resource, body, more_headers = {})
+def stub_gravity_request(gravity_resource, body, method = :get, more_headers = {})
   stub =
     stub_request(
-      :get,
+      method,
       "#{Convection.config.gravity_api_url}#{gravity_resource}"
     ).to_return(body: body.to_json, headers: HEADERS)
   stub.with(headers: more_headers) unless more_headers.empty?

--- a/spec/system/list_artwork_spec.rb
+++ b/spec/system/list_artwork_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+require "support/gravity_helper"
+require "support/gravql_helper"
+require "support/jwt_helper"
+
+describe "Listing a new artwork", type: :feature do
+  let(:submission) { Fabricate(:submission, state: "approved", title: "My Artwork") }
+  let(:admin_id) { "adminid" }
+
+  before do
+    add_default_stubs(
+      id: submission.user.gravity_user_id,
+      artist_id: submission.artist_id
+    )
+
+    # Skip roles check
+    allow_any_instance_of(ApplicationController).to receive(
+      :require_artsy_authentication
+    )
+
+    # Set current user
+    stub_jwt_header(admin_id)
+
+    allow(Convection.config).to receive(:gravity_xapp_token).and_return("xapp_token")
+    stub_gravql_artists(
+      body: {
+        data: {
+          artists: [
+            {
+              id: submission.artist_id,
+              name: "Gob Bluth",
+              is_p1: false,
+              target_supply: true
+            }
+          ]
+        }
+      }
+    )
+  end
+
+  it "lists artwork" do
+    visit admin_submission_path(submission)
+    expect(page).to have_content("My Artwork")
+    expect(page).to have_content("approved")
+
+    click_on "List Artwork"
+    expect(page).to have_content("Please select a partner")
+
+    stub_gravity_request("/v1/artist/#{submission.artist_id}", {public: true})
+    stub_gravity_request("/v1/artwork", {_id: "abc123"}, :post)
+
+    find_field(id: "gravity_partner_id", type: :hidden).set("foo")
+    click_on "Create Artwork"
+    expect(page).to have_content("Created artwork")
+    expect(page).to have_content("Listed Artworks")
+    expect(page).to have_content("abc123")
+    expect(submission.reload.listed_artwork_ids).to include("abc123")
+  end
+end

--- a/spec/system/submission_editing_spec.rb
+++ b/spec/system/submission_editing_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require "rails_helper"
 require "support/gravity_helper"
 require "support/gravql_helper"


### PR DESCRIPTION
This begins to support creating listed artworks directly from consignments. The "list artwork" button uses Gravity's v1 API to confirm a valid artist association, create a new artwork, and upload images. It stores a reference to the new artwork record in the new `Submission#listed_artwork_ids` column.

To dos:
* [x] Prompt for a partner under which to create the new artwork. (Reuse the [existing partner autocomplete](https://convection.artsy.net/admin/offers/new_step_0?submission_id=215148)).
* [ ] Source some artwork fields from the "better" data in Salesforce. (Reuse the [existing Salesforce integration](https://github.com/artsy/convection/blob/main/lib/salesforce_service.rb) and `Convection_ID__c` field.)
* [x] Create edition sets when necessitated by the `attribution_class` and `edition_*` fields.
* [x] Set an `import_source`/`external_id` such that Gravity can build its own connection from the My Collection work to this new listing, [as we do for Salesforce-imported records](https://github.com/artsy/gravity/blob/facf327b4ee6c1eb7ce9eb86b88ad5929ef18dbe/app/services/artwork_service.rb#L221). Gravity will require changes because [a "Convection" source](https://github.com/artsy/gravity/blob/facf327b4ee6c1eb7ce9eb86b88ad5929ef18dbe/app/models/domain/artwork.rb#L702) is currently used to [bypass some validations](https://github.com/artsy/gravity/blob/facf327b4ee6c1eb7ce9eb86b88ad5929ef18dbe/app/models/util/commerce_validation.rb#L61) for My Collection works.

Looks like:

<img width="1173" alt="Screenshot 2024-05-08 at 6 32 53 PM" src="https://github.com/artsy/convection/assets/28120/d7c5fb33-a247-4667-bca8-5f9a15843891">


And:

<img width="362" alt="Screenshot 2024-05-08 at 6 44 26 PM" src="https://github.com/artsy/convection/assets/28120/395b2bea-a16b-459a-b0c9-689879def0c3">
