### PR TITLE
feat: display additional artwork attributes from MP

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -235,7 +235,7 @@ module Admin
     private
 
     def set_submission
-      @submission = Submission.find(params[:id])
+      @submission = SubmissionPresenter.new(Submission.find(params[:id]), session[:access_token])
     end
 
     def authorize_submission

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -26,13 +26,14 @@ module SubmissionsHelper
     "#{values.join("x")}#{submission.dimensions_metric.try(:downcase)}"
   end
 
-  def formatted_dimensions_inch_cm(submission)
-    values =
+  def formatted_dimensions_inch_cm(submission, framed: false)
+    values = framed ?
+      [submission.framed_height, submission.framed_width, submission.framed_depth].select(&:present?) :
       [submission.height, submission.width, submission.depth].select(&:present?)
 
     return [] if values.empty?
 
-    case submission.dimensions_metric.try(:downcase)
+    case (framed ? submission.framed_metric : submission.dimensions_metric).try(:downcase)
     when "cm"
       %W[
         #{values.join(" x ")}\ cm

--- a/app/presenters/submission_presenter.rb
+++ b/app/presenters/submission_presenter.rb
@@ -1,0 +1,67 @@
+class SubmissionPresenter < SimpleDelegator
+  attr_reader :access_token
+
+  def initialize(submission, access_token)
+    @access_token = access_token
+
+    super(submission)
+  end
+
+  def condition
+    my_collection_data.dig(:data, :artwork, :condition, :displayText)
+  end
+
+  def condition_description
+    my_collection_data.dig(:data, :artwork, :condition, :description)
+  end
+
+  def is_framed?
+    my_collection_data.dig(:data, :artwork, :isFramed) ? "Yes" : "No"
+  end
+
+  def framed_height
+    my_collection_data.dig(:data, :artwork, :framedHeight)
+  end
+
+  def framed_width
+    my_collection_data.dig(:data, :artwork, :framedWidth)
+  end
+
+  def framed_depth
+    my_collection_data.dig(:data, :artwork, :framedDepth)
+  end
+
+  def framed_metric
+    my_collection_data.dig(:data, :artwork, :framedMetric)
+  end
+
+  private
+
+  def my_collection_data
+    @my_collection_data ||= Metaql::Schema.execute(
+      query: my_collection_data_query,
+      access_token: access_token,
+      variables: {
+        id: my_collection_artwork_id
+      }
+    )
+  end
+
+  def my_collection_data_query
+    <<~GQL
+      query artworkDetails($id: String!) {
+        artwork(id: $id){
+          condition {
+            displayText
+            description
+          }
+          isFramed
+          framedHeight
+          framedWidth
+          framedDepth
+          framedMetric
+        }
+      }
+    GQL
+  end
+end

--- a/app/views/admin/submissions/_submission_details.html.erb
+++ b/app/views/admin/submissions/_submission_details.html.erb
@@ -119,15 +119,6 @@
 
 <div class='overview-item'>
   <div class='overview-item-title'>
-    Location
-  </div>
-  <div class='overview-item-value'>
-    <%= formatted_location(@submission) %>
-  </div>
-</div>
-
-<div class='overview-item'>
-  <div class='overview-item-title'>
     Price in mind
   </div>
   <div class='overview-item-value minimum-price'>
@@ -168,5 +159,54 @@
   </div>
   <div class='overview-item-value'>
     <%= @submission.created_at&.strftime('%b %-d @ %l:%M %p %Z') %>
+  </div>
+</div>
+
+<hr />
+
+<div class='overview-item'>
+  <div class='overview-item-title'>
+    Shipping Location
+  </div>
+  <div class='overview-item-value'>
+    <%= formatted_location(@submission) %>
+  </div>
+</div>
+
+<div class='overview-item condition'>
+  <div class='overview-item-title'>
+    Condition
+  </div>
+  <div class='overview-item-value'>
+    <%= @submission.condition %>
+  </div>
+</div>
+
+<div class='overview-item condition-description'>
+  <div class='overview-item-title'>
+    Condition Description
+  </div>
+  <div class='overview-item-value'>
+    <%= @submission.condition_description %>
+  </div>
+</div>
+
+<div class='overview-item is-framed'>
+  <div class='overview-item-title'>
+    Is Framed?
+  </div>
+  <div class='overview-item-value'>
+    <%= @submission.is_framed? %>
+  </div>
+</div>
+
+<div class='overview-item framed-dimensions'>
+  <div class='overview-item-title'>
+    Framed Dimensions
+  </div>
+  <div class='overview-item-value'>
+    <% formatted_dimensions_inch_cm(@submission, framed: true).map do |formatted_dimension| %>
+      <div><%= formatted_dimension %></div>
+    <% end %>
   </div>
 </div>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -30,7 +30,7 @@
             <%= render @notes %>
             <div class='new-note'>
               <h4>New note</h4>
-              <%= render 'admin/notes/form', note: Note.new(submission: @submission) %>
+              <%= render 'admin/notes/form', note: Note.new(submission: @submission.__getobj__) %>
             </div>
           </div>
         </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,7 @@ module Convection
       %W[
         #{config.root}/lib
         #{Rails.root.join("app", "events")}
+        #{Rails.root.join("app", "presenters")}
         #{Rails.root.join("app", "services")}
         #{Rails.root.join("app", "workers")}
         #{Rails.root.join("app", "workers", "sneakers")}

--- a/spec/fabricators/submission_fabricator.rb
+++ b/spec/fabricators/submission_fabricator.rb
@@ -3,6 +3,7 @@
 Fabricator(:submission) do
   user { Fabricate(:user) }
   artist_id { Fabricate.sequence(:artist_id) }
+  my_collection_artwork_id { Fabricate.sequence(:my_collection_artwork_id) }
   uuid { SecureRandom.uuid }
   title { Fabricate.sequence(:title) { |i| "The Last Supper #{i}" } }
   year 2_010

--- a/spec/requests/api/graphql/mutations/add_user_to_submission_spec.rb
+++ b/spec/requests/api/graphql/mutations/add_user_to_submission_spec.rb
@@ -18,7 +18,7 @@ describe "addUserToSubmission mutation" do
   end
 
   it "associates a user with an unclaimed draft submission, referenced by UUID" do
-    submission = Fabricate(:submission, user: nil)
+    submission = Fabricate(:submission, user: nil, my_collection_artwork_id: nil)
 
     mutation = <<-GRAPHQL
         mutation {

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 
 describe SubmissionService do
@@ -14,13 +15,17 @@ describe SubmissionService do
     Fabricate(
       :submission,
       artist_id: "artistid",
+      my_collection_artwork_id: nil,
       user: user,
       title: "My Artwork"
     )
   end
   let(:access_token) { "access_token" }
 
-  before { add_default_stubs }
+  before do
+    add_default_stubs
+    stub_graphql_artwork_request(submission.my_collection_artwork_id)
+  end
 
   context "create_submission" do
     let(:params) do
@@ -78,7 +83,7 @@ describe SubmissionService do
       end
     end
 
-    context "when the submission has a My Colleciton artwork" do
+    context "when the submission has a My Collection artwork" do
       let(:params_with_source) { params.merge({source: "my_collection", my_collection_artwork_id: "artwork-id"}) }
 
       it "updates the My Collection artwork to set the submission ID" do
@@ -255,6 +260,7 @@ describe SubmissionService do
         state: "submitted",
         artist_id: "artistid",
         user_id: nil,
+        my_collection_artwork_id: nil,
         user: nil,
         title: "My Artwork",
         user_name: "michael",

--- a/spec/support/graphql_helper.rb
+++ b/spec/support/graphql_helper.rb
@@ -1,0 +1,15 @@
+def stub_graphql_artwork_request(id = nil)
+  mock_artwork_data = {
+    condition: {
+      displayText: "Excellent", description: "Like new"
+    },
+    isFramed: true,
+    framedHeight: 30,
+    framedWidth: 30,
+    framedMetric: "cm"
+  }
+
+  stub = stub_request(:post, Convection.config.metaphysics_api_url)
+  stub.with(body: /#{Regexp.quote(id)}/) if id.present?
+  stub.to_return(status: 200, body: {data: {artwork: mock_artwork_data}}.to_json, headers: {})
+end

--- a/spec/system/list_artwork_spec.rb
+++ b/spec/system/list_artwork_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 require "support/gravql_helper"
 require "support/jwt_helper"
@@ -39,6 +40,7 @@ describe "Listing a new artwork", type: :feature do
         }
       }
     )
+    stub_graphql_artwork_request(submission.my_collection_artwork_id)
   end
 
   it "lists artwork" do

--- a/spec/system/submission_editing_spec.rb
+++ b/spec/system/submission_editing_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 require "support/gravql_helper"
 require "support/jwt_helper"
@@ -64,6 +65,8 @@ describe "Editing a submission", type: :feature do
         }
       }
     )
