### PR TITLE
chore: add submission source to convection GraphQL

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1374,6 +1374,7 @@ type Submission {
   rejectionReason: String
   saleState: String
   signature: Boolean
+  source: SubmissionSource
 
   """
   If this artwork exists in Gravity, its ID

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -53,6 +53,7 @@ module Types
     nilable_field :user_phone, String, null: true
     nilable_field :width, String, null: true
     nilable_field :year, String, null: true
+    nilable_field :source, Types::SubmissionSourceType, null: true
     nilable_field :utm_source, String, null: true
     nilable_field :utm_medium, String, null: true
     nilable_field :utm_term, String, null: true


### PR DESCRIPTION
This PR resolves [ONYX-986]


This PR exposes the submission source to the submission interface. This is needed in order to properly fill the state when loading the edit submission flow screen in this PR https://github.com/artsy/eigen/pull/10281


[ONYX-986]: https://artsyproduct.atlassian.net/browse/ONYX-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