### PR TITLE
feat: Update My Collection artwork when creating a submission

### DIFF
--- a/app/graphql/resolvers/create_submission_resolver.rb
+++ b/app/graphql/resolvers/create_submission_resolver.rb
@@ -6,7 +6,8 @@ class CreateSubmissionResolver < BaseResolver
       SubmissionService.create_submission(
         @arguments,
         @context[:current_user],
-        is_convection: false
+        is_convection: false,
+        access_token: @context[:jwt_token]
       )
 
     {consignment_submission: submission}

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -14,7 +14,8 @@ class SubmissionService
       submission_params,
       gravity_user_id,
       is_convection: true,
-      current_user: nil
+      current_user: nil,
+      access_token: nil
     )
       if submission_params[
         :edition_size_formatted
@@ -45,6 +46,12 @@ class SubmissionService
       end
 
       submission = Submission.create!(create_params)
+
+      unless is_convection
+        if submission.user && !access_token.nil? && submission.my_collection_artwork_id && submission.source == "my_collection"
+          update_my_collection_artwork(submission, access_token)
+        end
+      end
 
       if create_params[:state] == "rejected"
         delay_until(
@@ -93,7 +100,7 @@ class SubmissionService
           submission.assign_attributes(
             reject_non_target_supply_artist(submission.artist_id)
           )
-          if !submission.draft? && submission.user && !access_token.nil?
+          if submission.user && !access_token.nil?
             create_or_update_my_collection_artwork(submission, access_token)
           end
         end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -18,6 +18,7 @@ describe SubmissionService do
       title: "My Artwork"
     )
   end
+  let(:access_token) { "access_token" }
 
   before { add_default_stubs }
 
@@ -64,6 +65,31 @@ describe SubmissionService do
             is_convection: false
           )
         expect(new_submission.reload.source).to eq nil
+      end
+
+      it "does not update the My Collection artwork" do
+        expect(SubmissionService).not_to receive(:update_my_collection_artwork)
+
+        SubmissionService.create_submission(
+          params,
+          "userid",
+          is_convection: false
+          )
+      end
+    end
+
+    context "when the submission has a My Colleciton artwork" do
+      let(:params_with_source) { params.merge({source: "my_collection", my_collection_artwork_id: "artwork-id" }) }
+
+      it "updates the My Collection artwork to set the submission ID" do
+        expect(SubmissionService).to receive(:update_my_collection_artwork)
+
+        SubmissionService.create_submission(
+          params_with_source,
+          "userid",
+          is_convection: false,
+          access_token: access_token
+        )
       end
     end
 

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -74,12 +74,12 @@ describe SubmissionService do
           params,
           "userid",
           is_convection: false
-          )
+        )
       end
     end
 
     context "when the submission has a My Colleciton artwork" do
-      let(:params_with_source) { params.merge({source: "my_collection", my_collection_artwork_id: "artwork-id" }) }
+      let(:params_with_source) { params.merge({source: "my_collection", my_collection_artwork_id: "artwork-id"}) }
 
       it "updates the My Collection artwork to set the submission ID" do
         expect(SubmissionService).to receive(:update_my_collection_artwork)


### PR DESCRIPTION
Addresses [ONYX-1133]

## Description

Currently, it is not possible to query draft submissions (when the Tier 1 submission flow is not yet finished) on a My Collection artwork ([GitHub](https://github.com/artsy/metaphysics/blob/3390f03de49bc99765ba6d62cb283a1b2a085753/src/schema/v2/artwork/index.ts#L429)), because they get linked when the submission gets submitted (state change to "SUBMITTED"). For the new My Collection submission status design, this would be necessary to make draft submissions visible on the My Collection artwork page.

---

With this PR, the submission will be linked to the My Collection artwork already when the submission is created. This would ensure that the artwork and the submission are linked correctly when a user submits an artwork from My Collection.

---

**Alternative Approaches**

Alternatively, we could update the My Collection artwork in the [stitched Metaphysics resolver](https://github.com/artsy/metaphysics/blob/3390f03de49bc99765ba6d62cb283a1b2a085753/src/lib/stitching/convection/v2/stitching.ts#L129). My reasoning for doing it in Convection instead is that we would then have two different places where we update the related My Collection artwork (Convection & Metaphysics).  

In the future, it might be good to migrate these updates to Metaphysics and not update data in Gravity from Convection.



[ONYX-1133]: https://artsyproduct.atlassian.net/browse/ONYX-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