### PR TITLE
feat(onyx-1099): add address line 1 & 2 to submissions

### DIFF
--- a/_schema.graphql
+++ b/_schema.graphql
@@ -534,6 +534,8 @@ input CreateSubmissionMutationInput {
   editionSize: Int
   editionSizeFormatted: String
   height: String
+  locationAddress: String
+  locationAddress2: String
   locationCity: String
   locationCountry: String
   locationCountryCode: String
@@ -1374,6 +1376,8 @@ type Submission {
   """
   id: ID!
   internalID: ID
+  locationAddress: String
+  locationAddress2: String
   locationCity: String
   locationCountry: String
   locationCountryCode: String
@@ -1767,6 +1771,26 @@ enum SubmissionSort {
   sort by literature in descending order
   """
   LITERATURE_DESC
+
+  """
+  sort by location_address2 in ascending order
+  """
+  LOCATION_ADDRESS2_ASC
+
+  """
+  sort by location_address2 in descending order
+  """
+  LOCATION_ADDRESS2_DESC
+
+  """
+  sort by location_address in ascending order
+  """
+  LOCATION_ADDRESS_ASC
+
+  """
+  sort by location_address in descending order
+  """
+  LOCATION_ADDRESS_DESC
 
   """
   sort by location_city in ascending order
@@ -2185,6 +2209,8 @@ input UpdateSubmissionMutationInput {
   externalId: ID
   height: String
   id: ID
+  locationAddress: String
+  locationAddress2: String
   locationCity: String
   locationCountry: String
   locationCountryCode: String

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -256,6 +256,8 @@ module Admin
         edition_size_formatted
         exhibition
         height
+        location_address
+        location_address2
         location_city
         location_country
         location_state

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -69,6 +69,8 @@ module Api
           :edition_size,
           :edition_size_formatted,
           :height,
+          :location_address,
+          :location_address2,
           :location_city,
           :location_country,
           :location_state,

--- a/app/controllers/concerns/graphql_helper.rb
+++ b/app/controllers/concerns/graphql_helper.rb
@@ -198,9 +198,12 @@ module GraphqlHelper
       artistIds: [submission.artist_id],
       artworkLocation:
         [
+          submission.location_address,
+          submission.location_address2,
           submission.location_city,
           submission.location_state,
-          submission.location_country
+          submission.location_country,
+          submission.location_postal_code
         ].delete_if(&:blank?).join(", "),
       category: submission.category,
       date: submission.year,

--- a/app/events/submission_event.rb
+++ b/app/events/submission_event.rb
@@ -27,6 +27,8 @@ class SubmissionEvent < Events::BaseEvent
       artist_id: @object.artist_id,
       state: @object.state,
       year: @object.year,
+      location_address: @object.location_address,
+      location_address2: @object.location_address2,
       location_city: @object.location_city,
       location_state: @object.location_state,
       location_country: @object.location_country,

--- a/app/graphql/mutations/create_submission_mutation.rb
+++ b/app/graphql/mutations/create_submission_mutation.rb
@@ -24,6 +24,8 @@ module Mutations
       description: "Deprecated: Use edition_size_formatted field instead"
     argument :edition_size_formatted, String, required: false
     argument :height, String, required: false
+    argument :location_address, String, required: false
+    argument :location_address2, String, required: false
     argument :location_city, String, required: false
     argument :location_country, String, required: false
     argument :location_state, String, required: false

--- a/app/graphql/mutations/update_submission_mutation.rb
+++ b/app/graphql/mutations/update_submission_mutation.rb
@@ -24,6 +24,8 @@ module Mutations
       description: "Deprecated: Use edition_size_formatted field instead"
     argument :edition_size_formatted, String, required: false
     argument :height, String, required: false
+    argument :location_address, String, required: false
+    argument :location_address2, String, required: false
     argument :location_city, String, required: false
     argument :location_country, String, required: false
     argument :location_state, String, required: false

--- a/app/graphql/types/submission_type.rb
+++ b/app/graphql/types/submission_type.rb
@@ -31,6 +31,8 @@ module Types
     nilable_field :edition_number, String, null: true
     nilable_field :edition_size, String, null: true
     nilable_field :height, String, null: true
+    nilable_field :location_address, String, null: true
+    nilable_field :location_address2, String, null: true
     nilable_field :location_city, String, null: true
     nilable_field :location_country, String, null: true
     nilable_field :location_state, String, null: true

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -12,7 +12,9 @@ module SubmissionsHelper
       submission.location_city,
       submission.location_state,
       submission.location_country,
-      submission.location_postal_code
+      submission.location_postal_code,
+      submission.location_address,
+      submission.location_address2
     ].select(&:present?).join(", ")
   end
 

--- a/app/views/admin/submissions/_form.html.erb
+++ b/app/views/admin/submissions/_form.html.erb
@@ -286,6 +286,28 @@
           <div class='row single-padding-top'>
             <div class='col-sm-12'>
               <label class='col-sm-2 control-label bold-label'>
+                Address Line 1
+              </label>
+              <div class='col-sm-10'>
+                <%= f.text_field :location_address, class: 'form-control' %>
+              </div>
+            </div>
+          </div>
+
+          <div class='row single-padding-top'>
+            <div class='col-sm-12'>
+              <label class='col-sm-2 control-label bold-label'>
+                Address Line 2
+              </label>
+              <div class='col-sm-10'>
+                <%= f.text_field :location_address2, class: 'form-control' %>
+              </div>
+            </div>
+          </div>
+
+          <div class='row single-padding-top'>
+            <div class='col-sm-12'>
+              <label class='col-sm-2 control-label bold-label'>
                 Location State
               </label>
               <div class='col-sm-10'>

--- a/db/migrate/20240716094023_add_location_address_to_submissions.rb
+++ b/db/migrate/20240716094023_add_location_address_to_submissions.rb
@@ -1,0 +1,6 @@
+class AddLocationAddressToSubmissions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :submissions, :location_address, :string, null: true
+    add_column :submissions, :location_address2, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_05_092437) do
+ActiveRecord::Schema.define(version: 2024_07_16_094023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -239,6 +239,8 @@ ActiveRecord::Schema.define(version: 2024_07_05_092437) do
     t.string "location_postal_code"
     t.string "location_country_code"
     t.string "listed_artwork_ids", default: [], null: false, array: true
+    t.string "location_address"
+    t.string "location_address2"
     t.index ["consigned_partner_submission_id"], name: "index_submissions_on_consigned_partner_submission_id"
     t.index ["ext_user_id"], name: "index_submissions_on_ext_user_id"
     t.index ["primary_image_id"], name: "index_submissions_on_primary_image_id"

--- a/spec/events/submission_event_spec.rb
+++ b/spec/events/submission_event_spec.rb
@@ -16,6 +16,8 @@ describe SubmissionEvent do
       width: "14",
       depth: "2",
       dimensions_metric: "in",
+      location_address: "123 Fake St",
+      location_address2: "Apt 2",
       location_city: "New York",
       location_state: "NY",
       location_country: "US",
@@ -91,6 +93,8 @@ describe SubmissionEvent do
       expect(event.properties[:artist_id]).to eq "artistid"
       expect(event.properties[:state]).to eq "submitted"
       expect(event.properties[:year]).to eq "1992"
+      expect(event.properties[:location_address]).to eq "123 Fake St"
+      expect(event.properties[:location_address2]).to eq "Apt 2"
       expect(event.properties[:location_city]).to eq "New York"
       expect(event.properties[:location_state]).to eq "NY"
       expect(event.properties[:location_country]).to eq "US"

--- a/spec/fabricators/submission_fabricator.rb
+++ b/spec/fabricators/submission_fabricator.rb
@@ -13,6 +13,8 @@ Fabricator(:submission) do
   dimensions_metric "in"
   signature false
   authenticity_certificate false
+  location_address "123 Fake St"
+  location_address2 "Apt 2"
   location_city "New York"
   location_state "New York"
   location_country "USA"

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -11,6 +11,8 @@ describe SubmissionsHelper, type: :helper do
       submission =
         Fabricate(
           :submission,
+          location_address: "123 Fake St",
+          location_address2: "Apt 2",
           location_city: "Brooklyn",
           location_state: "New York",
           location_country: "USA",
@@ -18,13 +20,15 @@ describe SubmissionsHelper, type: :helper do
         )
       expect(
         helper.formatted_location(submission)
-      ).to eq "Brooklyn, New York, USA, 12345"
+      ).to eq "Brooklyn, New York, USA, 12345, 123 Fake St, Apt 2"
     end
 
     it "returns empty string when location values are nil" do
       submission =
         Fabricate(
           :submission,
+          location_address: "",
+          location_address2: "",
           location_city: "",
           location_state: "",
           location_country: "",

--- a/spec/helpers/submissions_helper_spec.rb
+++ b/spec/helpers/submissions_helper_spec.rb
@@ -45,7 +45,7 @@ describe SubmissionsHelper, type: :helper do
           location_state: "Tokyo",
           location_country: "Japan"
         )
-      expect(helper.formatted_location(submission)).to eq("Tokyo, Japan")
+      expect(helper.formatted_location(submission)).to eq("Tokyo, Japan, 123 Fake St, Apt 2")
     end
   end
 

--- a/spec/mailers/previews/base_preview.rb
+++ b/spec/mailers/previews/base_preview.rb
@@ -48,6 +48,8 @@ class BasePreview < ActionMailer::Preview
           "\"Accomplice” characters from KAWS are appropriately branded with the artist's trademark \"X\" " \
           "to replace each of the figure's original eyes. The black example is from an edition of 500 " \
           "and the pink example is from an edition of 1000",
+      location_address: "123 Fake St",
+      location_address2: "Apt 2",
       location_city: "New York",
       location_state: "NY",
       location_country: "USA",


### PR DESCRIPTION
[Jira](https://artsyproduct.atlassian.net/browse/ONYX-1099)

Adds address line 1 & 2 for tier 2 information needs. 
Adds these fields to graphql object type and to create / update mutations

Sample request 1:

```graphql
{
  submission(id: "246195") {
    id
    locationAddress
    locationAddress2
    locationCity
  }
}
```

Sample request 2:

```graphql
mutation {
  updateConsignmentSubmission(input: { id: "246195", locationAddress: "Not fake str", locationAddress2: "apt 3" }) {
    consignmentSubmission {
      locationAddress
      locationAddress2
    }
  }
}
```