### PR TITLE
feat: add edition set and image source data to listing modal + allow field-by-field choices

### DIFF
--- a/app/assets/stylesheets/locals.css.scss
+++ b/app/assets/stylesheets/locals.css.scss
@@ -358,3 +358,23 @@ a.make-primary-link {
     height: 500px !important;
   }
 }
+
+#artwork_source_data {
+  tr:nth-child(odd) {
+    background-color: #f9f9f9;
+  }
+
+  label {
+    display: inline-block;
+
+    span,
+    img {
+      padding: 5px;
+    }
+
+    span:has(+input:checked),
+    img:has(+input:checked) {
+      background-color: #eef;
+    }
+  }
+}

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -268,9 +268,7 @@ class Submission < ApplicationRecord
       condition_description: condition_report,
       signature: signature_detail,
       coa_by_authenticating_body: coa_by_authenticating_body,
-      coa_by_gallery: coa_by_gallery,
-      import_source: "convection",
-      external_id: id
+      coa_by_gallery: coa_by_gallery
     }
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -114,6 +114,10 @@ class Submission < ApplicationRecord
     consigned_partner_submission&.state
   end
 
+  def sorted_images
+    images.sort_by.with_index { |a, i| a == primary_image ? -1 : i }
+  end
+
   def as_json(options = {})
     if options[:properties] == :short
       return(
@@ -245,7 +249,7 @@ class Submission < ApplicationRecord
   def to_artwork_params
     {
       title: title,
-      artists: [artist_id],
+      artists: [artist_id.presence].compact,
       category: category,
       medium: medium,
       date: year,
@@ -273,7 +277,7 @@ class Submission < ApplicationRecord
   def to_edition_set_params
     {
       edition_size: edition_size,
-      available_editions: [edition_number],
+      available_editions: [edition_number.presence].compact,
       artist_proofs: artist_proofs,
       height: height,
       width: width,

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -328,31 +328,23 @@ class SubmissionService
       submission
     end
 
-    def list_artwork(submission, gravity_partner_id, access_token)
-      raise SubmissionError, "Partner is required" unless gravity_partner_id.present?
+    def list_artwork(submission, access_token, artwork_params, edition_set_params, images_or_urls)
       # Validate artist is set and public
-      raise SubmissionError, "Must have an artist to list" if submission.artist_id.blank?
-      artist = GravityV1.get("/api/v1/artist/#{submission.artist_id}")
+      raise SubmissionError, "Must have an artist to list" if artwork_params[:artists].empty?
+      artist = GravityV1.get("/api/v1/artist/#{artwork_params[:artists].first}")
       raise SubmissionError, "Artist must be public" unless artist["public"]
 
-      # TODO: Source data from Salesforce or MyCollection artworks as desired
-
       # Create artwork
-      artwork = GravityV1.post("/api/v1/artwork",
-        params: submission.to_artwork_params.merge(partner: gravity_partner_id),
-        token: access_token)
+      artwork = GravityV1.post("/api/v1/artwork", params: artwork_params, token: access_token)
 
       # Add edition set if applicable
-      if submission.edition?
-        GravityV1.post("/api/v1/artwork/#{artwork["_id"]}/edition_set",
-          params: submission.to_edition_set_params,
-          token: access_token)
+      if edition_set_params.any?
+        GravityV1.post("/api/v1/artwork/#{artwork["_id"]}/edition_set", params: edition_set_params, token: access_token)
       end
 
-      # Add images, primary image first
-      submission.sorted_images
-        .map { |a| a.original_image }
-        .each do |url|
+      # Add images
+      images_or_urls.each do |image_or_url|
+        url = image_or_url.respond_to?(:original_image) ? image_or_url.original_image : image_or_url
         GravityV1.post("/api/v1/artwork/#{artwork["_id"]}/image",
           params: {remote_image_url: url, low_priority: true},
           token: access_token)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -350,8 +350,7 @@ class SubmissionService
       end
 
       # Add images, primary image first
-      submission.assets
-        .sort_by.with_index { |a, i| submission.primary_image && a == submission.primary_image ? -1 : i }
+      submission.sorted_images
         .map { |a| a.original_image }
         .each do |url|
         GravityV1.post("/api/v1/artwork/#{artwork["_id"]}/image",

--- a/app/views/admin/submissions/_list_artwork_modal.html.erb
+++ b/app/views/admin/submissions/_list_artwork_modal.html.erb
@@ -1,7 +1,11 @@
 <%
   submission_artwork_params = @submission.to_artwork_params || {}
   salesforce_artwork_params = SalesforceService.salesforce_artwork_to_artwork_params(@submission.salesforce_artwork) || {}
-  fields = submission_artwork_params.keys | salesforce_artwork_params.keys
+  artwork_fields = submission_artwork_params.keys | salesforce_artwork_params.keys
+
+  submission_edition_set_params = @submission.to_edition_set_params || {}
+  salesforce_edition_set_params = SalesforceService.salesforce_artwork_to_edition_set_params(@submission.salesforce_artwork) || {}
+  edition_set_fields = submission_edition_set_params.keys | salesforce_edition_set_params.keys
 %>
 <div class='modal remodal smaller-modal' data-remodal-id='list-artwork-modal'
   data-remodal-options="hashTracking: false">
@@ -30,13 +34,39 @@
                   <th>Submission Data</th>
                   <th>Salesforce Data</th>
                 </tr>
-                <% fields.each do |field| %>
+
+                <!-- artwork fields -->
+                <% artwork_fields.each do |field| %>
                   <tr>
                     <td><%= field %></td>
                     <td><%= submission_artwork_params[field] %></td>
                     <td><%= salesforce_artwork_params[field] %></td>
                   </tr>
                 <% end %>
+
+                <!-- edition set fields -->
+                <% edition_set_fields.each do |field| %>
+                  <tr>
+                    <td><%= field %></td>
+                    <td><%= submission_edition_set_params[field] %></td>
+                    <td><%= salesforce_edition_set_params[field] %></td>
+                  </tr>
+                <% end %>
+
+                <!-- images -->
+                <tr>
+                  <td>Images</td>
+                  <td>
+                    <% @submission.sorted_images.each do |image| %>
+                      <%= image_tag image.image_urls["thumbnail"], style: 'max-width: 100px; max-height: 100px;' %>
+                    <% end %>
+                  </td>
+                  <td>
+                    <% SalesforceService.salesforce_artwork_to_image_urls(@submission.salesforce_artwork).each do |image_url| %>
+                      <%= image_tag image_url, style: 'max-width: 100px; max-height: 100px;' %>
+                    <% end %>
+                  </td>
+                </tr>
               </table>
             </div>
             <div class='single-padding-top'>

--- a/app/views/admin/submissions/_list_artwork_modal.html.erb
+++ b/app/views/admin/submissions/_list_artwork_modal.html.erb
@@ -1,12 +1,3 @@
-<%
-  submission_artwork_params = @submission.to_artwork_params || {}
-  salesforce_artwork_params = SalesforceService.salesforce_artwork_to_artwork_params(@submission.salesforce_artwork) || {}
-  artwork_fields = submission_artwork_params.keys | salesforce_artwork_params.keys
-
-  submission_edition_set_params = @submission.to_edition_set_params || {}
-  salesforce_edition_set_params = SalesforceService.salesforce_artwork_to_edition_set_params(@submission.salesforce_artwork) || {}
-  edition_set_fields = submission_edition_set_params.keys | salesforce_edition_set_params.keys
-%>
 <div class='modal remodal smaller-modal' data-remodal-id='list-artwork-modal'
   data-remodal-options="hashTracking: false">
   <div class='modal-header'>
@@ -27,30 +18,52 @@
             <%= hidden_field_tag 'gravity_partner_id' %>
 
             <div style="text-align:right;">
-              <a onclick='$("#artwork_source_data").toggle(); return false;'><em>View source data</em></a>
+              <a onclick='$("#artwork_source_data").toggle(); return false;'><em>Select source data</em></a>
               <table class='table table-striped' id="artwork_source_data" style="display: none;">
                 <tr>
-                  <th>Field</th>
-                  <th>Submission Data</th>
-                  <th>Salesforce Data</th>
+                  <th>Field sources:</th>
+                  <th>Submission</th>
+                  <th>Salesforce</th>
                 </tr>
 
                 <!-- artwork fields -->
-                <% artwork_fields.each do |field| %>
+                <% @artwork_fields.each do |field| %>
                   <tr>
-                    <td><%= field %></td>
-                    <td><%= submission_artwork_params[field] %></td>
-                    <td><%= salesforce_artwork_params[field] %></td>
+                    <td><%= field.to_s.humanize %></td>
+                    <td>
+                      <%= label_tag do %>
+                        <span><%= @submission_artwork_params[field] %></span>
+                        <%= radio_button_tag "artwork_sources[#{field}]", "submission", @artwork_sources[field] == "submission" %>
+                      <% end %>
+                    </td>
+                    <td>
+                      <%= label_tag do %>
+                        <span><%= @salesforce_artwork_params[field] %></span>
+                        <%= radio_button_tag "artwork_sources[#{field}]", "salesforce", @artwork_sources[field] == "salesforce" %>
+                      <% end %>
+                    </td>
                   </tr>
                 <% end %>
 
                 <!-- edition set fields -->
-                <% edition_set_fields.each do |field| %>
-                  <tr>
-                    <td><%= field %></td>
-                    <td><%= submission_edition_set_params[field] %></td>
-                    <td><%= salesforce_edition_set_params[field] %></td>
-                  </tr>
+                <% if @submission.edition? %>
+                  <% @edition_set_fields.each do |field| %>
+                    <tr>
+                      <td><%= field.to_s.humanize %></td>
+                      <td>
+                        <%= label_tag do %>
+                          <span><%= @submission_edition_set_params[field] %></span>
+                          <%= radio_button_tag "edition_set_sources[#{field}]", "submission", @edition_set_sources[field] == "submission" %>
+                        <% end %>
+                      </td>
+                      <td>
+                        <%= label_tag do %>
+                          <span><%= @salesforce_edition_set_params[field] %></span>
+                          <%= radio_button_tag "edition_set_sources[#{field}]", "salesforce", @edition_set_sources[field] == "salesforce" %>
+                        <% end %>
+                      </td>
+                    </tr>
+                  <% end %>
                 <% end %>
 
                 <!-- images -->
@@ -58,12 +71,18 @@
                   <td>Images</td>
                   <td>
                     <% @submission.sorted_images.each do |image| %>
-                      <%= image_tag image.image_urls["thumbnail"], style: 'max-width: 100px; max-height: 100px;' %>
+                      <%= label_tag do %>
+                        <%= image_tag image.image_urls["thumbnail"] || "", style: 'max-width: 100px; max-height: 100px;' %>
+                        <%= check_box_tag "image_ids[]", image.id, true %>
+                      <% end %>
                     <% end %>
                   </td>
                   <td>
                     <% SalesforceService.salesforce_artwork_to_image_urls(@submission.salesforce_artwork).each do |image_url| %>
-                      <%= image_tag image_url, style: 'max-width: 100px; max-height: 100px;' %>
+                      <%= label_tag do %>
+                        <%= image_tag image_url, style: 'max-width: 100px; max-height: 100px;' %>
+                        <%= check_box_tag "salesforce_image_urls[]", "TODO", false %>
+                      <% end %>
                     <% end %>
                   </td>
                 </tr>

--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -16,7 +16,7 @@ class SalesforceService
     def salesforce_artwork_for_submission(submission)
       return unless api_enabled? && submission
 
-      # TODO: Re-add Medium_Type__c once reflected in staging sandbox
+      # TODO: Add Medium_Type__c, Size_of_edition__c, Available_works__c once available in staging
       api.query(
         <<~SQL
           select Id, Primary_Artist__c, CurrencyIsoCode, Depth__c, Artwork_Title__c, Artwork_Year__c, Diameter__c, Width__c, Height__c, Medium__c, Ecommerce__c, Price_Listed__c, Price_Hidden__c, Certificate_of_Authenticity__c, COA_by_Authenticating_Body__c, COA_by_Gallery__c, Condition_Notes__c, Edition_Information__c, Framed__c, Metric__c, Primary_Image_URL__c, Provenance__c, Signature_Description__c, Signed_by_Artist__c, Signed_in_Plate__c, Signed_Other__c, Not_Signed__c, Artwork_Price_Min__c, Artwork_Price_Max__c, Literature__c, Exhibition_History__c, Edition_Number__c
@@ -26,17 +26,15 @@ class SalesforceService
       ).first
     end
 
-    # TODO: Edition_Number__c is unused due to its poor formatting
-    # TODO: Consider Size_of_edition__c and Available_works__c once reflected in staging sandbox
     def salesforce_artwork_to_artwork_params(salesforce_artwork)
       return unless salesforce_artwork
 
       {
-        artists: [find_artist(salesforce_artwork.Primary_Artist__c)&.Gravity_Artist_ID__c].compact,
+        artists: [find_artist(salesforce_artwork.Primary_Artist__c)&.Gravity_Artist_ID__c.presence].compact,
         price_currency: salesforce_artwork.CurrencyIsoCode.presence,
         depth: salesforce_artwork.Depth__c.presence,
         title: salesforce_artwork.Artwork_Title__c.presence,
-        year: salesforce_artwork.Artwork_Year__c.presence,
+        date: salesforce_artwork.Artwork_Year__c.presence,
         diameter: salesforce_artwork.Diameter__c.presence,
         width: salesforce_artwork.Width__c.presence,
         height: salesforce_artwork.Height__c.presence,
@@ -62,6 +60,19 @@ class SalesforceService
         price_max: salesforce_artwork.Artwork_Price_Max__c.presence,
         literature: salesforce_artwork.Literature__c.presence,
         exhibition_history: salesforce_artwork.Exhibition_History__c.presence
+      }
+    end
+
+    def salesforce_artwork_to_edition_set_params(salesforce_artwork)
+      return unless salesforce_artwork
+
+      {
+        edition_size: salesforce_artwork.Size_of_edition__c.presence,
+        available_editions: [salesforce_artwork.Available_works__c.presence].compact,
+        height: salesforce_artwork.Height__c.presence,
+        width: salesforce_artwork.Width__c.presence,
+        depth: salesforce_artwork.Depth__c.presence,
+        metric: salesforce_artwork.Metric__c.presence
       }
     end
 

--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -16,10 +16,9 @@ class SalesforceService
     def salesforce_artwork_for_submission(submission)
       return unless api_enabled? && submission
 
-      # TODO: Add Medium_Type__c, Size_of_edition__c, Available_works__c once available in staging
       api.query(
         <<~SQL
-          select Id, Primary_Artist__c, CurrencyIsoCode, Depth__c, Artwork_Title__c, Artwork_Year__c, Diameter__c, Width__c, Height__c, Medium__c, Ecommerce__c, Price_Listed__c, Price_Hidden__c, Certificate_of_Authenticity__c, COA_by_Authenticating_Body__c, COA_by_Gallery__c, Condition_Notes__c, Edition_Information__c, Framed__c, Metric__c, Primary_Image_URL__c, Provenance__c, Signature_Description__c, Signed_by_Artist__c, Signed_in_Plate__c, Signed_Other__c, Not_Signed__c, Artwork_Price_Min__c, Artwork_Price_Max__c, Literature__c, Exhibition_History__c, Edition_Number__c
+          select Id, Primary_Artist__c, CurrencyIsoCode, Depth__c, Artwork_Title__c, Artwork_Year__c, Diameter__c, Width__c, Height__c, Medium__c, Ecommerce__c, Price_Listed__c, Price_Hidden__c, Certificate_of_Authenticity__c, COA_by_Authenticating_Body__c, COA_by_Gallery__c, Condition_Notes__c, Edition_Information__c, Framed__c, Metric__c, Primary_Image_URL__c, Provenance__c, Signature_Description__c, Signed_by_Artist__c, Signed_in_Plate__c, Signed_Other__c, Not_Signed__c, Artwork_Price_Min__c, Artwork_Price_Max__c, Literature__c, Exhibition_History__c, Edition_Number__c, Medium_Type__c, Size_of_edition__c, Available_works__c
           from Artwork__c
           where Convection_ID__c = '#{submission.id}'
         SQL


### PR DESCRIPTION
A little progress pulling edition- and image-related fields into the listing modal.

There are no affordances for picking and choosing different sources by field, but that might come next.