### PR TITLE
chore: Remove Submission mailer feature flags

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -208,7 +208,7 @@ class SubmissionService
         Submission::APPROVED
       )
 
-        delay.deliver_approval_notification(submission.id)
+      delay.deliver_approval_notification(submission.id)
 
       if submission.assigned_to
         assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)

--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -191,10 +191,7 @@ class SubmissionService
       if submission.assigned_to
         assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)
 
-        if assigned_admin && Convection.unleash.enabled?(
-          "onyx-admin-submission-resubmitted-email",
-          Unleash::Context.new(user_id: assigned_admin.gravity_user_id.to_s)
-        )
+        if assigned_admin
           delay.deliver_admin_submission_resubmitted_notification(submission.id)
         end
       end
@@ -211,20 +208,12 @@ class SubmissionService
         Submission::APPROVED
       )
 
-      if Convection.unleash.enabled?(
-        "onyx-collector-submission-approved-tier-2-email",
-        Unleash::Context.new(user_id: submission&.user&.gravity_user_id.to_s)
-      )
         delay.deliver_approval_notification(submission.id)
-      end
 
       if submission.assigned_to
         assigned_admin = AdminUser.find_by(gravity_user_id: submission.assigned_to)
 
-        if assigned_admin && Convection.unleash.enabled?(
-          "onyx-admin-submission-approved-email",
-          Unleash::Context.new(user_id: assigned_admin.gravity_user_id.to_s)
-        )
+        if assigned_admin
           delay.deliver_admin_submission_approved_notification(submission.id)
         end
       end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -381,7 +381,7 @@ describe SubmissionService do
         {state: "approved"},
         current_user: "userid"
       )
-      expect(ActionMailer::Base.deliveries.length).to eq 0
+      expect(ActionMailer::Base.deliveries.length).to eq 1
       expect(submission.state).to eq "approved"
       expect(submission.approved_by).to eq "userid"
       expect(submission.approved_at).to_not be_nil
@@ -401,7 +401,7 @@ describe SubmissionService do
         current_user: "userid",
         is_convection: true
       )
-      expect(ActionMailer::Base.deliveries.length).to eq 0
+      expect(ActionMailer::Base.deliveries.length).to eq 1
       expect(partner1.partner_submissions.length).to eq 0
       expect(partner2.partner_submissions.length).to eq 0
     end

--- a/spec/views/admin/submissions/show.html.erb_spec.rb
+++ b/spec/views/admin/submissions/show.html.erb_spec.rb
@@ -350,7 +350,7 @@ describe "admin/submissions/show.html.erb", type: :feature do
         expect(page).to have_content("Create Offer")
 
         emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 0
+        expect(emails.length).to eq 1
         expect(page).to have_content "Approved by Jon Jonson"
         expect(PartnerSubmission.count).to eq 0
         ActionMailer::Base.deliveries = []


### PR DESCRIPTION
Addresses [ONYX-1388]

## Description

This removes all Submission mailer feature flags. The new email templates have already been tested and released. In case we want to disable the mails, we can just roll back the PRs.

[ONYX-1388]: https://artsyproduct.atlassian.net/browse/ONYX-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