### PR TITLE
feat: track history of submission changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "jquery-rails"
 gem "kaminari" # for pagination
 gem "money" # for currency/money formatting
 gem "neat", "1.7.2" # required for watt
+gem "paper_trail" # track history of submissions
 gem "pg_search" # for searching within convection's database
 gem "premailer-rails" # generate text parts from HTML automatically
 gem "rack-cors" # to allow cross-origin requests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -327,6 +327,9 @@ GEM
     omniauth-rails_csrf_protection (1.0.0)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    paper_trail (15.1.0)
+      activerecord (>= 6.1)
+      request_store (~> 1.4)
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
@@ -405,6 +408,8 @@ GEM
     redcarpet (3.5.1)
     redis (4.8.1)
     regexp_parser (2.1.1)
+    request_store (1.7.0)
+      rack (>= 1.4)
     restforce (5.3.0)
       faraday (>= 0.9.0, <= 1.10.0)
       faraday_middleware (>= 0.8.8, <= 2.0)
@@ -578,6 +583,7 @@ DEPENDENCIES
   kaminari
   money
   neat (= 1.7.2)
+  paper_trail
   pg
   pg_search
   premailer-rails

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -33,5 +33,9 @@ module Api
     def jwt_token
       @jwt_token ||= request.env["JWT_TOKEN"]
     end
+
+    def user_for_paper_trail
+      current_user
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_current_user
   before_action :set_raven_context
+  before_action :set_paper_trail_whodunnit
 
   NotAuthorized = Class.new(StandardError)
 
@@ -28,5 +29,9 @@ class ApplicationController < ActionController::Base
 
   def set_raven_context
     Raven.user_context(id: @current_user)
+  end
+
+  def user_for_paper_trail
+    @current_user
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -6,6 +6,8 @@ class Submission < ApplicationRecord
   include PgSearch::Model
   include ReloadUuid
 
+  has_paper_trail
+
   alias_attribute :deleted?, :deleted_at
 
   scope :not_deleted, -> { where(deleted_at: nil) }

--- a/db/migrate/20240711211617_create_versions.rb
+++ b/db/migrate/20240711211617_create_versions.rb
@@ -1,0 +1,37 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[6.1]
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions do |t|
+      t.string :item_type, null: false
+      t.bigint :item_id, null: false
+      t.string :event, null: false
+      t.string :whodunnit
+      t.text :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      # MySQL users should use the following line for `created_at`
+      # t.datetime :created_at, limit: 6
+      t.datetime :created_at
+    end
+    add_index :versions, %i[item_type item_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_05_092437) do
+ActiveRecord::Schema.define(version: 2024_07_11_211617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -253,6 +253,16 @@ ActiveRecord::Schema.define(version: 2024_07_05_092437) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["gravity_user_id"], name: "index_users_on_gravity_user_id"
+  end
+
+  create_table "versions", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.string "event", null: false
+    t.string "whodunnit"
+    t.text "object"
+    t.datetime "created_at"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
   add_foreign_key "assets", "submissions"

--- a/spec/requests/api/graphql/mutations/update_consignment_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/update_consignment_submission_spec.rb
@@ -142,6 +142,8 @@ describe "updateConsignmentSubmission mutation" do
 
         update_response = body["data"]["updateConsignmentSubmission"]
         expect(update_response).to_not eq nil
+        expect(submission1.versions.size).to eq(2)
+        expect(submission1.versions.last.whodunnit).to eq("userid4")
       end
     end
 


### PR DESCRIPTION
This is a "spike" into integrating `paper_trail` for lightweight tracking of submission changes (related to [ONYX-1109](https://artsyproduct.atlassian.net/browse/ONYX-1109)). I followed [the default setup instructions](https://github.com/paper-trail-gem/paper_trail), and just overrode the `user_for_paper_trail` method for our 2 different use-cases (administrative requests, or API requests including via GraphQL). No user is tracked for logged-out updates, but that should be obvious from the submission data, I guess.

I don't want to bloat the repo for no reason, but if this sort of history is useful, we could consider a few further updates, neither difficult:
* make the history available in the UI (in some raw form)
* consider [switching](https://github.com/paper-trail-gem/paper_trail?tab=readme-ov-file#6b-custom-serializer) from YAML (the default) to JSON data formatting

[ONYX-1109]: https://artsyproduct.atlassian.net/browse/ONYX-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