### PR TITLE
chore: disable some emails to admin & user

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -4,25 +4,27 @@ class AdminMailer < ApplicationMailer
   helper :submissions, :url
 
   def submission(submission:, user:, artist:)
-    @submission = submission
-    @user = user
-    @artist = artist
-    @utm_params =
-      utm_params(
-        source: "sendgrid",
-        campaign: "sell",
-        term: "cx",
-        content: "received"
-      )
+    Rails.logger.warn "[Consignments suspended] Declining to deliver admin email for Submission #{submission&.id}"
 
-    smtpapi category: %w[submission],
-            unique_args: {
-              submission_id: submission.id
-            }
-    mail(
-      to: Convection.config.admin_email_address,
-      subject: "Submission ##{@submission.id}"
-    ) { |format| format.html { render layout: "mailer_no_footer" } }
+    # @submission = submission
+    # @user = user
+    # @artist = artist
+    # @utm_params =
+    #   utm_params(
+    #     source: "sendgrid",
+    #     campaign: "sell",
+    #     term: "cx",
+    #     content: "received"
+    #   )
+    #
+    # smtpapi category: %w[submission],
+    #         unique_args: {
+    #           submission_id: submission.id
+    #         }
+    # mail(
+    #   to: Convection.config.admin_email_address,
+    #   subject: "Submission ##{@submission.id}"
+    # ) { |format| format.html { render layout: "mailer_no_footer" } }
   end
 
   def submission_approved(submission:, artist:)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,26 +4,28 @@ class UserMailer < ApplicationMailer
   helper :url, :submissions, :offers
 
   def submission_receipt(submission:, artist:)
-    @submission = submission
-    @artist = artist
+    Rails.logger.warn "[Consignments suspended] Declining to deliver user email for Submission #{submission&.id}"
 
-    @utm_params =
-      utm_params(
-        source: "sendgrid",
-        campaign: "sell",
-        term: "cx",
-        content: "received"
-      )
-
-    smtpapi category: %w[submission_receipt],
-            unique_args: {
-              submission_id: submission.id
-            }
-    mail(
-      to: submission.email,
-      subject: "Thank you for submitting your artwork to Artsy",
-      bcc: Convection.config.bcc_email_address
-    )
+    # @submission = submission
+    # @artist = artist
+    #
+    # @utm_params =
+    #   utm_params(
+    #     source: "sendgrid",
+    #     campaign: "sell",
+    #     term: "cx",
+    #     content: "received"
+    #   )
+    #
+    # smtpapi category: %w[submission_receipt],
+    #         unique_args: {
+    #           submission_id: submission.id
+    #         }
+    # mail(
+    #   to: submission.email,
+    #   subject: "Thank you for submitting your artwork to Artsy",
+    #   bcc: Convection.config.bcc_email_address
+    # )
   end
 
   def first_upload_reminder(submission:)

--- a/spec/requests/api/submissions/update_spec.rb
+++ b/spec/requests/api/submissions/update_spec.rb
@@ -125,11 +125,12 @@ describe "PUT /api/submissions" do
         expect(response.status).to eq 201
         expect(@submission.reload.receipt_sent_at).to_not be_nil
         emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 3
+        expect(emails.length).to eq 2
         admin_email = emails.detect { |e| e.to.include?("lucille@bluth.com") }
-        admin_copy = "We have received the following submission from: Jon"
-        expect(admin_email.html_part.body.to_s).to include(admin_copy)
-        expect(admin_email.text_part.body.to_s).to include(admin_copy)
+        expect(admin_email).to be_nil
+        # admin_copy = "We have received the following submission from: Jon"
+        # expect(admin_email.html_part.body.to_s).to include(admin_copy)
+        # expect(admin_email.text_part.body.to_s).to include(admin_copy)
 
         user_email = emails.detect { |e| e.to.include?("michael@bluth.com") }
         user_copy =

--- a/spec/requests/api/submissions/update_spec.rb
+++ b/spec/requests/api/submissions/update_spec.rb
@@ -125,7 +125,7 @@ describe "PUT /api/submissions" do
         expect(response.status).to eq 201
         expect(@submission.reload.receipt_sent_at).to_not be_nil
         emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 2
+        expect(emails.length).to eq 1
         admin_email = emails.detect { |e| e.to.include?("lucille@bluth.com") }
         expect(admin_email).to be_nil
         # admin_copy = "We have received the following submission from: Jon"
@@ -133,8 +133,7 @@ describe "PUT /api/submissions" do
         # expect(admin_email.text_part.body.to_s).to include(admin_copy)
 
         user_email = emails.detect { |e| e.to.include?("michael@bluth.com") }
