### PR TITLE
refactor: use load-secrets-and-run script from updated docker image

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -589,10 +589,6 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
-            - name: scripts
-              mountPath: /usr/local/bin/load_secrets_and_run.sh
-              subPath: load_secrets_and_run.sh
-            command: ["/usr/local/bin/load_secrets_and_run.sh"]
             args:
             - sh
             - ./export-db.sh
@@ -611,25 +607,3 @@ spec:
           volumes:
           - name: secrets
             emptyDir: {}
-          - name: scripts
-            configMap:
-              name: convection-scripts
-              defaultMode: 0755
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: convection-scripts
-  namespace: default
-data:
-  load_secrets_and_run.sh: |
-    #!/bin/bash
-    CMD="$@"
-    if [ ! -z "$SECRETS_FILE" ]
-    then
-      echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
-      source "$SECRETS_FILE"
-    fi
-    echo "Running command: $CMD"
-    $CMD

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -462,10 +462,6 @@ spec:
             - name: secrets
               mountPath: /secrets
               readOnly: true
-            - name: scripts
-              mountPath: /usr/local/bin/load_secrets_and_run.sh
-              subPath: load_secrets_and_run.sh
-            command: ["/usr/local/bin/load_secrets_and_run.sh"]
             args:
             - sh
             - ./import-db.sh
@@ -484,25 +480,3 @@ spec:
           volumes:
           - name: secrets
             emptyDir: {}
-          - name: scripts
-            configMap:
-              name: convection-scripts
-              defaultMode: 0755
-
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: convection-scripts
-  namespace: default
-data:
-  load_secrets_and_run.sh: |
-    #!/bin/bash
-    CMD="$@"
-    if [ ! -z "$SECRETS_FILE" ]
-    then
-      echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
-      source "$SECRETS_FILE"
-    fi
-    echo "Running command: $CMD"
-    $CMD


### PR DESCRIPTION
This PR removes the use of a configMap to store and mount the load-secrets-and-run.sh script. Once https://github.com/artsy/docker-images/pull/113 are pushed to our docker hub, we can rely on the script included in the containers.

I'll need to sequence the roll out, so am assigning to myself.

### Related PR(s)
- https://github.com/artsy/docker-images/pull/113