### PR TITLE
feat(onyx-1042): submission GraphQL type supports myCollectionArtworkID field

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1367,6 +1367,7 @@ type Submission {
   locationState: String
   medium: String
   minimumPriceDollars: Int
+  myCollectionArtworkID: String
   offers(gravityPartnerId: ID!): [Offer!]!
   primaryImage: Asset
   provenance: String

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -36,6 +36,7 @@ module Types
     nilable_field :location_country_code, String, null: true
     nilable_field :medium, String, null: true
     nilable_field :minimum_price_dollars, Integer, null: true
+    nilable_field :myCollectionArtworkID, String, null: true, method: :my_collection_artwork_id
     nilable_field :primary_image, Types::AssetType, null: true
     nilable_field :provenance, String, null: true
     nilable_field :published_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/spec/requests/api/graphql/queries/submission_spec.rb
+++ b/spec/requests/api/graphql/queries/submission_spec.rb
@@ -129,6 +129,34 @@ describe "submission query" do
           )
         end
       end
+
+      context "myCollectionArtworkID" do
+        let(:token) { "foo.bar.baz" }
+        let(:submission) { Fabricate :submission, session_id: "session", my_collection_artwork_id: "artwork-id" }
+        let(:query_inputs) { "id: #{submission.id}, sessionID: \"session\"" }
+
+        it "returns correct myCollectionArtworkID field" do
+          query = <<-GRAPHQL
+            query {
+              submission(#{query_inputs}) {
+                myCollectionArtworkID
+              }
+            }
+          GRAPHQL
+
+          post "/api/graphql", params: {query: query}, headers: headers
+
+          expect(response.status).to eq 200
+          body = JSON.parse(response.body)
+
+          submission_response = body["data"]["submission"]
+          expect(submission_response).to match(
+            {
+              "myCollectionArtworkID" => "artwork-id"
+            }
+          )
+        end
+      end
     end
 
     context "with a request from a submission owner" do


### PR DESCRIPTION
To more easily query for artwork metadata stored in My Collection via an associated Submission (in Convection), we want to expose an artwork field under Submission within the GraphQL schema:

```graphql
query X {
  submission(id: "x") {
    artwork {
      ...
    }
  }
}
```

Convection needs to return myCollectionArtworkID field so that Metaphysics could do the stitching thing.