-        user_copy =
-          "to evaluate whether we currently have a suitable market for it"
+        user_copy = "not accepting consignments"
         expect(user_email.html_part.body.to_s).to include(user_copy)
         expect(user_email.text_part.body.to_s).to include(user_copy)
       end

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -190,8 +190,8 @@ describe "Submission Flow" do
       expect(response.status).to eq 201
       expect(submission.reload.state).to eq "submitted"
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 2
-      expect(emails[0].html_part.body).to include("https://new-image.jpg")
+      expect(emails.length).to eq 1
+      # expect(emails[0].html_part.body).to include("https://new-image.jpg")
 
       # GET to retrieve the image url for the submission
       get "/api/assets",

--- a/spec/requests/submission_spec.rb
+++ b/spec/requests/submission_spec.rb
@@ -51,10 +51,10 @@ describe "Submission Flow" do
     expect(submission.reload.state).to eq "submitted"
 
     emails = ActionMailer::Base.deliveries
-    expect(emails.length).to eq 4
-    expect(emails[1].to).to eq(%w[michael@bluth.com])
-    expect(emails[1].subject).to include("You're Almost Done")
-    expect(emails[2].to).to eq(%w[michael@bluth.com]) # sidekiq flushes everything at once
+    expect(emails.length).to eq 3
+    expect(emails[0].to).to eq(%w[michael@bluth.com])
+    expect(emails[0].subject).to include("You're Almost Done")
+    expect(emails[1].to).to eq(%w[michael@bluth.com]) # sidekiq flushes everything at once
     expect(emails.map(&:subject)).to include(
       "Artsy Consignments - complete your submission"
     )
@@ -97,10 +97,10 @@ describe "Submission Flow" do
       expect(response.status).to eq 201
       expect(@submission.reload.state).to eq "submitted"
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 4
-      expect(emails[1].to).to eq(%w[michael@bluth.com])
-      expect(emails[1].subject).to include("You're Almost Done")
-      expect(emails[2].to).to eq(%w[michael@bluth.com]) # sidekiq flushes everything at once
+      expect(emails.length).to eq 3
+      expect(emails[0].to).to eq(%w[michael@bluth.com])
+      expect(emails[0].subject).to include("You're Almost Done")
+      expect(emails[1].to).to eq(%w[michael@bluth.com]) # sidekiq flushes everything at once
       expect(emails.map(&:subject)).to include(
         "Artsy Consignments - complete your submission"
       )
@@ -190,8 +190,8 @@ describe "Submission Flow" do
       expect(response.status).to eq 201
       expect(submission.reload.state).to eq "submitted"
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 3
-      expect(emails[1].html_part.body).to include("https://new-image.jpg")
+      expect(emails.length).to eq 2
+      expect(emails[0].html_part.body).to include("https://new-image.jpg")
 
       # GET to retrieve the image url for the submission
       get "/api/assets",

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -328,7 +328,7 @@ describe SubmissionService do
         .with(submission.id, "submitted")
       SubmissionService.update_submission(submission, {state: "submitted"})
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 4
+      expect(emails.length).to eq 3
     end
 
     it "sends no reminders if the submission has images" do
@@ -338,7 +338,7 @@ describe SubmissionService do
       Fabricate(:image, submission: submission)
       SubmissionService.update_submission(submission, {state: "submitted"})
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 3
+      expect(emails.length).to eq 2
     end
 
     it "sends no emails if the state is not being changed" do
@@ -1212,10 +1212,7 @@ describe SubmissionService do
         .with(submission.id, "submitted")
       SubmissionService.notify_admin(submission.id)
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 1
-      expect(emails.first.html_part.body).to include("My Artwork")
-      expect(emails.first.to).to eq(%w[sell@artsy.net])
-      expect(submission.reload.admin_receipt_sent_at).to_not be nil
+      expect(emails.length).to eq 0
     end
 
     it "does not send an email if one has already been sent" do
@@ -1298,8 +1295,8 @@ describe SubmissionService do
       Fabricate(:unprocessed_image, submission: submission)
       SubmissionService.deliver_submission_notification(submission.id)
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 1
-      expect(emails.first.html_part.body).to include("My Artwork")
+      expect(emails.length).to eq 0
+      # expect(emails.first.html_part.body).to include("My Artwork")
     end
   end
 end

--- a/spec/services/submission_service_spec.rb
+++ b/spec/services/submission_service_spec.rb
@@ -338,7 +338,7 @@ describe SubmissionService do
       Fabricate(:image, submission: submission)
       SubmissionService.update_submission(submission, {state: "submitted"})
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 2
+      expect(emails.length).to eq 1
     end
 
     it "sends no emails if the state is not being changed" do
@@ -1078,22 +1078,22 @@ describe SubmissionService do
       it "sends a receipt" do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 1
