### PR TITLE
spike(onyx-910): submission page renders (partially) artwork details backed by Metaphysics

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -80,7 +80,7 @@ module Admin
 
     def show
       if Convection.unleash.enabled?(
-        'onyx-mp-backed-artwork-details',
+        "onyx-mp-backed-artwork-details",
         Unleash::Context.new(user_id: @current_user) # current_user is a User#gravity_user_id for some reason
       )
         set_artwork_details!
@@ -234,7 +234,7 @@ module Admin
         is_p1: response.try(:[], :artist).try(:[], :targetSupply).try(:[], :isP1),
         target_supply: response.try(:[], :artist).try(:[], :targetSupply).try(:[], :isTargetSupply),
         images: response.try(:[], :images)&.map do |image|
-          OpenStruct.new( url: image.try(:[], :resized).try(:[], :url), default: image.try(:[], :isDefault) )
+          OpenStruct.new(url: image.try(:[], :resized).try(:[], :url), default: image.try(:[], :isDefault))
         end
       )
     end

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -79,7 +79,12 @@ module Admin
     end
 
     def show
-      set_artwork_details!
+      if Convection.unleash.enabled?(
+        'onyx-mp-backed-artwork-details',
+        Unleash::Context.new(user_id: @current_user) # current_user is a User#gravity_user_id for some reason
+      )
+        set_artwork_details!
+      end
 
       notified_partner_submissions =
         @submission.partner_submissions.where.not(notified_at: nil)
@@ -222,9 +227,9 @@ module Admin
         provenance: response.try(:[], :provenance),
         has_certificate_of_authenticity: response.try(:[], :hasCertificateOfAuthenticity) || "No",
         certificate_of_authenticity_details: response.try(:[], :certificateOfAuthenticity).try(:[], :details),
-        coa_by_authenticating_body: false, # TODO: Not yet supported
-        coa_by_gallery: false, # TODO: Not yet supported
-        location: "-", # Not yet supported
+        coa_by_authenticating_body: "N/A", # Not yet supported
+        coa_by_gallery: "N/A", # Not yet supported
+        location: "N/A", # Not yet supported
         price_in_mind: response.try(:[], :pricePaid).try(:[], :display),
         is_p1: response.try(:[], :artist).try(:[], :targetSupply).try(:[], :isP1),
         target_supply: response.try(:[], :artist).try(:[], :targetSupply).try(:[], :isTargetSupply),

--- a/app/views/admin/submissions/_assets.html.erb
+++ b/app/views/admin/submissions/_assets.html.erb
@@ -1,0 +1,27 @@
+<div class="col-md-12">
+  <div class="row">
+    <div class="col-md-12">
+      You can manage images directly from the user's My Collection artwork page:
+      <%= link_to 'My Collection Artwork', "https://artsy.net/collector-profile/my-collection/artworks/#{@submission.my_collection_artwork_id}" %>
+    </div>
+  </div>
+
+  <div class="row">
+    <% @artwork_details.images&.map do |image| %>
+      <div class='list-group-item list-group-item--asset'>
+        <div class='list-group-item-content'>
+          <div class='asset-thumb'>
+            <%= image_tag image.url %>
+          </div>
+        </div>
+        <div class='asset-controls'>
+          <% if image.default %>
+            <div class='primary-image-label'>
+              Default
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/submissions/_assets.html.erb
+++ b/app/views/admin/submissions/_assets.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-12">
       You can manage images directly from the user's My Collection artwork page:
-      <%= link_to 'My Collection Artwork', "https://artsy.net/collector-profile/my-collection/artworks/#{@submission.my_collection_artwork_id}" %>
+      <%= link_to 'My Collection Artwork', "https://artsy.net/my-collection/artworks/#{@submission.my_collection_artwork_id}/edit" %>
     </div>
   </div>
 

