### PR TITLE
feat: allow `consignments_representative` role access

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -4,6 +4,11 @@ module Admin
   class AssetsController < ApplicationController
     before_action :set_submission
     before_action :set_asset, only: %i[show destroy]
+    before_action :authorize_submission
+
+    def authorized_artsy_token?(token)
+      ArtsyAdminAuth.valid?(token, [ArtsyAdminAuth::CONSIGNMENTS_REPRESENTATIVE])
+    end
 
     def show
       @original_image = @asset.original_image
@@ -48,6 +53,12 @@ module Admin
 
     def set_submission
       @submission = Submission.find(params[:submission_id])
+    end
+
+    def authorize_submission
+      if !ArtsyAdminAuth.consignments_manager?(session[:access_token]) && @submission.assigned_to != @current_user
+        raise ApplicationController::NotAuthorized
+      end
     end
 
     def set_asset

--- a/lib/artsy_admin_auth.rb
+++ b/lib/artsy_admin_auth.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class ArtsyAdminAuth
+  CONSIGNEMNTS_MANAGER = "consignments_manager"
+  CONSIGNMENTS_REPRESENTATIVE = "consignments_representative"
+
   class << self
     def decode_token(token)
       return nil if token.blank?
@@ -9,17 +12,22 @@ class ArtsyAdminAuth
       decoded_token
     end
 
-    def valid?(token)
+    def valid?(token, additional_roles = [])
+      allowed_roles = [CONSIGNEMNTS_MANAGER] + additional_roles
       decoded_token = decode_token(token)
       return false if decoded_token.nil?
 
-      roles = decoded_token["roles"]
-      roles.include?("consignments_manager")
+      roles = decoded_token.fetch("roles", "").split(",")
+      allowed_roles.any? { |role| roles.include?(role) }
     end
 
     def decode_user(token)
       decoded_token = decode_token(token)
       decoded_token&.fetch("sub", nil)
+    end
+
+    def consignments_manager?(token)
+      valid?(token)
     end
   end
 end

--- a/spec/controllers/admin/assets_controller_spec.rb
+++ b/spec/controllers/admin/assets_controller_spec.rb
@@ -9,6 +9,9 @@ describe Admin::AssetsController, type: :controller do
       allow_any_instance_of(Admin::AssetsController).to receive(
         :require_artsy_authentication
       )
+      allow_any_instance_of(Admin::AssetsController).to receive(
+        :authorize_submission
+      )
       add_default_stubs
       @submission =
         Fabricate(

--- a/spec/controllers/admin/submissions_controller_spec.rb
+++ b/spec/controllers/admin/submissions_controller_spec.rb
@@ -8,6 +8,9 @@ describe Admin::SubmissionsController, type: :controller do
       allow_any_instance_of(Admin::SubmissionsController).to receive(
         :require_artsy_authentication
       )
+      allow_any_instance_of(Admin::SubmissionsController).to receive(
+        :authorize_submission
+      )
       allow(Convection.config).to receive(:gravity_xapp_token).and_return(
         "xapp_token"
       )

--- a/spec/system/list_artwork_spec.rb
+++ b/spec/system/list_artwork_spec.rb
@@ -17,6 +17,9 @@ describe "Listing a new artwork", type: :feature do
     allow_any_instance_of(ApplicationController).to receive(
       :require_artsy_authentication
     )
+    allow_any_instance_of(Admin::SubmissionsController).to receive(
+      :authorize_submission
+    )
 
     # Set current user
     stub_jwt_header(admin_id)

--- a/spec/system/submission_editing_spec.rb
+++ b/spec/system/submission_editing_spec.rb
@@ -33,6 +33,9 @@ describe "Editing a submission", type: :feature do
     allow_any_instance_of(ApplicationController).to receive(
       :require_artsy_authentication
     )
+    allow_any_instance_of(Admin::SubmissionsController).to receive(
+      :authorize_submission
+    )
 
     # Set current user
     stub_jwt_header(admin_id)

--- a/spec/views/admin/consignments/show.html.erb_spec.rb
+++ b/spec/views/admin/consignments/show.html.erb_spec.rb
@@ -39,6 +39,9 @@ describe "admin/consignments/show.html.erb", type: :feature do
       allow_any_instance_of(ApplicationController).to receive(
         :require_artsy_authentication
       )
+      allow_any_instance_of(Admin::SubmissionsController).to receive(
+        :authorize_submission
+      )
 
       stub_jwt_header("userid")
       add_default_stubs(

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -32,6 +32,9 @@ describe "admin/offers/show.html.erb", type: :feature do
       allow_any_instance_of(ApplicationController).to receive(
         :require_artsy_authentication
       )
+      allow_any_instance_of(Admin::SubmissionsController).to receive(
+        :authorize_submission
+      )
       stub_jwt_header("userid")
 
       stub_gravity_root

--- a/spec/views/admin/submissions/new.html.erb_spec.rb
+++ b/spec/views/admin/submissions/new.html.erb_spec.rb
@@ -10,6 +10,9 @@ describe "admin/submissions/new.html.erb", type: :feature do
       allow_any_instance_of(Admin::SubmissionsController).to receive(
         :require_artsy_authentication
       )
+      allow_any_instance_of(Admin::SubmissionsController).to receive(
+        :authorize_submission
+      )
       page.visit "/admin/submissions/new"
     end
 

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -17,6 +17,12 @@ describe "admin/submissions/show.html.erb", type: :feature do
       allow_any_instance_of(ApplicationController).to receive(
         :require_artsy_authentication
       )
+      allow_any_instance_of(Admin::SubmissionsController).to receive(
+        :authorize_submission
+      )
+      allow_any_instance_of(Admin::AssetsController).to receive(
+        :authorize_submission
+      )
       allow(Convection.config).to receive(:auction_offer_form_url).and_return(
         "https://google.com/auction"
       )


### PR DESCRIPTION
Authenticated users with the `consignments_representative` role can access submissions and associated assets if they are currently assigned to the submission. Otherwise access is denied.

Jira: [ONYX-1193](https://artsyproduct.atlassian.net/browse/ONYX-1193) 🔒 

[ONYX-1193]: https://artsyproduct.atlassian.net/browse/ONYX-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