### PR TITLE
chore: rescue_from NotAuthorized error in admin controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,10 @@ class ApplicationController < ActionController::Base
 
   expose(:size) { (params[:size] || 100).to_i }
 
+  rescue_from ApplicationController::NotAuthorized do
+    head(:forbidden)
+  end
+
   # override application to decode token and allow only users with `admin` role
   def authorized_artsy_token?(token)
     # Additionally allow read-only access to consignment reps.


### PR DESCRIPTION
Rescues from any unhandled NotAuthorized exception by rendering a standard 403: Forbidden HTTP response. Our RestController rescues from this exception in a similar way but returns a JSON payload ([link][rest-controller]).

This basic forbidden response is also used by the artsy-auth gem ([link][artsy-auth]).

[rest-controller]: https://github.com/artsy/convection/blob/a2056fac53643ba8f91871d776b4f005a627edab/app/controllers/api/rest_controller.rb#L14-L16
[artsy-auth]: https://github.com/artsy/artsy-auth/blob/53ce676122243748ef2104e3c7fc083698a4f5a5/lib/artsy-auth/authenticated.rb#L13

## Screenshots

| Before | After |
|--------|--------|
| ![Screenshot 2025-01-09 at 17 15 26](https://github.com/user-attachments/assets/84f1e16d-80ca-456d-859e-ee53cbe510ba) | ![Screenshot 2025-01-09 at 17 09 03](https://github.com/user-attachments/assets/df56a4b8-5072-4dd4-98ce-3898dadf83f7) |