### PR TITLE
feat: link admin submission to salesforce page

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -43,6 +43,10 @@ module UrlHelper
     "#{Convection.config.artsy_cms_url}/artworks/#{artwork_id}/edit?update_current_partner=1"
   end
 
+  def salesforce_url(object_id)
+    "#{Convection.config.salesforce_url}/#{object_id}"
+  end
+
   def my_collection_artwork_url(artwork_id)
     "#{Convection.config.artsy_url}/collector-profile/my-collection/artwork/#{artwork_id}"
   end

--- a/app/views/admin/submissions/_salesforce.html.erb
+++ b/app/views/admin/submissions/_salesforce.html.erb
@@ -1,0 +1,6 @@
+<div class='overview-section'>
+  <div class='bold-label'>Salesforce</div>
+  <div class='single-padding-top'>
+     🗒️ Artwork <%= link_to @submission.salesforce_artwork[:Id], salesforce_url(@submission.salesforce_artwork[:Id]), class: "smaller-sidebar-link" %>
+  </div>
+</div>

--- a/app/views/admin/submissions/show.html.erb
+++ b/app/views/admin/submissions/show.html.erb
@@ -145,6 +145,7 @@
           </div>
           <%= render 'collector_info', submission: @submission %>
           <%= render 'created_by', submission: @submission %>
+          <%= render 'salesforce', submission: @submission if @submission.salesforce_artwork.present? %>
           <div class='overview-section'>
             <div class='bold-label'>Partner Interest</div>
             <div class='single-padding-top'>

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -55,6 +55,7 @@ Convection.config =
     salesforce_password: ENV["SALESFORCE_PASSWORD"],
     salesforce_security_token: ENV["SALESFORCE_SECURITY_TOKEN"],
     salesforce_username: ENV["SALESFORCE_USERNAME"],
+    salesforce_url: ENV["SALESFORCE_URL"],
     sentry_dsn: ENV["SENTRY_DSN"],
     sidekiq_username: ENV["SIDEKIQ_USERNAME"] || "admin",
     sidekiq_password: ENV["SIDEKIQ_PASSWORD"] || "replace-me",


### PR DESCRIPTION
Provide an easy way to jump to the associated artwork record in Salesforce.

## Screenshots

![Screenshot 2024-09-06 at 13 01 04](https://github.com/user-attachments/assets/787e3e1d-a95f-4659-b891-56afb213a230)