+
+    stub_graphql_artwork_request(submission.my_collection_artwork_id)
   end
 
   context "adding an admin to a submission" do

--- a/spec/views/admin/consignments/show.html.erb_spec.rb
+++ b/spec/views/admin/consignments/show.html.erb_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 require "support/jwt_helper"
 
@@ -69,6 +70,8 @@ describe "admin/consignments/show.html.erb", type: :feature do
             "Content-Type" => "application/json"
           }
         )
+
+      stub_graphql_artwork_request(submission.my_collection_artwork_id)
       page.visit admin_consignment_path(partner_submission)
     end
 

--- a/spec/views/admin/offers/show.html.erb_spec.rb
+++ b/spec/views/admin/offers/show.html.erb_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 require "support/gravql_helper"
 require "support/jwt_helper"
@@ -11,7 +12,8 @@ describe "admin/offers/show.html.erb", type: :feature do
       Fabricate(
         :submission,
         state: Submission::APPROVED,
-        user: Fabricate(:user, email: "user@example.com")
+        user: Fabricate(:user, email: "user@example.com"),
+        my_collection_artwork_id: "my-collection-artwork-id"
       )
     end
     let(:partner) { Fabricate(:partner) }
@@ -71,6 +73,7 @@ describe "admin/offers/show.html.erb", type: :feature do
           }
         }
       )
