### PR TITLE
feat: add read-only access to Consignment Representatives

### DIFF
--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class AssetsController < ApplicationController
     before_action :set_submission
     before_action :set_asset, only: %i[show destroy]
-    before_action :authorize_submission
+    before_action :authorize_submission, only: %i[new create destroy]
 
     def authorized_artsy_token?(token)
       ArtsyAdminAuth.valid?(token, [ArtsyAdminAuth::CONSIGNMENTS_REPRESENTATIVE])

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -7,6 +7,7 @@ module Admin
     before_action :authorize_submission, only: %i[new create destroy]
 
     def authorized_artsy_token?(token)
+      # Allow access on edit/destructive actions to consignment reps (default: read-only).
       ArtsyAdminAuth.valid?(token, [ArtsyAdminAuth::CONSIGNMENTS_REPRESENTATIVE])
     end
 

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -24,6 +24,10 @@ module Admin
       end
     end
 
+    def authorized_artsy_token?(token)
+      ArtsyAdminAuth.valid?(token, [ArtsyAdminAuth::CONSIGNMENTS_REPRESENTATIVE])
+    end
+
     private
 
     def note_params

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -25,6 +25,7 @@ module Admin
     end
 
     def authorized_artsy_token?(token)
+      # Allow access on edit/destructive actions to consignment reps (default: read-only).
       ArtsyAdminAuth.valid?(token, [ArtsyAdminAuth::CONSIGNMENTS_REPRESENTATIVE])
     end
 

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -17,7 +17,7 @@ module Admin
 
     before_action :set_submission, only: SUBMISSION_ACTIONS
     before_action :set_submission_artist, only: %i[show edit]
-    before_action :authorize_submission, only: SUBMISSION_ACTIONS
+    before_action :authorize_submission, only: SUBMISSION_ACTIONS - %i[show]
 
     expose(:submissions) do
       matching_submissions = SubmissionMatch.find_all(params)

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -3,7 +3,6 @@
 module Admin
   class SubmissionsController < ApplicationController
     SUBMISSION_ACTIONS = %i[
-      show
       edit
       update
       undo_approval
@@ -15,9 +14,9 @@ module Admin
 
     include GraphqlHelper
 
-    before_action :set_submission, only: SUBMISSION_ACTIONS
+    before_action :set_submission, only: SUBMISSION_ACTIONS + %i[show]
     before_action :set_submission_artist, only: %i[show edit]
-    before_action :authorize_submission, only: SUBMISSION_ACTIONS - %i[show]
+    before_action :authorize_submission, only: SUBMISSION_ACTIONS
 
     expose(:submissions) do
       matching_submissions = SubmissionMatch.find_all(params)

--- a/app/controllers/admin/submissions_controller.rb
+++ b/app/controllers/admin/submissions_controller.rb
@@ -52,6 +52,7 @@ module Admin
     end
 
     def authorized_artsy_token?(token)
+      # Allow access on edit/destructive actions to consignment reps (default: read-only).
       ArtsyAdminAuth.valid?(token, [ArtsyAdminAuth::CONSIGNMENTS_REPRESENTATIVE])
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
 
   # override application to decode token and allow only users with `admin` role
   def authorized_artsy_token?(token)
+    # Additionally allow read-only access to consignment reps.
     if %w[index show].include?(action_name)
       ArtsyAdminAuth.valid?(token, [ArtsyAdminAuth::CONSIGNMENTS_REPRESENTATIVE])
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,11 @@ class ApplicationController < ActionController::Base
 
   # override application to decode token and allow only users with `admin` role
   def authorized_artsy_token?(token)
-    ArtsyAdminAuth.valid?(token)
+    if %w[index show].include?(action_name)
+      ArtsyAdminAuth.valid?(token, [ArtsyAdminAuth::CONSIGNMENTS_REPRESENTATIVE])
+    else
+      ArtsyAdminAuth.valid?(token)
+    end
   end
 
   def set_current_user


### PR DESCRIPTION
In discussions with Collector Services, we've decided that users with the "Consignment Representative" user role should generally have read-only access to all content in Convection.

Consignment Representative may additional mutate the following:
- Submission notes (in all cases)
- Submission data including state and assets (only if assigned)