### PR TITLE
feat: create Gravity edition set based on more flexible criteria

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -284,6 +284,10 @@ class Submission < ApplicationRecord
     }
   end
 
+  def likely_edition?
+    edition? || edition_size.present? || edition_number.present?
+  end
+
   def salesforce_artwork
     @salesforce_artwork ||= SalesforceService.salesforce_artwork_for_submission(self)
   end

--- a/app/views/admin/submissions/_list_artwork_modal.html.erb
+++ b/app/views/admin/submissions/_list_artwork_modal.html.erb
@@ -46,7 +46,7 @@
                 <% end %>
 
                 <!-- edition set fields -->
-                <% if @submission.edition? %>
+                <% if @submission.likely_edition? %>
                   <% @edition_set_fields.each do |field| %>
                     <tr>
                       <td><%= field.to_s.humanize %></td>


### PR DESCRIPTION
The `edition` parameter is no longer provided by clients, so it's not reliable in practice. (There are many editioned submissions with `edition: false`.) When listing a submission for sale, we'll create an edition set based on the presence of other fields.