### PR TITLE
feat: Send submission resubmitted email to assigned admin

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -43,6 +43,23 @@ class AdminMailer < ApplicationMailer
     ) { |format| format.html { render layout: "mailer_no_footer" } }
   end
 
+  def submission_resubmitted(submission:)
+    @submission = submission
+    @user = submission.user
+
+    assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)
+
+    smtpapi category: %w[submission],
+            unique_args: {
+              submission_id: submission.id
+            }
+
+    mail(
+      to: assigned_admin.email,
+      subject: "Submission ##{@submission.id} resubmitted"
+    ) { |format| format.html { render layout: "mailer_no_footer" } }
+  end
+
   def artwork_updated(submission:, artwork_data:, changes: nil, image_added: nil)
     assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)
 

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -192,7 +192,7 @@ class SubmissionService
         assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)
 
         if assigned_admin && Convection.unleash.enabled?(
-          "onyx-admin-submission-approved-email",
+          "onyx-admin-submission-resubmitted-email",
           Unleash::Context.new(user_id: assigned_admin.gravity_user_id.to_s)
         )
           delay.deliver_admin_submission_resubmitted_notification(submission.id)
@@ -336,9 +336,8 @@ class SubmissionService
 
     def deliver_admin_submission_resubmitted_notification(submission_id)
       submission = Submission.find(submission_id)
-      artist = Gravity.client.artist(id: submission.artist_id)._get
 
-      AdminMailer.submission_resubmitted(submission: submission, artist: artist)
+      AdminMailer.submission_resubmitted(submission: submission)
         .deliver_now
     end
 

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -122,6 +122,8 @@ class SubmissionService
       case submission.state
       when "submitted"
         submit!(submission)
+      when "resubmitted"
+        resubmit!(submission)
       when "approved"
         approve!(submission, current_user, is_convection)
       when "published"
@@ -183,6 +185,19 @@ class SubmissionService
 
       delay_until(Convection.config.second_reminder_days_after.days.from_now)
         .notify_user(submission.id)
+    end
+
+    def resubmit!(submission)
+      if submission.assigned_to
+        assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)
+
+        if assigned_admin && Convection.unleash.enabled?(
+          "onyx-admin-submission-approved-email",
+          Unleash::Context.new(user_id: assigned_admin.gravity_user_id.to_s)
+        )
+          delay.deliver_admin_submission_resubmitted_notification(submission.id)
+        end
+      end
     end
 
     def approve!(submission, current_user, is_convection)
@@ -316,6 +331,14 @@ class SubmissionService
       artist = Gravity.client.artist(id: submission.artist_id)._get
 
       UserMailer.submission_approved(submission: submission, artist: artist)
+        .deliver_now
+    end
+
+    def deliver_admin_submission_resubmitted_notification(submission_id)
+      submission = Submission.find(submission_id)
+      artist = Gravity.client.artist(id: submission.artist_id)._get
+
+      AdminMailer.submission_resubmitted(submission: submission, artist: artist)
         .deliver_now
     end
 

--- a/app/views/admin_mailer/submission_resubmitted.html.erb
+++ b/app/views/admin_mailer/submission_resubmitted.html.erb
@@ -1,0 +1,33 @@
+<%= stylesheet_link_tag 'emails', media: 'all' %>
+
+<table class='padded-email'>
+  <tr>
+    <td>
+      <table class='email-content' align='left'>
+        <tr>
+          <td>
+            <%= render 'shared/email/email_header' %>
+          </td>
+        </tr>
+        <tr>
+          <td class='email-sub-title'>
+            <p>
+              Submission #<%= @submission.id %> from User <%= link_to "##{@user.gravity_user_id}", user_management_url(@user.gravity_user_id) %> (<%= @user.email %>) has been resubmitted.
+            </p>
+            <p>
+              As the assigned representative, you have access to view and manage this submission in Convection.
+            </p>
+            <p>
+              <%= link_to('View Submission', "#{Convection.config.convection_url}/admin/submissions/#{@submission.id}") %>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <%= render 'shared/email/submission_block', submission: @submission %>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -5,6 +5,10 @@ class AdminMailerPreview < ActionMailer::Preview
     AdminMailer.submission(**receipt_mail_params)
   end
 
+  def submission_resubmitted
+    AdminMailer.submission_resubmitted(**submission_resubmitted_params)
+  end
+
   def submission_approved
     AdminMailer.submission_approved(**submission_approved_params)
   end
@@ -33,6 +37,12 @@ class AdminMailerPreview < ActionMailer::Preview
     {
       submission: Submission.submitted.where.not(assigned_to: nil).last,
       artist: OpenStruct.new(id: "artist_id", name: "Damien Hirst")
+    }
+  end
+
+  def submission_resubmitted_params
+    {
+      submission: Submission.submitted.where.not(assigned_to: nil).last
     }
   end
 


### PR DESCRIPTION
Addresses [ONYX-1192]

* Related PR that adds an admin email for approved submissions: https://github.com/artsy/convection/pull/1512
* Feature Flag: https://unleash.artsy.net/projects/default/features/onyx-admin-submission-resubmitted-email

## Description

Send an email to the assigned admin representative once a submission has been resubmitted by the user (tier 2 sell flow finished).

[ONYX-1192]: https://artsyproduct.atlassian.net/browse/ONYX-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