### PR TITLE
feat: allow non-draft submissions to be fetched by authorized users

### DIFF
--- a/app/graphql/resolvers/submission_resolver.rb
+++ b/app/graphql/resolvers/submission_resolver.rb
@@ -6,14 +6,10 @@ class SubmissionResolver < BaseResolver
   def run
     check_submission_presence!
 
-    unless draft_in_progress?(submission, @arguments) || admin? || partner?
+    unless matching_user(submission, @arguments&.[](:session_id)) || admin? || partner?
       raise GraphQL::ExecutionError, "Submission Not Found"
     end
 
     submission
-  end
-
-  def draft_in_progress?(submission, arguments)
-    submission.draft? && matching_user(submission, arguments&.[](:session_id))
   end
 end

--- a/app/graphql/resolvers/update_submission_resolver.rb
+++ b/app/graphql/resolvers/update_submission_resolver.rb
@@ -6,16 +6,9 @@ class UpdateSubmissionResolver < BaseResolver
   def run
     check_submission_presence!
 
-    unless admin?
-      unless matching_user(submission, @arguments&.[](:session_id))
-        raise(GraphQL::ExecutionError, "Submission Not Found")
-      end
+    unless matching_user(submission, @arguments&.[](:session_id)) || admin?
+      raise(GraphQL::ExecutionError, "Submission Not Found")
     end
-
-    # I'm not clear if this is needed or not - there are no tests for it so I'm
-    # suspicious that it's stale.
-    #
-    # params.delete('dimensions_metric')
 
     SubmissionService.update_submission(
       submission,

--- a/spec/requests/api/graphql/queries/submission_spec.rb
+++ b/spec/requests/api/graphql/queries/submission_spec.rb
@@ -303,7 +303,7 @@ describe "submission query" do
           JWT.encode(payload, Convection.config.jwt_secret)
         end
 
-        it "returns an error for that request" do
+        it "returns the submission" do
           post "/api/graphql", params: {query: query}, headers: headers
 
           expect(response.status).to eq 200
@@ -330,17 +330,20 @@ describe "submission query" do
           JWT.encode(payload, Convection.config.jwt_secret)
         end
 
-        it "returns an error for that request" do
+        it "returns the submission" do
           post "/api/graphql", params: {query: query}, headers: headers
 
           expect(response.status).to eq 200
           body = JSON.parse(response.body)
 
           submission_response = body["data"]["submission"]
-          expect(submission_response).to eq nil
-
-          error_message = body["errors"][0]["message"]
-          expect(error_message).to eq "Submission Not Found"
+          expect(submission_response).to match(
+            {
+              "id" => submission.id.to_s,
+              "artistId" => submission.artist_id,
+              "title" => submission.title
+            }
+          )
         end
       end
     end


### PR DESCRIPTION
Allow users to query for non-draft submissions so that they can continue to provide information in later steps in the flow.