### PR TITLE
Migrate from asdf to mise

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -10,11 +10,11 @@ brew 'rabbitmq', restart_service: true
 brew 'redis', restart_service: true
 EOF
 
-if command -v asdf >/dev/null; then
-  echo "Installing language dependencies with asdf"
-  asdf install
+if command -v mise >/dev/null; then
+  echo "Installing language dependencies with mise"
+  mise install
 else
-  echo "Skipping language dependencies installation (asdf not found)"
+  echo "Skipping language dependencies installation (mise not found)"
 fi
 
 echo "install the bundler version locked in Gemfile.lock, if any..."


### PR DESCRIPTION
## Summary
Migrates the setup script from asdf to mise for language dependency management.

## Changes
- Replace `asdf` command checks with `mise` command checks
- Replace `asdf install` with `mise install`
- Update messaging to reference mise instead of asdf

## Context
This migration is part of the broader Artsy effort to standardize on mise as the language version manager across all repositories.

Related to: https://github.com/artsy/README/issues/550