--- a/app/views/admin/submissions/_assets.html.erb
+++ b/app/views/admin/submissions/_assets.html.erb
@@ -1,27 +1,29 @@
-<div class="col-md-12">
-  <div class="row">
-    <div class="col-md-12">
-      You can manage images directly from the user's My Collection artwork page:
-      <%= link_to 'My Collection Artwork', "https://artsy.net/my-collection/artworks/#{@submission.my_collection_artwork_id}/edit" %>
+<% if @artwork_details %>
+  <div class="col-md-12">
+    <div class="row">
+      <div class="col-md-12">
+        You can manage images directly from the user's My Collection artwork page:
+        <%= link_to 'My Collection Artwork', "https://artsy.net/my-collection/artworks/#{@submission.my_collection_artwork_id}/edit" %>
+      </div>
     </div>
-  </div>
 
-  <div class="row">
-    <% @artwork_details.images&.map do |image| %>
-      <div class='list-group-item list-group-item--asset'>
-        <div class='list-group-item-content'>
-          <div class='asset-thumb'>
-            <%= image_tag image.url %>
+    <div class="row">
+      <% @artwork_details.images&.map do |image| %>
+        <div class='list-group-item list-group-item--asset'>
+          <div class='list-group-item-content'>
+            <div class='asset-thumb'>
+              <%= image_tag image.url %>
+            </div>
+          </div>
+          <div class='asset-controls'>
+            <% if image.default %>
+              <div class='primary-image-label'>
+                Default
+              </div>
+            <% end %>
           </div>
         </div>
-        <div class='asset-controls'>
-          <% if image.default %>
-            <div class='primary-image-label'>
-              Default
-            </div>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/admin/submissions/_new_submission_details.html.erb
+++ b/app/views/admin/submissions/_new_submission_details.html.erb
@@ -1,0 +1,176 @@
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Artist/Designer
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.artist_name&.upcase %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Title
+  </div>
+  <div class='overview-item-value'>
+    <em><%= @artwork_details.title %></em>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Signature
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.signature %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Category
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.category %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Medium
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.medium %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Edition Size
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.edition_size %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Edition Number
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.edition_number %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Dimensions
+  </div>
+  <div class='overview-item-value'>
+    <div><%= @artwork_details.dimensions_in %></div>
+    <div><%= @artwork_details.dimensions_cm %></div>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Year
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.year %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Provenance
+  </div>
+  <div class='overview-item-value'>
+    <strong><%= @artwork_details.provenance %></strong>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Certificate of auth.
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.has_certificate_of_authenticity %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    COA by authenticating body (Not supported yet)
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.coa_by_authenticating_body ? 'Yes' : 'No' %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    COA by gallery (Not supported yet)
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.coa_by_gallery ? 'Yes' : 'No' %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Location (Not supported yet)
+  </div>
+  <div class='overview-item-value'>
+    <%= @artwork_details.location %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Price in mind
+  </div>
+  <div class='overview-item-value minimum-price'>
+    <% if @artwork_details.price_in_mind %>
+      <%= "Yes, #{@artwork_details.price_in_mind}" %>
+    <% else %>
+      No
+    <% end %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Supply Priority
+  </div>
+  <div class='overview-item-value supply-priority'>
+    <%#= @artwork_details && artist_supply_priority(@artwork_details.is_p1, @artwork_details.target_supply) %>
+    <%= @artwork_details && artist_supply_priority(**@artwork_details.to_h) %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Auction Score
+  </div>
+  <div class='overview-item-value auction-score'>
+    <%= formatted_score(@submission.auction_score) %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Artist Score
+  </div>
+  <div class='overview-item-value artist-score'>
+    <%= formatted_score(@submission.artist_score) %>
+  </div>
+</div>
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Created At
+  </div>
+  <div class='overview-item-value'>
+    <%= @submission.created_at&.strftime('%b %-d @ %l:%M %p %Z') %>
+  </div>
+</div>

