### PR TITLE
chore: deprecated userPhone interface

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -1387,6 +1387,10 @@ type Submission {
   userEmail: String
   userId: String!
   userName: String
+
+  """
+  Deprecated: Use userPhoneNumber interface field instead
+  """
   userPhone: String
   utmMedium: String
   utmSource: String

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -51,7 +51,7 @@ module Types
     nilable_field :user_id, String, null: false, default_value: -1
     nilable_field :user_name, String, null: true
     nilable_field :user_email, String, null: true
-    nilable_field :user_phone, String, null: true
+    nilable_field :user_phone, String, null: true, description: "Deprecated: Use userPhoneNumber interface field instead"
     nilable_field :width, String, null: true
     nilable_field :year, String, null: true
     nilable_field :source, Types::SubmissionSourceType, null: true


### PR DESCRIPTION
This PR deprecates the `userPhone` number string field and suggests instead to use `userPhoneNumber` interface that's stitched from MP

<img width="1004" alt="Screenshot 2024-06-27 at 12 36 32" src="https://github.com/artsy/convection/assets/11945712/349fb538-f22a-4c12-a806-49240617ec03">
