### PR TITLE
chore: add bullet gem to track n+1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "uglifier"
 gem "unleash"
 
 group :development, :test do
+  gem "bullet"
   gem "guard-rspec", require: false
   gem "pry-byebug"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
       sass (~> 3.4)
       thor
     builder (3.2.4)
+    bullet (7.2.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     bunny (2.17.0)
       amq-protocol (~> 2.3, >= 2.3.1)
     byebug (11.1.3)
@@ -526,6 +529,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.0.0)
+    uniform_notifier (1.16.0)
     unleash (4.0.0)
       murmurhash3 (~> 0.1.6)
     webdrivers (4.6.0)
@@ -557,6 +561,7 @@ DEPENDENCIES
   bootsnap
   bootstrap-sass
   bourbon (= 4.2.3)
+  bullet
   capybara
   coffee-rails
   console_color

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,6 +3,13 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = true

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,22 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) { driven_by :headless_chrome }
+
+  if Bullet.enable?
+    config.before do |example|
+      bullet_start_request_block = proc do
+        Bullet.start_request
+      end
+
+      hooks = example.send(:hooks)
+      hooks.register(:append, :before, :each, &bullet_start_request_block)
+    end
+
+    config.after do
+      Bullet.perform_out_of_channel_notifications if Bullet.notification?
+      Bullet.end_request
+    end
+  end
 end
 
 Capybara.server = :puma, {Silent: true}


### PR DESCRIPTION
This is my attempt to increase awareness of N+1 queries (which negatively affect application performance) and try to reduce a number of them. This PR adds https://github.com/flyerhzm/bullet that notifies developers when there are N+1 queries in their code and helps to deal with them. In development, bullet notifications appear in `development.log` and `bullet.log` files, in test environment - in `test.log` and `bullet.log` files. There is a 'fail' mode for test environment, but I think we are not ready for it yet. 

# Example

When opening `/admin/submissions` page, you fill find this in logs:

```
GET /admin/submissions
USE eager loading detected
  Submission => [:admin]
  Add to your query: .includes([:admin])
Call stack
  /Users/nikitaskalkin/Projects/convection/app/helpers/application_helper.rb:55:in `creator_title'
  /Users/nikitaskalkin/Projects/convection/app/helpers/application_helper.rb:41:in `creator_label'
...


GET /admin/submissions
USE eager loading detected
  Submission => [:primary_image]
  Add to your query: .includes([:primary_image])
Call stack
  /Users/nikitaskalkin/Projects/convection/app/models/submission.rb:180:in `thumbnail'
...
```

These 2 n+1 queries can be fixed by adding `.includes([:admin, :primary_image])` [here](https://github.com/artsy/convection/blob/main/app/controllers/admin/submissions_controller.rb#L21) (will do in a separate PR).