### PR TITLE
feat: make Salesforce artwork data available to listing step

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -281,4 +281,8 @@ class Submission < ApplicationRecord
       metric: dimensions_metric
     }
   end
+
+  def salesforce_artwork
+    @salesforce_artwork ||= SalesforceService.salesforce_artwork_for_submission(self)
+  end
 end

--- a/app/views/admin/submissions/_list_artwork_modal.html.erb
+++ b/app/views/admin/submissions/_list_artwork_modal.html.erb
@@ -1,3 +1,8 @@
+<%
+  submission_artwork_params = @submission.to_artwork_params || {}
+  salesforce_artwork_params = SalesforceService.salesforce_artwork_to_artwork_params(@submission.salesforce_artwork) || {}
+  fields = submission_artwork_params.keys | salesforce_artwork_params.keys
+%>
 <div class='modal remodal smaller-modal' data-remodal-id='list-artwork-modal'
   data-remodal-options="hashTracking: false">
   <div class='modal-header'>
@@ -16,6 +21,24 @@
           <div class='form-group'>
             <%= text_field_tag 'gravity_partner', '', class: 'form-control', id: 'partner-search' %>
             <%= hidden_field_tag 'gravity_partner_id' %>
+
+            <div style="text-align:right;">
+              <a onclick='$("#artwork_source_data").toggle(); return false;'><em>View source data</em></a>
+              <table class='table table-striped' id="artwork_source_data" style="display: none;">
+                <tr>
+                  <th>Field</th>
+                  <th>Submission Data</th>
+                  <th>Salesforce Data</th>
+                </tr>
+                <% fields.each do |field| %>
+                  <tr>
+                    <td><%= field %></td>
+                    <td><%= submission_artwork_params[field] %></td>
+                    <td><%= salesforce_artwork_params[field] %></td>
+                  </tr>
+                <% end %>
+              </table>
+            </div>
             <div class='single-padding-top'>
               <%= submit_tag 'Create Artwork', class: 'btn btn-primary btn-full-width', id: 'partner-search-submit' %>
             </div>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -55,7 +55,7 @@
           <%= render 'state_actions' %>
           <%= render 'listed_artworks' %>
           <%= render 'rejection_reasons_modal'%>
-          <%= render 'list_artwork_modal'%>
+          <%= render 'list_artwork_modal' if @submission.approved? || @submission.published? %>
           <div class='overview-section'>
             <div class='bold-label'>State</div>
             <div class='single-padding-top'>


### PR DESCRIPTION
This is an ugly, incremental step toward making Salesforce's artwork data available to the artwork-listing utility. Most of the effort went into identifying all of the relevant Salesforce fields and mapping them to the corresponding Gravity fields. Still, there are a few fields that need follow-up:
* `Medium_Type__c` is defined in the production Salesforce instance, but not the sandbox. Once added, it's a potential source for the `category` field.
* `Size_of_edition__c` and `Available_works__c` are also not defined in the sandbox, causing submission approvals to fail [when creating the Salesforce artwork](https://github.com/artsy/convection/blob/6518a6d5da268d34a9ca327170e1863e1239f576/lib/salesforce_service.rb#L73-L74).
* The `Edition_Number__c` field is formatted like `13/50` (sometimes), which doesn't directly correspond to Gravity fields.

As ugly as this is, I tried to make this mergeable. The source fields are revealed (for informational purposes) only when clicking a toggle in the listing modal:
![list_consignment5](https://github.com/artsy/convection/assets/28120/163e988d-90d5-4f61-91b5-b5a548bc1a0e)
