### PR TITLE
fix: Adjust update submission error message when state not draft

### DIFF
--- a/app/graphql/resolvers/update_submission_resolver.rb
+++ b/app/graphql/resolvers/update_submission_resolver.rb
@@ -6,11 +6,14 @@ class UpdateSubmissionResolver < BaseResolver
   def run
     check_submission_presence!
 
-    unless (
-             matching_user(submission, @arguments&.[](:session_id)) &&
-               submission.draft?
-           ) || admin?
-      raise(GraphQL::ExecutionError, "Submission Not Found")
+    unless admin?
+      unless matching_user(submission, @arguments&.[](:session_id))
+        raise(GraphQL::ExecutionError, "Submission Not Found")
+      end
+
+      unless submission.draft?
+        raise(GraphQL::ExecutionError, "Cannot update a submission that is not in draft state.")
+      end
     end
 
     # I'm not clear if this is needed or not - there are no tests for it so I'm

--- a/spec/requests/api/graphql/mutations/update_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/update_consignment_submission_spec.rb
@@ -233,7 +233,7 @@ describe "updateConsignmentSubmission mutation" do
           expect(update_response).to eq nil
 
           error_message = body["errors"][0]["message"]
-          expect(error_message).to eq "Submission Not Found"
+          expect(error_message).to eq "Cannot update a submission that is not in draft state."
         end
       end
     end


### PR DESCRIPTION
Context: https://github.com/artsy/force/pull/14076#discussion_r1652855229

## Description

Adjust update submission error message when state not draft.