+      stub_graphql_artwork_request(submission.my_collection_artwork_id)
       page.visit "/admin/offers/#{offer.id}"
     end
 

--- a/spec/views/admin/submissions/edit.html.erb_spec.rb
+++ b/spec/views/admin/submissions/edit.html.erb_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 require "support/gravql_helper"
 
@@ -40,6 +41,8 @@ describe "admin/submissions/edit.html.erb", type: :feature do
           }
         }
       )
+
+      stub_graphql_artwork_request(@submission.my_collection_artwork_id)
 
       page.visit "/admin/submissions/#{@submission.id}/edit"
     end

--- a/spec/views/admin/submissions/index.html.erb_spec.rb
+++ b/spec/views/admin/submissions/index.html.erb_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 require "support/gravql_helper"
 
@@ -52,12 +53,13 @@ describe "admin/submissions/index.html.erb", type: :feature do
         stub_gravity_user(id: "userid")
         stub_gravity_user_detail(id: "userid")
         3.times do
-          Fabricate(
+          submission = Fabricate(
             :submission,
             user: user,
             artist_id: "artistid",
             state: "submitted"
           )
+          stub_graphql_artwork_request(submission.my_collection_artwork_id)
         end
         page.visit admin_submissions_path
       end
@@ -110,28 +112,32 @@ describe "admin/submissions/index.html.erb", type: :feature do
             title: "blah"
           )
         end
-        @submission =
+        [
+          @submission =
+            Fabricate(
+              :submission,
+              user: @user2,
+              artist_id: "artistid2",
+              state: "approved",
+              title: "my work"
+            ),
           Fabricate(
             :submission,
             user: @user2,
-            artist_id: "artistid2",
-            state: "approved",
-            title: "my work"
+            artist_id: "artistid4",
+            state: "rejected",
+            title: "title"
+          ),
+          Fabricate(
+            :submission,
+            user: @user2,
+            artist_id: "artistid4",
+            state: "draft",
+            title: "blah blah"
           )
-        Fabricate(
-          :submission,
-          user: @user2,
-          artist_id: "artistid4",
-          state: "rejected",
-          title: "title"
-        )
-        Fabricate(
-          :submission,
-          user: @user2,
-          artist_id: "artistid4",
-          state: "draft",
-          title: "blah blah"
-        )
+        ].each do |submission|
+          stub_graphql_artwork_request(submission.my_collection_artwork_id)
+        end
 
         @artists = [
           {id: "artistid", name: "Andy Warhol"},

--- a/spec/views/admin/submissions/new.html.erb_spec.rb
+++ b/spec/views/admin/submissions/new.html.erb_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 require "support/gravql_helper"
 
@@ -13,6 +14,7 @@ describe "admin/submissions/new.html.erb", type: :feature do
       allow_any_instance_of(Admin::SubmissionsController).to receive(
         :authorize_submission
       )
+      stub_graphql_artwork_request
       page.visit "/admin/submissions/new"
     end
 

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/graphql_helper"
 require "support/gravity_helper"
 require "support/gravql_helper"
 require "support/jwt_helper"
@@ -62,6 +63,7 @@ describe "admin/submissions/show.html.erb", type: :feature do
       )
 
       stub_jwt_header("userid")
+      stub_graphql_artwork_request(@submission.my_collection_artwork_id)
       page.visit "/admin/submissions/#{@submission.id}"
     end
 
@@ -211,6 +213,16 @@ describe "admin/submissions/show.html.erb", type: :feature do
 
     it "displays supply priority" do
       within(".supply-priority") { expect(page).to have_content("P2") }
+    end
+
+    it "displays condition" do
+      within(".overview-item.condition") { expect(page).to have_content("Excellent") }
+      within(".overview-item.condition-description") { expect(page).to have_content("Like new") }
+    end
+
+    it "displays framed_dimensions" do
+      within(".overview-item.is-framed") { expect(page).to have_content("Yes") }
+      within(".overview-item.framed-dimensions") { expect(page).to have_content("30 x 30 cm") }
     end
 
     context "notes" do


### PR DESCRIPTION
Some of the data we persist within the submission flow lives in Gravity, associated with the collector's My Collection artwork.

This commit queries for that data and renders it within a new uneditable section on the submission admin page.

![Screenshot 2024-09-05 at 10 12 04](https://github.com/user-attachments/assets/0a63d6e8-ef81-4d85-a517-7c50b495e7ed)
