### PR TITLE
fix: ensure likely editions are created as well as displayed

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -151,7 +151,7 @@ module Admin
       end
 
       edition_set_params = {}.with_indifferent_access
-      if @submission.edition?
+      if @submission.likely_edition?
         params[:edition_set_sources].each do |key, value|
           if value == "submission"
             edition_set_params[key] = @submission_edition_set_params[key.to_sym]


### PR DESCRIPTION
This is a follow-up fix to https://github.com/artsy/convection/pull/1474, which exposed edition fields under more circumstances. We also need to create the edition set record according to the same logic.