### PR TITLE
feat: update logic for associating a submission to the logged in user

### DIFF
--- a/app/graphql/resolvers/add_user_to_submission_resolver.rb
+++ b/app/graphql/resolvers/add_user_to_submission_resolver.rb
@@ -27,4 +27,8 @@ class AddUserToSubmissionResolver < BaseResolver
 
     {consignment_submission: submission}
   end
+
+  def submission
+    @submission ||= Submission.find_by(uuid: submission_id)
+  end
 end

--- a/app/graphql/resolvers/add_user_to_submission_resolver.rb
+++ b/app/graphql/resolvers/add_user_to_submission_resolver.rb
@@ -6,14 +6,17 @@ class AddUserToSubmissionResolver < BaseResolver
   def run
     check_submission_presence!
 
-    # check if user's email in Gravity matches the one on the submission
-    unless matching_email(submission)
-      raise(GraphQL::ExecutionError, "Submission not found for this user")
+    # early no-op if already claimed by the current user
+    if submitted_by_current_user?(submission)
+      return {consignment_submission: submission}
     end
 
-    #  make sure submission has no user
     if submission.user_id
       raise(GraphQL::ExecutionError, "Submission already has a user")
+    end
+
+    if submission.state != Submission::DRAFT
+      raise(GraphQL::ExecutionError, "Submission must be in a draft state to claim")
     end
 
     SubmissionService.add_user_to_submission(
@@ -22,7 +25,6 @@ class AddUserToSubmissionResolver < BaseResolver
       @context[:jwt_token]
     )
 
-    # return submission
     {consignment_submission: submission}
   end
 end

--- a/spec/requests/api/graphql/mutations/add_user_to_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/add_user_to_submission_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "support/gravity_helper"
+
+describe "addUserToSubmission mutation" do
+  let(:user) { Fabricate(:user, gravity_user_id: "userid") }
+
+  let(:token) do
+    payload = {aud: "gravity", sub: user.gravity_user_id, roles: "user"}
+    JWT.encode(payload, Convection.config.jwt_secret)
+  end
+
+  let(:headers) { {"Authorization" => "Bearer #{token}"} }
+
+  before do
+    allow(Convection.config).to receive(:send_new_receipt_email).and_return(true)
+  end
+
+  it "associates a user with an unclaimed draft submission" do
+    submission = Fabricate(:submission, user: nil)
+
+    mutation = <<-GRAPHQL
+        mutation {
+          addUserToSubmission(input: { id: \"#{submission.id}\" }) {
+            clientMutationId
+            consignmentSubmission {
+              internalID
+            }
+          }
+        }
+    GRAPHQL
+
+    expect(SubmissionService).to receive(:create_my_collection_artwork).and_return(true)
+
+    post "/api/graphql", params: {query: mutation}, headers: headers
+
+    expect(response.status).to eq 200
+    body = JSON.parse(response.body)
+
+    expect(body["data"]["addUserToSubmission"]["consignmentSubmission"]["internalID"]).to eq submission.id.to_s
+  end
+
+  it "no-ops and returns the submission if the current user is already associated with the submission" do
+    submission = Fabricate(:submission, user: user)
+
+    mutation = <<-GRAPHQL
+        mutation {
+          addUserToSubmission(input: { id: \"#{submission.id}\" }) {
+            clientMutationId
+            consignmentSubmission {
+              internalID
+            }
+          }
+        }
+    GRAPHQL
+
+    post "/api/graphql", params: {query: mutation}, headers: headers
+
+    expect(response.status).to eq 200
+    body = JSON.parse(response.body)
+
+    expect(body["data"]["addUserToSubmission"]["consignmentSubmission"]["internalID"]).to eq submission.id.to_s
+  end
+
+  it "returns an error if the submission has already been claimed by a different user" do
+    submission = Fabricate(:submission, user: Fabricate(:user))
+
+    mutation = <<-GRAPHQL
+        mutation {
+          addUserToSubmission(input: { id: \"#{submission.id}\" }) {
+            clientMutationId
+            consignmentSubmission {
+              internalID
+            }
+          }
+        }
+    GRAPHQL
+
+    expect {
+      post "/api/graphql", params: {query: mutation}, headers: headers
+    }.to change(Asset, :count).by(0)
+
+    expect(response.status).to eq 200
+
+    body = JSON.parse(response.body)
+
+    error_message = body["errors"][0]["message"]
+    expect(error_message).to eq "Submission already has a user"
+  end
+
+  it "returns an error if the submission is not in a draft state" do
+    submission = Fabricate(:submission, user: nil, state: Submission::SUBMITTED)
+
+    mutation = <<-GRAPHQL
+        mutation {
+          addUserToSubmission(input: { id: \"#{submission.id}\" }) {
+            clientMutationId
+            consignmentSubmission {
+              internalID
+            }
+          }
+        }
+    GRAPHQL
+
+    expect {
+      post "/api/graphql", params: {query: mutation}, headers: headers
+    }.to change(Asset, :count).by(0)
+
+    expect(response.status).to eq 200
+
+    body = JSON.parse(response.body)
+
+    error_message = body["errors"][0]["message"]
+    expect(error_message).to eq "Submission must be in a draft state to claim"
+  end
+end


### PR DESCRIPTION
Before:
- Submission email address must match logged in user's email address
- Submission user_id must not already be present

After:
- If user_id is present, it must corresponding to the ID of the logged in user
- If user_id is not present, submission must be in a draft state

cc/ @joeyAghion as you were interested in these permission changes.