### PR TITLE
feat: link to edit view for listed artworks instead of web page

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -39,6 +39,10 @@ module UrlHelper
     "#{Convection.config.artsy_url}/artwork/#{artwork_id}"
   end
 
+  def edit_artwork_url(artwork_id)
+    "#{Convection.config.artsy_cms_url}/artworks/#{artwork_id}/edit?update_current_partner=1"
+  end
+
   def my_collection_artwork_url(artwork_id)
     "#{Convection.config.artsy_url}/collector-profile/my-collection/artwork/#{artwork_id}"
   end

--- a/app/views/admin/submissions/_listed_artworks.html.erb
+++ b/app/views/admin/submissions/_listed_artworks.html.erb
@@ -3,7 +3,7 @@
     <div class='bold-label'>Listed Artworks</div>
     <% @submission.listed_artwork_ids.each do |artwork_id| %>
       <div class='single-padding-top smaller-sidebar-link'>
-        <%= link_to artwork_id, artwork_url(artwork_id) %>
+        <%= link_to artwork_id, edit_artwork_url(artwork_id) %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
As discussed, we should link administrators to the CMS view where they can edit a listed artwork further, not its public web page. This PR takes advantage of [a new Volt capability](https://github.com/artsy/volt/pull/7645) to accomplish that.

FYI @nickskalkin 