### PR TITLE
chore: update pg-data-sync tag in hokusai configs

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -575,7 +575,7 @@ spec:
               mountPath: /secrets
           containers:
           - name: convection-data-export
-            image: artsy/pg-data-sync:12
+            image: artsy/pg-data-sync:14.12
             imagePullPolicy: Always
             env:
             - name: APP_NAME

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -448,7 +448,7 @@ spec:
               mountPath: /secrets
           containers:
           - name: convection-data-import
-            image: artsy/pg-data-sync:12
+            image: artsy/pg-data-sync:14.12
             imagePullPolicy: Always
             env:
             - name: APP_NAME


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PHIRE-1637

Update `convection-data-export` jobs to use the new `pg-data-sync` tag that matches server version.

Must be merged after `production-shared` rds is upgraded and before the weekend.