### PR TITLE
feat: support total_count param for GET /submissions

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -37,7 +37,7 @@ module Api
 
       # Return x-total-count header if total_count param is present. Keep this last
       if params[:total_count].present?
-        headers["X-Total-Count"] = Submission.count
+        headers["X-Total-Count"] = submissions.count
       end
 
       render json: submissions.to_json, status: :ok

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -24,6 +24,10 @@ module Api
     end
 
     def index
+      # Return x-total-count header if total_count param is present
+      if params[:total_count].present?
+        headers["X-Total-Count"] = Submission.count
+      end
       param! :completed, :boolean, default: nil
 
       user = User.where(gravity_user_id: current_user).first

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -24,10 +24,6 @@ module Api
     end
 
     def index
-      # Return x-total-count header if total_count param is present
-      if params[:total_count].present?
-        headers["X-Total-Count"] = Submission.count
-      end
       param! :completed, :boolean, default: nil
 
       user = User.where(gravity_user_id: current_user).first
@@ -38,6 +34,12 @@ module Api
       end
 
       submissions = submissions.order(created_at: :desc).page(page).per(size)
+
+      # Return x-total-count header if total_count param is present. Keep this last
+      if params[:total_count].present?
+        headers["X-Total-Count"] = Submission.count
+      end
+
       render json: submissions.to_json, status: :ok
     end
 

--- a/spec/requests/api/submissions/index_spec.rb
+++ b/spec/requests/api/submissions/index_spec.rb
@@ -57,6 +57,18 @@ describe "Show Submission" do
       expect(body.first["id"]).to eq submission.id
     end
 
+    fit "returns total count when total_count param is present" do
+      Fabricate(:submission, user: user, state: "approved")
+      Fabricate(:submission, user: user, state: "draft")
+      Fabricate(:submission, user: user, state: "approved")
+
+      get "/api/submissions?total_count=true&size=1", headers: headers
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body.length).to eq 1
+      expect(response.headers["X-Total-Count"]).to eq 3
+    end
+
     describe "filtering" do
       it "defaults to all types of submissions submissions" do
         Fabricate(:submission, user: user, state: "approved")

--- a/spec/requests/api/submissions/index_spec.rb
+++ b/spec/requests/api/submissions/index_spec.rb
@@ -62,10 +62,10 @@ describe "Show Submission" do
       Fabricate(:submission, user: user, state: "draft")
       Fabricate(:submission, user: user, state: "approved")
 
-      get "/api/submissions?total_count=true&size=1", headers: headers
+      get "/api/submissions?total_count=true&size=10", headers: headers
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body.length).to eq 1
+      expect(body.length).to eq 3
       expect(response.headers["X-Total-Count"]).to eq 3
     end
 


### PR DESCRIPTION
This PR adds support to a new param to `GET /submissions` endpoint in order to return the total count of submission.
This might not be the best approach because we might need to support the same param in other endpoints, It would be interesting to investigate how to support that everywhere - but maybe that's not possible.

Why did we add this?
This was important in order to return the `totalCount` of submissions for a user in the `submissionsConnection` interface.