### PR TITLE
chore: Upgrade to sentry-ruby, rails, sidekiq sdks, removes sentry-raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,9 @@ gem "rails_param" # validate and coerce API parameters
 gem "redcarpet"
 gem "restforce"
 gem "sass-rails"
-gem "sentry-raven" # for error reporting
+gem "sentry-rails"
+gem "sentry-ruby"
+gem "sentry-sidekiq"
 gem "sidekiq"
 gem "sneakers" # RabbitMQ consumer workers
 gem "tzinfo-data" # overrides system time zone data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     backport (1.1.2)
     benchmark (0.1.1)
+    bigdecimal (3.1.8)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     bootstrap-sass (3.4.1)
@@ -476,8 +477,15 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
+    sentry-rails (5.21.0)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.21.0)
+    sentry-ruby (5.21.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.21.0)
+      sentry-ruby (~> 5.21.0)
+      sidekiq (>= 3.0)
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     sexp_processor (4.15.2)
@@ -599,7 +607,9 @@ DEPENDENCIES
   rspec-rails
   sass-rails
   selenium-webdriver
-  sentry-raven
+  sentry-rails
+  sentry-ruby
+  sentry-sidekiq
   sidekiq
   sneakers
   solargraph

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
       faraday_middleware
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.4)
+    jaro_winkler (1.5.6)
     jmespath (1.6.2)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -287,7 +287,7 @@ GEM
     minitest (5.22.2)
     money (6.16.0)
       i18n (>= 0.6.4, <= 2)
-    msgpack (1.4.2)
+    msgpack (1.7.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   helper Watt::Engine.helpers
 
   before_action :set_current_user
-  before_action :set_raven_context
+  before_action :set_sentry_context
 
   NotAuthorized = Class.new(StandardError)
 
@@ -26,7 +26,7 @@ class ApplicationController < ActionController::Base
     @current_user = ArtsyAdminAuth.decode_user(session[:access_token])
   end
 
-  def set_raven_context
-    Raven.user_context(id: @current_user)
+  def set_sentry_context
+    Sentry.set_user(user_id: @current_user&.id)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_sentry_context
-    Sentry.set_user(user_id: @current_user&.id)
+    # Heads up! @current_user is the user's id as a string not an object
+    Sentry.set_user(user_id: @current_user)
   end
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-Raven.configure do |config|
+Sentry.init do |config|
   config.dsn = Convection.config.sentry_dsn if Convection.config.sentry_dsn
-  config.processors -= [Raven::Processor::PostData]
 end


### PR DESCRIPTION
Attempt to get us off of deprecated `sentry-raven` gem, installs `sentry-ruby`, `sentry-rails`, `sentry-sidekiq`