### PR TITLE
fix: load secrets in data-sync cron containers

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -589,6 +589,10 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
+            - name: scripts
+              mountPath: /usr/local/bin/load_secrets_and_run.sh
+              subPath: load_secrets_and_run.sh
+            command: ["/usr/local/bin/load_secrets_and_run.sh"]
             args:
             - sh
             - ./export-db.sh
@@ -607,3 +611,25 @@ spec:
           volumes:
           - name: secrets
             emptyDir: {}
+          - name: scripts
+            configMap:
+              name: convection-scripts
+              defaultMode: 0755
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: convection-scripts
+  namespace: default
+data:
+  load_secrets_and_run.sh: |
+    #!/bin/bash
+    CMD="$@"
+    if [ ! -z "$SECRETS_FILE" ]
+    then
+      echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
+      source "$SECRETS_FILE"
+    fi
+    echo "Running command: $CMD"
+    $CMD

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -462,6 +462,10 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
+            - name: scripts
+              mountPath: /usr/local/bin/load_secrets_and_run.sh
+              subPath: load_secrets_and_run.sh
+            command: ["/usr/local/bin/load_secrets_and_run.sh"]
             args:
             - sh
             - ./import-db.sh
@@ -480,3 +484,25 @@ spec:
           volumes:
           - name: secrets
             emptyDir: {}
+          - name: scripts
+            configMap:
+              name: convection-scripts
+              defaultMode: 0755
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: convection-scripts
+  namespace: default
+data:
+  load_secrets_and_run.sh: |
+    #!/bin/bash
+    CMD="$@"
+    if [ ! -z "$SECRETS_FILE" ]
+    then
+      echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
+      source "$SECRETS_FILE"
+    fi
+    echo "Running command: $CMD"
+    $CMD


### PR DESCRIPTION
I've noticed [this error](https://artsy.slack.com/archives/C0HP61PUJ/p1734325328089029). Seems like secrets are not getting loaded in db sync containers. The fix is the same as https://github.com/artsy/positron/pull/3165

I haven't tested changes, just did a copy-paste from positron. Also I don't understand why it's required to load secrets explicitly only fro some containers, but fine to omit for others, could someone explain?