### PR TITLE
fix: lookup name/email/phone via Gravity when not present locally

### DIFF
--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -224,7 +224,7 @@ module Admin
         else
           user = {
             id: submissions.first.user_id,
-            email: submissions.first.user_email
+            email: submissions.first.email
           }
           users = [user]
         end

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -44,7 +44,7 @@ class BaseResolver
 
   def matching_email(submission)
     user = Gravity.client.user(id: @context[:current_user]).user_detail._get
-    submission.user_email.downcase == user.email.downcase
+    submission.email.downcase == user.email.downcase
   rescue
     Rails.logger.info "Unable to match user email with submission email"
     nil

--- a/app/views/admin/submissions/_collector_info.html.erb
+++ b/app/views/admin/submissions/_collector_info.html.erb
@@ -10,7 +10,7 @@
       <%= submission.name %>
     </div>
     <div class="smaller-sidebar-link" >
-      <%= link_to "#{submission.count_submissions_of_user} submissions made", admin_submissions_path(user: submission.user_id, user_email: submission.user_email) %>
+      <%= link_to "#{submission.count_submissions_of_user} submissions made", admin_submissions_path(user: submission.user_id, user_email: submission.email) %>
     </div>
     <div>
       <%= submission.email %>

--- a/lib/salesforce_service.rb
+++ b/lib/salesforce_service.rb
@@ -85,10 +85,10 @@ class SalesforceService
       if submission.user.present?
         api.select("Contact", submission.user.gravity_user_id, ["Id"], "Partner_Contact_Ext_Id__c").Id
       else
-        find_contact_id_by_email(submission.user_email)
+        find_contact_id_by_email(submission.email)
       end
     rescue Restforce::NotFoundError
-      find_contact_id_by_email(submission.user_email)
+      find_contact_id_by_email(submission.email)
     end
 
     def find_contact_id_by_email(user_email)
@@ -110,10 +110,10 @@ class SalesforceService
 
     def map_submission_to_salesforce_contact(submission)
       {
-        LastName: submission.user_name,
-        Email: submission.user_email,
+        LastName: submission.name,
+        Email: submission.email,
         Partner_Contact_Ext_Id__c: submission.user&.gravity_user_id,
-        Phone: submission.user_phone
+        Phone: submission.phone
       }
     end
 

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -207,9 +207,9 @@ describe SubmissionService do
       context "create_submission" do
         it "adds contact information to the user record" do
           new_submission = SubmissionService.create_submission(params, nil)
-          expect(new_submission.user_name).to eq "michael"
-          expect(new_submission.user_email).to eq "michael@bluth.com"
-          expect(new_submission.user_phone).to eq "555-5555"
+          expect(new_submission.name).to eq "michael"
+          expect(new_submission.email).to eq "michael@bluth.com"
+          expect(new_submission.phone).to eq "555-5555"
           expect(new_submission.count_submissions_of_user).to eq 1
           expect(new_submission.user).to eq nil
         end


### PR DESCRIPTION
We removed the Contact Information step a while back and have since been further relying on contact information associated with the authenticated Artsy user account. This follows-up on that change to ensure that we're using the new lookup methods that fallback to a Gravity lookup for display and Salesforce syncing.

Related [Slack thread here](https://artsy.slack.com/archives/C06DKRW4R/p1723651875767019).