### PR TITLE
feat: remove publish action from admin submission pages

### DIFF
--- a/app/models/submission_state_actions.rb
+++ b/app/models/submission_state_actions.rb
@@ -38,7 +38,7 @@ class SubmissionStateActions
     {
       class: default_classes << "btn-approve",
       confirm:
-        "No email will be sent to the consignor and this submission will be excluded from the digests.",
+        "An email will be sent to the consignor, letting them know that their submission has been accepted and prompt for additional (tier 2) information.",
       state: "approved",
       text: "Approve without CMS"
     }

--- a/app/models/submission_state_actions.rb
+++ b/app/models/submission_state_actions.rb
@@ -14,15 +14,15 @@ class SubmissionStateActions
   def run
     case submission.state
     when Submission::DRAFT, Submission::SUBMITTED
-      [approve_action, publish_action, hold_action, reject_action, close_action]
+      [approve_action, hold_action, reject_action, close_action]
     when Submission::RESUBMITTED
-      [publish_action, hold_action, close_action]
+      [hold_action, close_action]
     when Submission::APPROVED
-      [publish_action, hold_action, close_action]
+      [hold_action, close_action]
     when Submission::PUBLISHED
       [close_action]
     when Submission::HOLD
-      [approve_action, publish_action, reject_action, close_action]
+      [approve_action, reject_action, close_action]
     else
       []
     end
@@ -41,16 +41,6 @@ class SubmissionStateActions
         "No email will be sent to the consignor and this submission will be excluded from the digests.",
       state: "approved",
       text: "Approve without CMS"
-    }
-  end
-
-  def publish_action
-    {
-      class: default_classes << "btn-approve",
-      confirm:
-        "An email will be sent to the consignor, letting them know that their submission will be sent to our partner network and this work will appear in the digests and CMS. This action cannot be undone.",
-      state: "published",
-      text: "Publish"
     }
   end
 

--- a/spec/models/submission_state_actions_spec.rb
+++ b/spec/models/submission_state_actions_spec.rb
@@ -8,40 +8,40 @@ describe SubmissionStateActions do
   context "with a draft submission" do
     let(:state) { "draft" }
 
-    it "returns approve, publish, hold, reject and close actions" do
+    it "returns approve, hold, reject and close actions" do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
-      expect(states).to eq %w[approved published hold rejected closed]
+      expect(states).to eq %w[approved hold rejected closed]
     end
   end
 
   context "with a submitted submission" do
     let(:state) { "submitted" }
 
-    it "returns approve, publish, hold, reject and close actions" do
+    it "returns approve, hold, reject and close actions" do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
-      expect(states).to eq %w[approved published hold rejected closed]
+      expect(states).to eq %w[approved hold rejected closed]
     end
   end
 
   context "with a resubmitted submission" do
     let(:state) { "resubmitted" }
 
-    it "returns published, hold and close actions" do
+    it "returns hold and close actions" do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
-      expect(states).to eq %w[published hold closed]
+      expect(states).to eq %w[hold closed]
     end
   end
 
   context "with an approved submission" do
     let(:state) { "approved" }
 
-    it "returns the publish, hold and close actions" do
+    it "returns the hold and close actions" do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
-      expect(states).to eq %w[published hold closed]
+      expect(states).to eq %w[hold closed]
     end
   end
 
@@ -58,10 +58,10 @@ describe SubmissionStateActions do
   context "with an on hold submission" do
     let(:state) { "hold" }
 
-    it "returns approve, publish, reject and close actions" do
+    it "returns approve, reject and close actions" do
       actions = SubmissionStateActions.for(submission)
       states = actions.pluck(:state)
-      expect(states).to eq %w[approved published rejected closed]
+      expect(states).to eq %w[approved rejected closed]
     end
   end
 


### PR DESCRIPTION
Requested by the Collector Services team as this publish to digest flow isn't used anymore and could unintentionally send emails to partners if accidentally triggered.

> We used to use this to send emails to our partners about works we have if they wanted to make an offer but we no longer use this, and if accidentally clicked it still sends out that email.
>
> [via Slack on Oct 10th, 2024](https://artsy.slack.com/archives/C05EQL4R5N0/p1728590202064589)