-        expect(emails.first.html_part.body).to include(
-          "Our team of specialists will review your work to evaluate whether we currently have a suitable market for it. If your work is accepted, we’ll send you a sales offer and guide you in choosing the best option for selling it."
-        )
-        expect(emails.first.to).to eq(%w[michael@bluth.com])
-        expect(submission.reload.receipt_sent_at).to_not be nil
+        expect(emails.length).to eq 0
+        # expect(emails.first.html_part.body).to include(
+        #   "Our team of specialists will review your work to evaluate whether we currently have a suitable market for it. If your work is accepted, we’ll send you a sales offer and guide you in choosing the best option for selling it."
+        # )
+        # expect(emails.first.to).to eq(%w[michael@bluth.com])
+        # expect(submission.reload.receipt_sent_at).to_not be nil
       end
 
       it "sends a receipt without a prompt to create an Artsy account for user submissions" do
         SubmissionService.notify_user(submission.id)
         emails = ActionMailer::Base.deliveries
-        expect(emails.length).to eq 1
-        expect(emails.first.html_part.body).to_not include(
-          "find your artwork in"
-        )
-        expect(submission.reload.receipt_sent_at).to_not be nil
+        expect(emails.length).to eq 0
+        # expect(emails.first.html_part.body).to_not include(
+        #   "find your artwork in"
+        # )
+        # expect(submission.reload.receipt_sent_at).to_not be nil
       end
 
       it "does not send a receipt if one has already been sent" do
@@ -1186,10 +1186,9 @@ describe SubmissionService do
       )
       SubmissionService.notify_user(submission.id)
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 1
-
-      expect(emails.first.html_part.body).to include("find your artwork in")
-      expect(submission.reload.receipt_sent_at).to_not be nil
+      expect(emails.length).to eq 0
+      # expect(emails.first.html_part.body).to include("find your artwork in")
+      # expect(submission.reload.receipt_sent_at).to_not be nil
     end
 
     it "does not send a receipt with a prompt to create an Artsy account when config does not allow" do
@@ -1198,10 +1197,9 @@ describe SubmissionService do
       )
       SubmissionService.notify_user(submission.id)
       emails = ActionMailer::Base.deliveries
-      expect(emails.length).to eq 1
-
-      expect(emails.first.html_part.body).to_not include("find your artwork in")
-      expect(submission.reload.receipt_sent_at).to_not be nil
+      expect(emails.length).to eq 0
+      # expect(emails.first.html_part.body).to_not include("find your artwork in")
+      # expect(submission.reload.receipt_sent_at).to_not be nil
     end
   end
 
@@ -1213,6 +1211,9 @@ describe SubmissionService do
       SubmissionService.notify_admin(submission.id)
       emails = ActionMailer::Base.deliveries
       expect(emails.length).to eq 0
+      # expect(emails.first.html_part.body).to include("My Artwork")
+      # expect(emails.first.to).to eq(%w[sell@artsy.net])
+      # expect(submission.reload.admin_receipt_sent_at).to_not be nil
     end
 
     it "does not send an email if one has already been sent" do
@@ -1253,19 +1254,19 @@ describe SubmissionService do
       SubmissionService.deliver_submission_receipt(submission.id)
       emails = ActionMailer::Base.deliveries
 
-      expect(emails.length).to eq 1
-      expect(emails.first.bcc).to include("consignments-archive@artsymail.com")
-      expect(emails.first.html_part.body).to include(
-        "Thank you for submitting an artwork"
-      )
-      expect(emails.first.html_part.body).to include(
-        "Our team of specialists will review your work to evaluate whether we currently have a suitable market for it"
-      )
+      expect(emails.length).to eq 0
+      # expect(emails.first.bcc).to include("consignments-archive@artsymail.com")
+      # expect(emails.first.html_part.body).to include(
+      #   "Thank you for submitting an artwork"
+      # )
+      # expect(emails.first.html_part.body).to include(
+      #   "Our team of specialists will review your work to evaluate whether we currently have a suitable market for it"
+      # )
 
-      expect(emails.first.html_part.body).to include("utm_source=sendgrid")
-      expect(emails.first.html_part.body).to include("utm_medium=email")
-      expect(emails.first.html_part.body).to include("utm_campaign=sell")
-      expect(emails.first.html_part.body).to include("utm_content=received")
+      # expect(emails.first.html_part.body).to include("utm_source=sendgrid")
+      # expect(emails.first.html_part.body).to include("utm_medium=email")
+      # expect(emails.first.html_part.body).to include("utm_campaign=sell")
+      # expect(emails.first.html_part.body).to include("utm_content=received")
     end
   end
 


### PR DESCRIPTION
- https://artsyproduct.atlassian.net/browse/ONYX-1541
- https://artsyproduct.atlassian.net/browse/ONYX-1542

For now, disables:
- emails that go the admin email address (sell@)
- submission confirmations that are delivered to the user (rejection emails are untouched)

Instead it logs one of the following messages (for easy inspection of Papertrail, in case there's some code path that still leads to this outcome):

```
[Consignments suspended] Declining to deliver admin email for Submission 42
```

```
[Consignments suspended] Declining to deliver user email for Submission 42
```
