### PR TITLE
fix: allow publishing re-submitted submissions

### DIFF
--- a/app/models/submission_state_actions.rb
+++ b/app/models/submission_state_actions.rb
@@ -16,7 +16,7 @@ class SubmissionStateActions
     when Submission::DRAFT, Submission::SUBMITTED
       [approve_action, publish_action, hold_action, reject_action, close_action]
     when Submission::RESUBMITTED
-      [hold_action, reject_action, close_action]
+      [publish_action, hold_action, close_action]
     when Submission::APPROVED
       [publish_action, hold_action, close_action]
     when Submission::PUBLISHED

--- a/spec/models/submission_state_actions_spec.rb
+++ b/spec/models/submission_state_actions_spec.rb
@@ -28,10 +28,10 @@ describe SubmissionStateActions do
   context "with a resubmitted submission" do
     let(:state) { "resubmitted" }
 
-    it "returns hold, reject and close actions" do
+    it "returns published, hold and close actions" do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
-      expect(states).to eq %w[hold rejected closed]
+      expect(states).to eq %w[published hold closed]
     end
   end
 


### PR DESCRIPTION
It was discovered during QA session ([link](https://www.notion.so/artsy/Convection-Resubmitted-artwork-cannot-be-listed-b85049f80d5c423f9a2a886c70f8b4d9?pvs=4))

I think I removed "publish" action by mistake. @dblandin pointed out [here](https://github.com/artsy/convection/pull/1497#discussion_r1691478322) that preferred set of actions should be publish / hold and close, but instead of removing "reject" I removed "publish"