### PR TITLE
feat: auto-reject all incoming submissions (with delay) 

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -41,9 +41,7 @@ class SubmissionService
 
       unless is_convection || submission_params[:state]&.downcase == "draft"
         create_params.merge!(
-          state: "rejected",
-          rejection_reason: "Submissions suspended",
-          rejected_at: Time.now.utc
+          reject_non_target_supply_artist(submission_params[:artist_id])
         )
       end
 
@@ -100,9 +98,7 @@ class SubmissionService
       if submission.state_changed?
         unless is_convection
           submission.assign_attributes(
-            state: "rejected",
-            rejection_reason: "Submissions suspended",
-            rejected_at: Time.now.utc
+            reject_non_target_supply_artist(submission.artist_id)
           )
           if submission.user && !access_token.nil?
             create_or_update_my_collection_artwork(submission, access_token)

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -25,12 +25,8 @@ class UserMailerPreview < BasePreview
     UserMailer.fake_submission_rejected(**receipt_mail_params)
   end
 
-  def nsv_bsv_submission_rejected_logged_out
-    UserMailer.nsv_bsv_submission_rejected(**receipt_mail_params.merge(logged_in: false))
-  end
-
-  def nsv_bsv_submission_rejected_logged_in
-    UserMailer.nsv_bsv_submission_rejected(**receipt_mail_params.merge(logged_in: true))
+  def nsv_bsv_submission_rejected
+    UserMailer.nsv_bsv_submission_rejected(**receipt_mail_params)
   end
 
   def non_target_supply_artist_rejected

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -25,8 +25,12 @@ class UserMailerPreview < BasePreview
     UserMailer.fake_submission_rejected(**receipt_mail_params)
   end
 
-  def nsv_bsv_submission_rejected
-    UserMailer.nsv_bsv_submission_rejected(**receipt_mail_params)
+  def nsv_bsv_submission_rejected_logged_out
+    UserMailer.nsv_bsv_submission_rejected(**receipt_mail_params.merge(logged_in: false))
+  end
+
+  def nsv_bsv_submission_rejected_logged_in
+    UserMailer.nsv_bsv_submission_rejected(**receipt_mail_params.merge(logged_in: true))
   end
 
   def non_target_supply_artist_rejected

--- a/spec/requests/api/submissions/update_spec.rb
+++ b/spec/requests/api/submissions/update_spec.rb
@@ -139,6 +139,8 @@ describe "PUT /api/submissions" do
       end
 
       it "does not resend notifications" do
+        expect(NotificationService).not_to receive(:post_submission_event)
+        allow(SubmissionService).to receive(:deliver_rejection_notification)
         @submission.update!(receipt_sent_at: Time.now.utc)
         @submission.update!(admin_receipt_sent_at: Time.now.utc)
 

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -51,11 +51,11 @@ describe "Submission Flow" do
     expect(submission.reload.state).to eq "submitted"
 
     emails = ActionMailer::Base.deliveries
-    expect(emails.length).to eq 3
+    expect(emails.length).to eq 4
     expect(emails[1].to).to eq(%w[michael@bluth.com])
     expect(emails[1].subject).to include("You're Almost Done")
     expect(emails[2].to).to eq(%w[michael@bluth.com]) # sidekiq flushes everything at once
-    expect(emails.last.subject).to include(
+    expect(emails.map(&:subject)).to include(
       "Artsy Consignments - complete your submission"
     )
     expect(emails.last.to).to eq(%w[michael@bluth.com])
@@ -97,11 +97,11 @@ describe "Submission Flow" do
       expect(response.status).to eq 201
       expect(@submission.reload.state).to eq "submitted"
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 3
+      expect(emails.length).to eq 4
       expect(emails[1].to).to eq(%w[michael@bluth.com])
       expect(emails[1].subject).to include("You're Almost Done")
       expect(emails[2].to).to eq(%w[michael@bluth.com]) # sidekiq flushes everything at once
-      expect(emails.last.subject).to include(
+      expect(emails.map(&:subject)).to include(
         "Artsy Consignments - complete your submission"
       )
       expect(emails.last.to).to eq(%w[michael@bluth.com])

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -328,7 +328,7 @@ describe SubmissionService do
         .with(submission.id, "submitted")
       SubmissionService.update_submission(submission, {state: "submitted"})
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 3
+      expect(emails.length).to eq 4
     end
 
     it "sends no reminders if the submission has images" do
@@ -616,7 +616,7 @@ describe SubmissionService do
         "Unfortunately, we don’t have a selling opportunity for this work right now."
       )
       expect(submission.state).to eq "rejected"
-      expect(submission.rejection_reason).to eq "NSV"
+      expect(submission.rejection_reason).to eq "Submissions suspended"
       expect(submission.rejected_by).to eq "userid"
       expect(submission.rejected_at).to_not be_nil
       expect(submission.approved_by).to be_nil
@@ -657,7 +657,7 @@ describe SubmissionService do
       )
 
       expect(submission.state).to eq "rejected"
-      expect(submission.rejection_reason).to eq "Not Target Supply"
+      expect(submission.rejection_reason).to eq "Submissions suspended"
 
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 1
@@ -707,7 +707,7 @@ describe SubmissionService do
 
         expect(submission.state).to eq "rejected"
         expect(submission.my_collection_artwork_id).to eq "1"
-        expect(submission.rejection_reason).to eq "Not Target Supply"
+        expect(submission.rejection_reason).to eq "Submissions suspended"
       end
 
       it "create my collection artwork if artwork submitted" do


### PR DESCRIPTION
Follow up to #1562. Instead of auto-rejecting right away within the same response (with causes some confusing incompatibility with the active UX) – delay the action.

cc/ @nickskalkin @anandaroop 