--- a/app/views/admin/submissions/_new_submission_details.html.erb
+++ b/app/views/admin/submissions/_new_submission_details.html.erb
@@ -1,176 +1,178 @@
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Artist/Designer
+<% if @artwork_details %>
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Artist/Designer
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.artist_name&.upcase %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.artist_name&.upcase %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Title
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Title
+    </div>
+    <div class='overview-item-value'>
+      <em><%= @artwork_details.title %></em>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <em><%= @artwork_details.title %></em>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Signature
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Signature
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.signature %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.signature %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Category
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Category
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.category %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.category %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Medium
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Medium
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.medium %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.medium %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Edition Size
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Edition Size
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.edition_size %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.edition_size %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Edition Number
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Edition Number
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.edition_number %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.edition_number %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Dimensions
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Dimensions
+    </div>
+    <div class='overview-item-value'>
+      <div><%= @artwork_details.dimensions_in %></div>
+      <div><%= @artwork_details.dimensions_cm %></div>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <div><%= @artwork_details.dimensions_in %></div>
-    <div><%= @artwork_details.dimensions_cm %></div>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Year
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Year
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.year %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.year %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Provenance
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Provenance
+    </div>
+    <div class='overview-item-value'>
+      <strong><%= @artwork_details.provenance %></strong>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <strong><%= @artwork_details.provenance %></strong>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Certificate of auth.
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Certificate of auth.
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.has_certificate_of_authenticity %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.has_certificate_of_authenticity %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    COA by authenticating body (Not supported yet)
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      COA by authenticating body
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.coa_by_authenticating_body %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.coa_by_authenticating_body ? 'Yes' : 'No' %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    COA by gallery (Not supported yet)
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      COA by gallery
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.coa_by_gallery %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.coa_by_gallery ? 'Yes' : 'No' %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Location (Not supported yet)
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Location
+    </div>
+    <div class='overview-item-value'>
+      <%= @artwork_details.location %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @artwork_details.location %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Price in mind
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Price in mind
+    </div>
+    <div class='overview-item-value minimum-price'>
+      <% if @artwork_details.price_in_mind %>
+        <%= "Yes, #{@artwork_details.price_in_mind}" %>
+      <% else %>
+        No
+      <% end %>
+    </div>
   </div>
-  <div class='overview-item-value minimum-price'>
-    <% if @artwork_details.price_in_mind %>
-      <%= "Yes, #{@artwork_details.price_in_mind}" %>
-    <% else %>
-      No
-    <% end %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Supply Priority
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Supply Priority
+    </div>
+    <div class='overview-item-value supply-priority'>
+      <%#= @artwork_details && artist_supply_priority(@artwork_details.is_p1, @artwork_details.target_supply) %>
+      <%= @artwork_details && artist_supply_priority(**@artwork_details.to_h) %>
+    </div>
   </div>
-  <div class='overview-item-value supply-priority'>
-    <%#= @artwork_details && artist_supply_priority(@artwork_details.is_p1, @artwork_details.target_supply) %>
-    <%= @artwork_details && artist_supply_priority(**@artwork_details.to_h) %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Auction Score
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Auction Score
+    </div>
+    <div class='overview-item-value auction-score'>
+      <%= formatted_score(@submission.auction_score) %>
+    </div>
   </div>
-  <div class='overview-item-value auction-score'>
-    <%= formatted_score(@submission.auction_score) %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Artist Score
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Artist Score
+    </div>
+    <div class='overview-item-value artist-score'>
+      <%= formatted_score(@submission.artist_score) %>
+    </div>
   </div>
-  <div class='overview-item-value artist-score'>
-    <%= formatted_score(@submission.artist_score) %>
-  </div>
-</div>
 
-<div class='overview-item'>
-  <div class='overview-item-title'>
-    Created At
+  <div class='overview-item'>
+    <div class='overview-item-title'>
+      Created At
+    </div>
+    <div class='overview-item-value'>
+      <%= @submission.created_at&.strftime('%b %-d @ %l:%M %p %Z') %>
+    </div>
   </div>
-  <div class='overview-item-value'>
-    <%= @submission.created_at&.strftime('%b %-d @ %l:%M %p %Z') %>
-  </div>
-</div>
+<% end %>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -1,25 +1,41 @@
 <div class='row'>
   <div class='col-sm-12'>
     <div class='col-md-8'>
