### PR TITLE
fix: auto-reject even if images are supplied

### DIFF
--- a/app/services/submission_service.rb
+++ b/app/services/submission_service.rb
@@ -181,15 +181,16 @@ class SubmissionService
 
       notify_admin(submission.id)
       notify_user(submission.id)
-      return if submission.images.count.positive?
-
-      delay_until(Convection.config.second_reminder_days_after.days.from_now)
-        .notify_user(submission.id)
 
       # Delay auto-reject all incoming submissions
       delay_until(
         Convection.config.rejection_email_minutes_after.minutes.from_now
       ).delayed_reject!(submission.id)
+
+      return if submission.images.count.positive?
+
+      delay_until(Convection.config.second_reminder_days_after.days.from_now)
+        .notify_user(submission.id)
     end
 
     def resubmit!(submission)

--- a/spec/requests/api/submissions/update_spec.rb
+++ b/spec/requests/api/submissions/update_spec.rb
@@ -125,7 +125,7 @@ describe "PUT /api/submissions" do
         expect(response.status).to eq 201
         expect(@submission.reload.receipt_sent_at).to_not be_nil
         emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 2
+        expect(emails.length).to eq 3
         admin_email = emails.detect { |e| e.to.include?("lucille@bluth.com") }
         admin_copy = "We have received the following submission from: Jon"
         expect(admin_email.html_part.body.to_s).to include(admin_copy)

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -190,7 +190,7 @@ describe "Submission Flow" do
       expect(response.status).to eq 201
       expect(submission.reload.state).to eq "submitted"
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 2
+      expect(emails.length).to eq 3
       expect(emails[1].html_part.body).to include("https://new-image.jpg")
 
       # GET to retrieve the image url for the submission

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -338,7 +338,7 @@ describe SubmissionService do
       Fabricate(:image, submission: submission)
       SubmissionService.update_submission(submission, {state: "submitted"})
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 2
+      expect(emails.length).to eq 3
     end
 
     it "sends no emails if the state is not being changed" do


### PR DESCRIPTION
A[nother!] follow-up: ensure automatic rejections apply to submissions with images, too.