### PR TITLE
feat: add state filtering to Get /submissions

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -28,6 +28,11 @@ module Api
 
       user = User.where(gravity_user_id: current_user).first
       submissions = Submission.where(user: user)
+
+      if params.include? :state
+        submissions = submissions.where(state: params[:state])
+      end
+
       if params.include? :completed
         submissions =
           params[:completed] ? submissions.completed : submissions.draft

--- a/spec/requests/api/submissions/index_spec.rb
+++ b/spec/requests/api/submissions/index_spec.rb
@@ -31,22 +31,20 @@ describe "Show Submission" do
       expect(body).to eq []
     end
 
-
-    fit "returns only draft submissions when state is draft" do
-      submission = Fabricate(:submission, user: user, state: "draft")
+    it "returns only draft submissions when state is draft" do
+      Fabricate(:submission, user: user, state: "draft")
       Fabricate(:submission, user: user, state: "approved")
       Fabricate(:submission, user: user, state: "submitted")
 
       get "/api/submissions",
         params: {
-          state: "draft"
+          state: ["draft", "submitted"]
         },
         headers: headers
 
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
-      expect(body.length).to eq 1
-      expect(body[0]["id"]).to eq submission.id
+      expect(body.length).to eq 2
     end
 
     it "returns your own submissions" do

--- a/spec/requests/api/submissions/index_spec.rb
+++ b/spec/requests/api/submissions/index_spec.rb
@@ -45,6 +45,7 @@ describe "Show Submission" do
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body.length).to eq 2
+      expect(body.map { |submission| submission["state"]}).to eq ["submitted", "draft"]
     end
 
     it "returns your own submissions" do

--- a/spec/requests/api/submissions/index_spec.rb
+++ b/spec/requests/api/submissions/index_spec.rb
@@ -45,7 +45,7 @@ describe "Show Submission" do
       expect(response.status).to eq 200
       body = JSON.parse(response.body)
       expect(body.length).to eq 2
-      expect(body.map { |submission| submission["state"]}).to eq ["submitted", "draft"]
+      expect(body.map { |submission| submission["state"] }).to eq ["submitted", "draft"]
     end
 
     it "returns your own submissions" do

--- a/spec/requests/api/submissions/index_spec.rb
+++ b/spec/requests/api/submissions/index_spec.rb
@@ -31,6 +31,24 @@ describe "Show Submission" do
       expect(body).to eq []
     end
 
+
+    fit "returns only draft submissions when state is draft" do
+      submission = Fabricate(:submission, user: user, state: "draft")
+      Fabricate(:submission, user: user, state: "approved")
+      Fabricate(:submission, user: user, state: "submitted")
+
+      get "/api/submissions",
+        params: {
+          state: "draft"
+        },
+        headers: headers
+
+      expect(response.status).to eq 200
+      body = JSON.parse(response.body)
+      expect(body.length).to eq 1
+      expect(body[0]["id"]).to eq submission.id
+    end
+
     it "returns your own submissions" do
       submission = Fabricate(:submission, user: user, state: "approved")
       Fabricate(


### PR DESCRIPTION
This PR adds state filtering to `Get /submissions` endpoint. This comes as a follow-up on 
https://github.com/artsy/metaphysics/pull/5811#pullrequestreview-2138312442