+      <div style="margin-bottom: 10px;">
+        <span class='switch-views' style="cursor:pointer;color:#6E1FFF;">Toggle My Collection backed data</span>
+      </div>
       <div class='col-md-12'>
         <div class='watt-overview'>
           <div class='overview-section'>
             <div class='overview-section-title--inline'>
               Details
-              <span class='overview-section-title--inline__link'>
+              <span class='overview-section-title--inline__link old-submission-details' style="display:inline;">
                 <%= link_to 'Edit', edit_admin_submission_path(@submission) %>
               </span>
+              <span class='overview-section-title--inline__link new-submission-details' style="display:none;">
+                <%= link_to 'Edit', "https://artsy.net/collector-profile/my-collection/artworks/#{@submission.my_collection_artwork_id}/edit" %>
+              </span>
             </div>
-            <%= render 'submission_details', submission: @submission, artist: @artist %>
+            <div class="old-submission-details" style="display:block;">
+              <%= render 'submission_details', submission: @submission, artist: @artist %>
+            </div>
+            <div class="new-submission-details" style="display:none;">
+              <%= render 'new_submission_details', submission: @submission, artwork_details: @artwork_details %>
+            </div>
           </div>
           <div class='overview-section'>
             <div class='overview-section-title--inline'>
               Assets
-              <span class='overview-section-title--inline__link'>
+              <span class='overview-section-title--inline__link old-submission-details' style="display:inline;">
                 <%= link_to 'Add New', new_admin_submission_asset_path(@submission) %>
               </span>
             </div>
-            <%= render @submission.assets %>
+            <span class='overview-section-title--inline__link old-submission-details' style="display:block;">
+              <%= render @submission.assets %>
+            </span>
+            <span class='overview-section-title--inline__link new-submission-details' style="display:none;">
+              <%= render 'assets', submission: @submission, artwork_details: @artwork_details %>
+            </span>
           </div>
           <%= render 'admin/consignments/consignment_section', consignment: @submission.consigned_partner_submission, artist: @artist&.[](:name) %>
           <%= render 'admin/offers/offers_section', offers: @offers, truncated: true %>
@@ -172,4 +188,9 @@
             edit.style.display = 'none'
         }
     }
+
+    $('.switch-views').on('click', function() {
+      $('.old-submission-details').toggle()
+      $('.new-submission-details').toggle()
+    })
 </script>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -1,9 +1,14 @@
 <div class='row'>
   <div class='col-sm-12'>
     <div class='col-md-8'>
-      <div style="margin-bottom: 10px;">
-        <span class='switch-views' style="cursor:pointer;color:#6E1FFF;">Toggle My Collection backed data</span>
-      </div>
+      <% if @artwork_details %>
+        <div style="margin-bottom: 10px;">
+          <div class='switch-views'>
+            <span class="new-submission-details" style="cursor:pointer;color:#6E1FFF;display:none;">See artwork details backed by submission data</span>
+            <span class="old-submission-details" style="cursor:pointer;color:#6E1FFF;display:inline;">See artwork details backed by MyC artwork</span>
+          </div>
+        </div>
+      <% end %>
       <div class='col-md-12'>
         <div class='watt-overview'>
           <div class='overview-section'>


### PR DESCRIPTION
This PR allows to see up-to-date MyC artwork data in Convection. Almost all artwork-related fields are queryable from Metaphysics, thus it's possible to see updated artwork details in realtime. I've added a feature flag, and if use is enrolled, they can see a toggle which switches between submission's artwork details and MP-backed ones.

The switch control only visible to users enrolled in Unleash experiment - no visual changes for other users.

Note: not all fields are exposed via Metaphysics yet - we need to add them (2 COA fields). Also, location is empty for MyC artworks.

<video src="https://github.com/artsy/convection/assets/3934579/63187190-1e53-42bf-848d-1f44b621c503" />