### PR TITLE
fix "could not obtain a connection from the pool" error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ latest.dump
 node_modules/
 public
 yarn-error.log
+.ruby-version

--- a/app/services/my_collection_artwork_updated_service.rb
+++ b/app/services/my_collection_artwork_updated_service.rb
@@ -16,7 +16,7 @@ class MyCollectionArtworkUpdatedService
       return
     end
 
-    if submission.state != "submitted"
+    if submission.state != "approved"
       Rails.logger.info("[MyCollectionArtworkUpdatedService] Submission #{submission.id} is not in submitted state - skipping notification.")
       return
     end

--- a/config/initializers/sneakers.rb
+++ b/config/initializers/sneakers.rb
@@ -12,6 +12,8 @@ Sneakers.configure(
   log: Rails.logger,
   daemonize: false,
   pid_path: "tmp/pids/sneakers.pid",
-  workers: 1
+  workers: 1,
+  threads: ENV.fetch("RAILS_MAX_THREADS", 5), # match default database pool size.
+  prefetch: ENV.fetch("RAILS_MAX_THREADS", 5) # match threads size (docs recommend this)
 )
 Sneakers.logger.level = Logger::INFO


### PR DESCRIPTION
Should fix "could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use" error for sneakers. Default threads count is 10 as per [doc](https://github.com/jondot/sneakers/wiki/Configuration#workers), but `RAILS_MAX_THREADS` is 5.

Also made a change to notify admins only about changes made to approved submissions.