### PR TITLE
feat: add submission approved email to assigned admin

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -25,6 +25,24 @@ class AdminMailer < ApplicationMailer
     ) { |format| format.html { render layout: "mailer_no_footer" } }
   end
 
+  def submission_approved(submission:, artist:)
+    @submission = submission
+    @artist = artist
+    @user = submission.user
+
+    assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)
+
+    smtpapi category: %w[submission],
+            unique_args: {
+              submission_id: submission.id
+            }
+
+    mail(
+      to: assigned_admin.email,
+      subject: "Submission ##{@submission.id} approved"
+    ) { |format| format.html { render layout: "mailer_no_footer" } }
+  end
+
   def artwork_updated(submission:, artwork_data:, changes: nil, image_added: nil)
     assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)
 

--- a/app/views/admin_mailer/submission_approved.html.erb
+++ b/app/views/admin_mailer/submission_approved.html.erb
@@ -1,0 +1,33 @@
+<%= stylesheet_link_tag 'emails', media: 'all' %>
+
+<table class='padded-email'>
+  <tr>
+    <td>
+      <table class='email-content' align='left'>
+        <tr>
+          <td>
+            <%= render 'shared/email/email_header' %>
+          </td>
+        </tr>
+        <tr>
+          <td class='email-sub-title'>
+            <p>
+              Submission #<%= @submission.id %> from User <%= link_to "##{@user.gravity_user_id}", user_management_url(@user.gravity_user_id) %> (<%= @user.email %>) has been approved.
+            </p>
+            <p>
+              As the assigned representative, you have access to view and manage this submission in Convection.
+            </p>
+            <p>
+              <%= link_to('View Submission', "#{Convection.config.convection_url}/admin/submissions/#{@submission.id}") %>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= render 'shared/email/submission_block', submission: @submission %>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -5,6 +5,10 @@ class AdminMailerPreview < ActionMailer::Preview
     AdminMailer.submission(**receipt_mail_params)
   end
 
+  def submission_approved
+    AdminMailer.submission_approved(**submission_approved_params)
+  end
+
   def artwork_updated
     AdminMailer.artwork_updated(**artwork_updated_params)
   end
@@ -22,6 +26,13 @@ class AdminMailerPreview < ActionMailer::Preview
         ),
       artist: OpenStruct.new(id: "artist_id", name: "Andy Warhol"),
       user: OpenStruct.new(id: "x", name: "William Black")
+    }
+  end
+
+  def submission_approved_params
+    {
+      submission: Submission.submitted.where.not(assigned_to: nil).last,
+      artist: OpenStruct.new(id: "artist_id", name: "Damien Hirst")
     }
   end
 


### PR DESCRIPTION
Send an email to the assigned admin representative once a submission has been approved.