### PR TITLE
fix: Set missing artist for submission resubmitted admin mail template

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -43,8 +43,9 @@ class AdminMailer < ApplicationMailer
     ) { |format| format.html { render layout: "mailer_no_footer" } }
   end
 
-  def submission_resubmitted(submission:)
+  def submission_resubmitted(submission:, artist:)
     @submission = submission
+    @artist = artist
     @user = submission.user
 
     assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -336,8 +336,9 @@ class SubmissionService
 
     def deliver_admin_submission_resubmitted_notification(submission_id)
       submission = Submission.find(submission_id)
+      artist = Gravity.client.artist(id: submission.artist_id)._get
 
-      AdminMailer.submission_resubmitted(submission: submission)
+      AdminMailer.submission_resubmitted(submission: submission, artist: artist)
         .deliver_now
     end
 

--- a/app/views/admin_mailer/submission_approved.html.erb
+++ b/app/views/admin_mailer/submission_approved.html.erb
@@ -24,7 +24,7 @@
         </tr>
         <tr>
           <td>
-            <%= render 'shared/email/submission_block', submission: @submission %>
+            <%= render 'shared/email/submission_block', submission: @submission, artist: @artist %>
           </td>
         </tr>
       </table>

--- a/app/views/admin_mailer/submission_resubmitted.html.erb
+++ b/app/views/admin_mailer/submission_resubmitted.html.erb
@@ -24,7 +24,7 @@
         </tr>
         <tr>
           <td>
-            <%= render 'shared/email/submission_block', submission: @submission %>
+            <%= render 'shared/email/submission_block', submission: @submission, artist: @artist %>
           </td>
         </tr>
       </table>

--- a/app/views/shared/email/_submission_block.html.erb
+++ b/app/views/shared/email/_submission_block.html.erb
@@ -8,8 +8,8 @@
               <table class="contents">
                 <tr>
                   <td>
-                    <% if @submission.processed_images.length > 0 %>
-                      <%= image_tag(@submission.processed_images.first.image_urls['square'], id: 'first-image') %>
+                    <% if submission.processed_images.length > 0 %>
+                      <%= image_tag(submission.processed_images.first.image_urls['square'], id: 'first-image') %>
                     <% else %>
                       <%= image_tag(image_url('missing_image.png'), id: 'first-image') %>
                     <% end %>
@@ -27,32 +27,32 @@
               <table class='submission-metadata info'>
                 <tr>
                   <td class='artist-name'>
-                    <%= @artist.name %>
+                    <%= artist.name %>
                   </td>
                 </tr>
                 <tr>
                   <td class='artwork-title'>
-                    <i><%= @submission.title %></i><span><%= ", #{@submission.year}" %></span>
+                    <i><%= submission.title %></i><span><%= ", #{submission.year}" %></span>
                   </td>
                 </tr>
                 <tr>
                   <td class='artwork-category-medium'>
-                    <%= formatted_category(@submission) %>, <%= formatted_dimensions(submission) %>
+                    <%= formatted_category(submission) %>, <%= formatted_dimensions(submission) %>
                   </td>
                 </tr>
                 <tr>
                   <td class='artwork-location'>
-                    <%= formatted_location(@submission) %>
+                    <%= formatted_location(submission) %>
                   </td>
                 </tr>
                 <tr>
                   <td class='num-uploaded-images'>
-                    <%= "#{pluralize(@submission.images.count, 'photo')} uploaded" %>
+                    <%= "#{pluralize(submission.images.count, 'photo')} uploaded" %>
                   </td>
                 </tr>
                 <tr>
                   <td class='submission-block-id'>
-                    <%= "Submission ##{@submission.id}" %>
+                    <%= "Submission ##{submission.id}" %>
                   </td>
                 </tr>
               </table>

--- a/app/views/user_mailer/non_target_supply_artist_rejected.html.erb
+++ b/app/views/user_mailer/non_target_supply_artist_rejected.html.erb
@@ -31,7 +31,7 @@
         </tr>
         <tr>
           <td>
-            <%= render 'shared/email/submission_block', submission: @submission %>
+            <%= render 'shared/email/submission_block', submission: @submission, artist: @artist %>
           </td>
         </tr>
       </table>

--- a/app/views/user_mailer/other_submission_rejected.erb
+++ b/app/views/user_mailer/other_submission_rejected.erb
@@ -26,7 +26,7 @@
         </tr>
         <tr>
           <td>
-            <%= render 'shared/email/submission_block', submission: @submission %>
+            <%= render 'shared/email/submission_block', submission: @submission, artist: @artist %>
           </td>
         </tr>
       </table>

--- a/app/views/user_mailer/submission_approved.html.erb
+++ b/app/views/user_mailer/submission_approved.html.erb
@@ -40,7 +40,7 @@
         </tr>
         <tr>
           <td>
-            <%= render 'shared/email/submission_block', submission: @submission %>
+            <%= render 'shared/email/submission_block', submission: @submission, artist: @artist %>
           </td>
         </tr>
         <tr>

--- a/app/views/user_mailer/submission_receipt.html.erb
+++ b/app/views/user_mailer/submission_receipt.html.erb
@@ -28,7 +28,7 @@
 
               <tr>
                 <td>
-                  <%= render 'shared/email/submission_block', submission: @submission %>
+                  <%= render 'shared/email/submission_block', submission: @submission, artist: @artist %>
                 </td>
               </tr>
               <tr>

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -42,7 +42,8 @@ class AdminMailerPreview < ActionMailer::Preview
 
   def submission_resubmitted_params
     {
-      submission: Submission.submitted.where.not(assigned_to: nil).last
+      submission: Submission.submitted.where.not(assigned_to: nil).last,
+      artist: OpenStruct.new(id: "artist_id", name: "Damien Hirst")
     }
   end
 


### PR DESCRIPTION
Resolves [Sentry Error](https://artsynet.sentry.io/issues/6096938215/?project=270333&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0)

Related to https://github.com/artsy/convection/pull/1533

## Description

This PR resolves the [error](https://artsynet.sentry.io/issues/6096938215/?project=270333&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=0) caused by the missing artist in the "submission resubmitted" admin mail template. In addition, I updated the email template block to require the artist as an argument, making it harder to forget.